### PR TITLE
Correct small things in doc/latex.txt.

### DIFF
--- a/doc/latex.txt
+++ b/doc/latex.txt
@@ -69,7 +69,7 @@ the current buffer, by default mapped to '<localleader>lh'.  If the default
 mappings are used, |latex#help| will display them.  |latex#info| echoes the
 contents of |g:latex#data| and |b:latex|.  This is useful mainly for
 debugging.  Finally, |latex#reinit| clears the current data in |g:latex#data|
-and |b:latex|, stops running latexmk processes |latex#latexmk#stop_all|,  and
+and |b:latex|, stops running `latexmk` processes |latex#latexmk#stop_all|,  and
 then performs a new initialization with |latex#init|.
 
 For each latex project that is opened, a |Dictionary| is created and added to
@@ -133,7 +133,7 @@ The default mappings for |vim-latex| are given below.  See 'map-listing' for
 an explanation of the format.  The function |latex#help| is provided for
 convenience to list all the defined mappings, and it is by default mapped to
 '<localleader>lh'.  The default mappings may be disabled with the option
-|g:latex_mappings_enabled|, if the user wishes to create his own mappings.
+|g:latex_mappings_enabled|, if the user wishes to create their own mappings.
 
 n  %                *@:call latex#motion#find_matching_pair()<cr>
 v  %                *@:<c-u>call latex#motion#find_matching_pair(1)<cr>
@@ -236,7 +236,7 @@ If this variable exists and is 0, then |vim-latex| is completely disabled.  By
 default, it is not defined.
 
                                                            *g:latex_build_dir*
-Set this variable in case a dedicated build dir is used with latexmk/latex
+Set this variable in case a dedicated build dir is used with `latexmk`/`latex`
 compilations. >
   let g:latex_build_dir = '.'
 <
@@ -302,26 +302,27 @@ List of section constructs that should be folded. >
 <
                                                       *g:latex_indent_enabled*
 Use |vim-latex| indentation function.  Not as customizable as the official
-indentation function, but imho it is better.
-
+indentation function, but imho it is better. >
+  let g:latex_indent_enabled = '1'
+<
                                                     *g:latex_latexmk_autojump*
 Whether to automatically jump to the first error when the error window is
 opened with the default mapping or |latex#latexmk#errors|. >
   let g:latex_latexmk_autojump = '0'
 <
                                                      *g:latex_latexmk_enabled*
-Whether to enable the latexmk interface or not.  Note that even if it is not
+Whether to enable the `latexmk` interface or not.  Note that even if it is not
 enabled, the autoload functions will be available.  However, the
 necessary variables and autocommands will not be defined, and the mappings
 will not be created. >
   let g:latex_latexmk_enabled = 1
 <
                                                      *g:latex_latexmk_options*
-Set extra options for latexmk compilation. >
+Set extra options for `latexmk` compilation. >
   let g:latex_latexmk_options = ''
 <
                                                       *g:latex_latexmk_output*
-Set desired output for latexmk compilation. >
+Set desired output for `latexmk` compilation. >
   let g:latex_latexmk_output = 'pdf'
 <
                                                     *g:latex_latexmk_quickfix*
@@ -352,8 +353,8 @@ main tex file in multi-file projects. >
                                                     *g:latex_mappings_enabled*
 Whether to load the default mappings.  If this is set to 0, then no mappings
 will be defined.  Since all of the functionality is available as functions,
-this allows the user to define his or her own mappings. >
-  let g:latex_default_mappings = 1
+this allows the user to define their own mappings. >
+  let g:latex_mappings_enabled= 1
 <
                                                       *g:latex_motion_enabled*
 Whether to enable the motion interface.  If it is disabled, then neither the
@@ -406,7 +407,7 @@ OMNI COMPLETION                                         *vim-latex-completion*
 |vim-latex| provides an 'omnifunc' for omni completion, see |compl-omni| and
 |latex#complete#omnifunc|.  The function is enabled by default, but may be
 disabled with |g:latex_complete_enabled|.  Omni completion is accessible with
-'i_<CTRL-X><CTRL-O>'.
+'<CTRL-X><CTRL-O>'.
 
 The omni function completes labels and citations.  The completion candidates
 are gathered with the functions |latex#complete#labels| and
@@ -730,7 +731,7 @@ slightly with the options |g:latex_errorformat_show_warnings| and
 |g:latex_errorformat_ignore_warnings|.
 
                                                         *latex#latexmk#status*
-Show if the `latexmk` has been started for the current buffer.  An optional
+Show if `latexmk` has been started for the current buffer.  An optional
 argument may be supplied, in which case the status for all buffers is shown.
 
                                                           *latex#latexmk#stop*
@@ -741,7 +742,8 @@ argument may be given, in which case the function becomes verbose.
 Stops all running `latexmk` processes.
 
                                              *latex#motion#find_matching_pair*
-Finds a matching pair of parenthesis or begin-end-tags.  The functions is used
+Finds a matching pair of parentheses or begin-end-tags.  The functions is used
+to find the pair closest to the current cursor position.
 
                                                        *latex#motion#next_sec*
 A motion command function that moves to the next section.  Used to redefine
@@ -759,7 +761,7 @@ A function that is used to create text objects for inline math structures.
 
                                                                 *latex#reinit*
 Clears the current global and local data in |g:latex#data| and |b:latex|,
-stops running latexmk processes |latex#latexmk#stop_all|,  and then performs
+stops running `latexmk` processes |latex#latexmk#stop_all|,  and then performs
 a new initialization.
 
                                                               *latex#toc#open*
@@ -788,7 +790,7 @@ structure.
 Checks if the given position (or current position) is within a comment.
 
                                                         *latex#util#kpsewhich*
-Parse file with kpsewhich.
+Parse file with `kpsewhich`.
 
                                                          *latex#util#tex2tree*
 Turn tex structure to a tree composed of lists.  E.g. >


### PR DESCRIPTION
Hi!

I just went through the `vim-latex` documentation and corrected a few things:
1. two small gender thingies (their instead of his/his or her)
2. latexmk → `latexmk`
3. the default setting for `g:latex_indent_enabled` was missing
4. and a few other minor things.
