### PR TITLE
- Fix latexmk compiling on Windows 7

### DIFF
--- a/autoload/latex/latexmk.vim
+++ b/autoload/latex/latexmk.vim
@@ -273,10 +273,10 @@ function! s:latexmk_set_cmd(data) " {{{1
 
   if g:latex_latexmk_callback && has('clientserver')
     if has('win32')
-      let callback = 'vim --servername ""' . v:servername . '""'
-            \ . ' --remote-expr ""latex\#latexmk\#errors(0)""'
-      let cmd .= ' -e "$success_cmd .= ""' . callback . '"""'
-            \ .  ' -e "$failure_cmd .= ""' . callback . '"""'
+      let callback = 'vim --servername ' . v:servername 
+            \ . ' --remote-expr \"latex\#latexmk\#errors(0)\"'
+      let cmd .= ' -e "$success_cmd .= ''' . callback . '''"'
+            \ .  ' -e "$failure_cmd .= ''' . callback . '''"'
     else
       let callback = 'vim --servername ' . v:servername
             \ . ' --remote-expr \"latex\#latexmk\#errors(0)\"'


### PR DESCRIPTION
- Change the formatting of the command string on Windows 7
- Attempt to resolve #40
