### PR TITLE
win32: Wrap bg cmd in quotes

### DIFF
--- a/autoload/latex/util.vim
+++ b/autoload/latex/util.vim
@@ -124,13 +124,14 @@ function! latex#util#execute(exe) " {{{1
 
   " Set up command string based on the given system
   if has('win32')
-    if bg
-      let cmd = '!start /b ' . a:exe.cmd
-    else
-      let cmd = '!' . a:exe.cmd
-    endif
+    let cmd = a:exe.cmd
     if null
       let cmd .= ' >nul'
+    endif
+    if bg
+      let cmd = '!start /b "' . cmd . '"'
+    else
+      let cmd = '!' . cmd
     endif
   else
     let cmd = '!' . a:exe.cmd


### PR DESCRIPTION
If a command both starts and ends in quotes (e.g. `"sumatrapdf" "file.pdf"`), these outer quotes seem to be removed from the command when run under `!start /b`, creating an invalid command (the example becomes `sumatrapdf" "file.pdf`).

Wrapping the command in quotes seems to work as a fix, so that there are always outer quotes to be removed.
