### PR TITLE
Added a forgotten shellescape

### DIFF
--- a/autoload/latex/view.vim
+++ b/autoload/latex/view.vim
@@ -91,7 +91,7 @@ function! latex#view#mupdf(args) "{{{1
         \ . (line(".") + 1) . ":"
         \ . (col(".") + 1) . ":"
         \ . shellescape(expand("%:p"))
-        \ . " -o " . outfile
+        \ . " -o " . shellescape(outfile)
         \ . " | grep -m1 'Page:' | sed 's/Page://' | tr -d '\n'"
   let l:page = system(l:cmd)
   let g:latex#data[b:latex.id].cmds.view_mupdf_synctex = l:cmd


### PR DESCRIPTION
I realized I had forgotten to add a `shellescape` to the call of `synctex` when using MuPDF. @lervag, it would be nice if you could test this yourself. A command of this form:

![screenshot 2014-12-08 22 00 49](https://cloud.githubusercontent.com/assets/7765538/5347076/c9ba7706-7f25-11e4-9467-fe654da82df6.png)

works fine here:

![screenshot 2014-12-08 22 01 47](https://cloud.githubusercontent.com/assets/7765538/5347091/f027038c-7f25-11e4-936f-cba5976210ff.png)

**EDIT**: An absolute path within quotes passed to `synctex` works as well.
