### PR TITLE
ensure that under MS Windows cmd shell executes bang commands

### DIFF
--- a/autoload/latex/util.vim
+++ b/autoload/latex/util.vim
@@ -143,10 +143,19 @@ function! latex#util#execute(exe) " {{{1
     endif
   endif
 
+  if has('win32') && &shell !~? 'cmd'
+    let savedShell=[&shell, &shellcmdflag, &shellxquote, &shellxescape, &shellquote, &shellpipe, &shellredir, &shellslash]
+    set             shell&  shellcmdflag&  shellxquote&  shellxescape&  shellquote&  shellpipe&  shellredir&  shellslash&
+  endif
+
   if silent
     silent execute cmd
   else
     execute cmd
+  endif
+
+  if has('win32') && &shell !~? 'cmd'
+    let            [&shell, &shellcmdflag, &shellxquote, &shellxescape, &shellquote, &shellpipe, &shellredir, &shellslash]=savedShell
   endif
 
   " Return to previous working directory


### PR DESCRIPTION
all of the latexmk and util library assumes that
under MS Windows the cmd shell is used with its
standard parameters.

The commit does this assumption justice and so
makes the library commands such as latex clean, make,...
work under other terminals as well (powershell...).
