### PR TITLE
Expand documentation: autocompletion with YouCompleteMe

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -860,9 +860,25 @@ automatic completion with |vimtex|: >
   let g:neocomplete#sources#omni#input_patterns.tex =
         \ '\v\\\a*(ref|cite)\a*([^]]*\])?\{([^}]*,)*[^}]*'
 
-I do not know the appropriate settings to enable good autocomplete with
-YouCompleteMe.  If anyone has a good set of settings that provide autocomplete
-with YouCompleteMe for |vimtex|, I will be happy to accept pull requests.
+To enable automatic completion with YouCompleteMe, it has to be explicitely
+enabled for the tex filetype. For tex files, it is also a good idea to disable
+the identifier based completion and rely only on semantic completion, which
+will use the 'omnifunc' set by |vimtex|. Then the same patterns as above can
+be used to trigger the semantic completion.
+
+  " enable YCM for tex files
+  let g:ycm_filetype_whitelist.tex = 1
+
+  " disable identifier based completion for tex files
+  autocmd FileType tex let g:ycm_min_num_of_chars_for_completion = 99
+
+  " set patterns to trigger semantic completion
+  if !exists('g:ycm_semantic_triggers')
+    let g:ycm_semantic_triggers = {}
+  endif
+  let g:ycm_semantic_triggers.tex = [
+        \ '\v\\\a*(ref|cite)\a*([^]]*\])?\{([^}]*,)*[^}]*'
+        \ ]
 
 ==============================================================================
 FOLDING                                                        *vimtex-folding*


### PR DESCRIPTION
Finally the promised pull request to expand the documentation...

Of the three options involved, two have some issues:

1. The `ycm_min_num_of_chars_for_completion` option can't be set per buffer, reported in Valloric/YouCompleteMe#1437
2. The semantic completion is not triggered automatically and has to be invoked manually with `<C-space>`. This is reported in Valloric/YouCompleteMe#438; the issue has been closed 3 days after opening, but the discussion evolved significantly in the upcoming year. [This comment](https://github.com/Valloric/YouCompleteMe/issues/438#issuecomment-68581749) goes into some detail.

I don't know if the issues should be pointed out also in the documentation.

Lastly, I'm not sure what is the best way to indicate setting values to dictionaries in the docs, the `!exists` check should precede even the assignment to `g:ycm_filetype_whitelist`, which would not be readable very well. I've omitted the check in this case because that value is likely already defined when using YCM.