### PR TITLE
Fix util#execute on Windows

### DIFF
--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -154,9 +154,9 @@ function! vimtex#util#execute(exe) " {{{1
     endif
   else
     if silent
-      silent execute '!' cmd
+      silent execute '!' . cmd
     else
-      execute '!' cmd
+      execute '!' . cmd
     endif
 
     if !has("gui_running")


### PR DESCRIPTION
When executing a command, `!` and `cmd` should be concatenated to avoid a space between them. This is critical on Windows because the command `! start` has not the same behavior as `!start`.