### PR TITLE
Youcompleteme

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -65,6 +65,7 @@ function! vimtex#complete#omnifunc(findstart, base) " {{{1
         return -2
       endif
     endfor
+    return -3
   else
     "
     " Second call:  Find list of matches

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -881,24 +881,13 @@ It is described as:
 > Vim's omnicomplete system to provide semantic completions for many other
 > languages (Ruby, PHP etc.).
 
-To enable automatic completion with YouCompleteMe, it has to be explicitely
-enabled for the tex filetype.  For tex files, it is also a good idea to disable
-the identifier based completion and rely only on semantic completion, which
-will use the 'omnifunc' set by |vimtex|.  Then the same patterns as above can
-be used to trigger the semantic completion. >
+To enable automatic completion with |youcompleteme|, use the following options:
 
-  " Enable YCM for tex files
-  let g:ycm_filetype_whitelist.tex = 1
-
-  " Disable identifier based completion for tex files
-  autocmd FileType tex let g:ycm_min_num_of_chars_for_completion = 99
-
-  " Set patterns to trigger semantic completion
   if !exists('g:ycm_semantic_triggers')
     let g:ycm_semantic_triggers = {}
   endif
   let g:ycm_semantic_triggers.tex = [
-        \ '\v\\\a*(ref|cite)\a*([^]]*\])?\{([^}]*,)*[^}]*'
+        \ 're!\\[A-Za-z]*(ref|cite)[A-Za-z]*([^]]*])?{([^}]*, ?)*'
         \ ]
 
 ==============================================================================


### PR DESCRIPTION
`YouCompleteMe` always expects a return value from the `omnifunc` function hence the first commit.

The second commit is about the documentation. There are several mistakes. 
Firstly, it is not necessary to change the option `g:ycm_filetype_whitelist` because `YouCompleteMe` is enabled for all files by default. 
Secondly, identifier-based completion can be useful for some users so the `g:ycm_min_num_of_chars_for_completion` option should not be modified. Moreover, this option is global.
Finally, the pattern for the semantic completion must be written in `Python` regex, not `Vim`. The part to be completed (the labels and the citations) must not be present in the pattern.

With these changes, the automatic completion of `YouCompleteMe` works relatively well. There are some problems with labels and citations containing special characters (`:`for example) or spaces. The completion menu disappears when typing these characters and must be reopened with the `<C-space>` command.