### PR TITLE
Fix for multi-file projects

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -234,6 +234,10 @@ function! s:get_main_recurse(file) " {{{1
   " Search through candidates for \include{current file}
   "
   for l:file in l:candidates
+    if l:file == a:file
+      " Avoid checking this file again.
+      continue
+    endif
     if len(filter(readfile(l:file), 'v:val =~ ''\v\\(input|include)\{'
           \ . '\s*((.*)\/)?'
           \ . fnamemodify(a:file, ':t:r') . '(\.tex)?\s*''')) > 0

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -177,7 +177,12 @@ function! s:get_main() " {{{1
     let candidate = matchstr(line,
           \ '^\s*%\s*!\s*[tT][eE][xX]\s\+root\s*=\s*\zs.*\ze\s*$')
     if len(candidate) > 0
-      let main = fnamemodify(candidate, ':p')
+      if candidate[0] ==# '/'
+        let main = fnamemodify(candidate, ':p')
+      else
+        " Prepend directory of current file, if candidate is a relative path.
+        let main = fnamemodify(expand('%:h') . '/' . candidate, ':p')
+      endif
       if filereadable(main)
         return main
       endif


### PR DESCRIPTION
These two commits fix a couple of problems I had with multi-file LaTeX projects:

- The `%! TEX root = my-main.tex` header didn't work as expected when the path to the main file was relative. One example, just to be clear: if I have the files `main.tex` and `chapters/chap1.tex`, the header of the `chap1.tex` file would be `%! TEX root = ../main.tex`. In that case, the main file wasn't recognised unless my current working directory is `chapters/`. I think the relative path shouldn't be based on the current working directory, but on the directory of the current file (`chap1.tex` in this case). That's also how it's done in LaTeX-Box, for example.

- I had some infinite recursions when opening some sub-files, when vim was trying to find the main file. I don't really know why, but that happened to me with some specific tex files and not with others. Anyways, this is fixed by avoiding the checks on a single tex file more than once, which I think is reasonable.

Let me know if this is helpful, and feel free to make modifications. And thanks for this great plugin!