### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ disabled if desired.
   - `id ad` Delimiters
 - Other mappings
   - Delete the surrounding command or environment with `dse`/`dsc`
-  - Change the surrounding command or environment with `csd`/`cse`
+  - Change the surrounding command or environment with `csc`/`cse`
   - Toggle starred environment with `tse`
   - Toggle between e.g. `()` and `\left(\right)` with `tsd`
   - Close the current environment in insert mode with `]]`

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -87,7 +87,7 @@ Feature overview~
   - `id` `ad` Delimiters
 - Other mappings
   - Delete the surrounding command or environment with `dse`/`dsc`
-  - Change the surrounding command or environment with `csd`/`cse`
+  - Change the surrounding command or environment with `csc`/`cse`
   - Toggle starred environment with `tse`
   - Toggle between e.g. `()` and `\left(\right)` with `tsd`
   - Close the current environment in insert mode with `]]`


### PR DESCRIPTION
A couple places in the documentation mention a `csd` mapping, which I think should actually be `csc`.