### PR TITLE
Fix compilation when Vim path contains spaces

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -396,10 +396,10 @@ function! s:latexmk_build_cmd() " {{{1
   endif
 
   if g:vimtex_latexmk_callback && has('clientserver')
-    let success  = g:vimtex_latexmk_progname
+    let success  = '\"' . g:vimtex_latexmk_progname . '\"'
     let success .= ' --servername ' . v:servername
     let success .= ' --remote-expr \"vimtex\#latexmk\#callback(1)\"'
-    let failed   = g:vimtex_latexmk_progname
+    let failed   = '\"' . g:vimtex_latexmk_progname . '\"'
     let failed  .= ' --servername ' . v:servername
     let failed  .= ' --remote-expr \"vimtex\#latexmk\#callback(0)\"'
     let cmd .= vimtex#latexmk#add_option('success_cmd', success)


### PR DESCRIPTION
On Windows, `v:progpath` may contain spaces and so `g:vimtex_latexmk_progname` too. If this is the case, `$success_cmd` and `$failure_cmd` latexmk options will not work properly. This is fixed by surrounding `g:vimtex_latexmk_progname` with double quotes in these options.