### PR TITLE
escape path in MuPDF reverse search function

### DIFF
--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -257,7 +257,7 @@ function! s:mupdf.reverse_search() dict " {{{2
   let self.line = system(self.cmd_getline)
 
   " Go to file and line
-  silent exec 'edit ' . self.file
+  silent exec 'edit ' . fnameescape(self.file)
   if self.line > 0
     silent exec ':' . self.line
     " Unfold, move to top line to correspond to top pdf line, and go to end of


### PR DESCRIPTION
Fixed just a small bug I found when the path contained spaces...