### PR TITLE
No console window when executing vimtex#latexmk#clean and vimtex#latexmk#kill on Windows

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -123,7 +123,7 @@ function! vimtex#latexmk#clean(full) " {{{1
   let cmd .= vimtex#util#shellescape(b:vimtex.base)
   let exe = {
         \ 'cmd' : cmd,
-        \ 'bg'  : 0,
+        \ 'bg'  : 1,
         \ }
   call vimtex#util#execute(exe)
   let b:vimtex.cmd_latexmk_clean = cmd
@@ -476,7 +476,7 @@ endfunction
 
 function! s:latexmk_kill(data) " {{{1
   let exe = {}
-  let exe.bg = 0
+  let exe.bg = 1
   let exe.null = 0
 
   if has('win32')


### PR DESCRIPTION
This PR sets the background option for the `vimtex#latexmk#clean` and `vimtex#latexmk#kill` functions to prevent the opening of a console window on Windows.

I think this change is safe on Unix platforms.