### PR TITLE
Do not treat '(' as delimiter for indentation

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -138,7 +138,6 @@ let s:envs_lists = 'itemize\|description\|enumerate\|thebibliography'
 let s:envs_noindent = 'document\|verbatim\|lstlisting'
 let s:delimiters_open = '\(' . join([
         \ '{',
-        \ '(',
         \ '\[',
         \ '\\{',
         \ '\\(',
@@ -149,7 +148,6 @@ let s:delimiters_open = '\(' . join([
       \ ], '\|') . '\)'
 let s:delimiters_close = '\(' . join([
         \ '}',
-        \ ')',
         \ '\]',
         \ '\\}',
         \ '\\)',


### PR DESCRIPTION
Can't think of a good reason for an open-paren to increase indentation level in LaTeX sources, but it does get in the way of typing text with parenthetical expressions when hard-wrapping.