### PR TITLE
Fixes #212. Fix pdflatex substitution to work with Latexmk's 'internal' keyword

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -383,8 +383,8 @@ function! s:latexmk_build_cmd() " {{{1
   endif
 
   let cmd .= ' ' . g:vimtex_latexmk_options
-  let cmd .= ' -e ' . shellescape(
-        \ '$pdflatex =~ s/^((.(?<!^internal(?=\s)))*?) /$1 -file-line-error /', 1)
+  let cmd .= ' -e ' . vimtex#util#shellescape(
+        \ '$pdflatex =~ s/^((.(?<!^internal(?=\s)))*?) /$1 -file-line-error /')
   if g:vimtex_latexmk_build_dir !=# ''
     let cmd .= ' -outdir=' . g:vimtex_latexmk_build_dir
   endif

--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -384,7 +384,7 @@ function! s:latexmk_build_cmd() " {{{1
 
   let cmd .= ' ' . g:vimtex_latexmk_options
   let cmd .= ' -e ' . vimtex#util#shellescape(
-        \ '$pdflatex =~ s/ / -file-line-error /')
+        \ '$pdflatex =~ s/^((.(?<!^internal(?=\s)))*?) /$1 -file-line-error /')
   if g:vimtex_latexmk_build_dir !=# ''
     let cmd .= ' -outdir=' . g:vimtex_latexmk_build_dir
   endif

--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -383,8 +383,8 @@ function! s:latexmk_build_cmd() " {{{1
   endif
 
   let cmd .= ' ' . g:vimtex_latexmk_options
-  let cmd .= ' -e ' . vimtex#util#shellescape(
-        \ '$pdflatex =~ s/^((.(?<!^internal(?=\s)))*?) /$1 -file-line-error /')
+  let cmd .= ' -e ' . shellescape(
+        \ '$pdflatex =~ s/^((.(?<!^internal(?=\s)))*?) /$1 -file-line-error /', 1)
   if g:vimtex_latexmk_build_dir !=# ''
     let cmd .= ' -outdir=' . g:vimtex_latexmk_build_dir
   endif

--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -123,7 +123,7 @@ endfunction
 function! vimtex#util#shellescape(path) " {{{1
   " Blackslashes in path must be escaped to be correctly parsed by the
   " substitute() function.
-  let l:path = escape(a:path, '\')
+  let l:path = has('win32') ? escape(a:path, '\') : a:path
 
   "
   " In a Windows environment, a path used in "cmd" only needs to be enclosed by
@@ -132,7 +132,7 @@ function! vimtex#util#shellescape(path) " {{{1
   " reports an error.  Any path that goes into vimtex#util#execute() should be
   " processed through this function.
   "
-  return has('win32') ? '"' . l:path . '"' : shellescape(l:path)
+  return has('win32') ? '"' . l:path . '"' : shellescape(l:path, 1)
 endfunction
 
 " }}}1


### PR DESCRIPTION
This regex substitution won't touch the `pdflatex` command if `internal` is at the beginning of the command. This is needed for Latexmk subroutines.

Testing:

    pdflatex somefile           --> pdflatex -file-line-errors somefile
    pdflatex internal somefile  --> pdflatex -file-line-errors internal somefile
    internal routine file       --> internal routine file
    pdfinternal somefile        --> pdfinternal -file-line-errors somefile
    internalpdf somefile        --> internalpdf -file-line-errors somefile
    pdfinternalpdf somefile     --> pdfinternalpdf -file-line-errors somefile

I'm not particularly a regex wizard, so this may be possible in an easier way. Unfortunately, Perl doesn't support variable length lookbehind.