### PR TITLE
Avoid clearing global listchars option

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -533,7 +533,6 @@ function! vimtex#wordcount(detailed) " {{{1
   setlocal bufhidden=wipe
   setlocal buftype=nofile
   setlocal cursorline
-  setlocal listchars=
   setlocal nobuflisted
   setlocal nolist
   setlocal nospell

--- a/autoload/vimtex/index.vim
+++ b/autoload/vimtex/index.vim
@@ -73,7 +73,6 @@ function! vimtex#index#create(index) " {{{1
   setlocal concealcursor=nvic
   setlocal conceallevel=0
   setlocal cursorline
-  setlocal listchars=
   setlocal nobuflisted
   setlocal nolist
   setlocal nospell


### PR DESCRIPTION
`listchars` is a global option, so it cannot be set locally to a certain buffer.