### PR TITLE
[bugfix] <m-i> conflict with the "é" character

### DIFF
--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -131,7 +131,6 @@ function! s:default_maps() " {{{1
   " Return default snippet list including list of simple maps
   return snippets + [
         \ { 'lhs_rhs' : ['...',   '\dots'],       'leader' : '' },
-        \ { 'lhs_rhs' : ['<m-i>', '\item '],      'leader' : '' },
         \ { 'lhs_rhs' : ['0',     '\emptyset'],   'wrapper' : 's:wrap_math'},
         \ { 'lhs_rhs' : ['6',     '\partial'],    'wrapper' : 's:wrap_math'},
         \ { 'lhs_rhs' : ['8',     '\infty'],      'wrapper' : 's:wrap_math'},


### PR DESCRIPTION
Somehow, the bug declared in [this issue](https://github.com/lervag/vimtex/issues/36) has re-appeared. On my French keyboard, typing on the `é` key inserts `\item`. The mapping causing this bug to happen has been removed.