### PR TITLE
imap_mappings: do not swallow leader outside math

### DIFF
--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -49,7 +49,7 @@ function! vimtex#imaps#add_map(map) " {{{1
 
   " Apply wrapper
   if l:wrapper !=# '' && exists('*' . l:wrapper)
-    let l:rhs = call(l:wrapper, [l:lhs, l:rhs])
+    let l:rhs = call(l:wrapper, [l:leader . l:lhs, l:rhs])
   endif
 
   " Add mapping
@@ -63,7 +63,7 @@ endfunction
 "
 function! s:wrap_math(lhs, rhs) " {{{1
   return '<c-r>=<sid>is_math() ? ' . string(a:rhs)
-        \ . ' : ' . string(a:lhs) . '<cr>'
+        \ . ' : ' .  string(a:lhs) . '<cr>'
 endfunction
 
 " }}}1


### PR DESCRIPTION
For example `4.` outside math environments should type `4.` not `.`.