### PR TITLE
allow for sending special keys in imaps

### DIFF
--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -62,8 +62,8 @@ endfunction
 " Wrappers
 "
 function! s:wrap_math(lhs, rhs) " {{{1
-  return '<c-r>=<sid>is_math() ? ' . string(a:rhs)
-        \ . ' : ' . string(a:lhs) . '<cr>'
+  return '<c-r>=<sid>is_math() ? "' . a:rhs
+        \ . '" : "' .  a:lhs . '"<cr>'
 endfunction
 
 " }}}1


### PR DESCRIPTION
for example, now
```vim
{ 'lhs_rhs' : ['__',    "_{}\\<lt>Left>"], 'leader' : '',   'wrapper' : 's:wrap_math'}
```
achieves what previously required UltiSnips#Anon()