### PR TITLE
Moved check for vimtex_latexmk_enabled to top of init script

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -25,9 +25,9 @@ endfunction
 
 " }}}1
 function! vimtex#latexmk#init_script() " {{{1
-  call s:check_system_compatibility()
-
   if !g:vimtex_latexmk_enabled | return | endif
+
+  call s:check_system_compatibility()
 
   " Ensure that all latexmk processes are stopped when a latex project is
   " closed and when vim exits


### PR DESCRIPTION
With this change, users will not get potential warnings related to latexmk originating from the function check_system_compatibility when vimtex_latexmk_enabled is set to 0.
