### PR TITLE
Add support for (t)csh

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -393,6 +393,8 @@ function! s:latexmk_build_cmd() " {{{1
     let cmd  = 'cd ' . vimtex#util#shellescape(b:vimtex.root)
     if fnamemodify(&shell, ':t') ==# 'fish'
       let cmd .= '; and set max_print_line 2000; and latexmk'
+    elseif fnamemodify(&shell, ':t') ==# 'tcsh'
+      let cmd .= ' && set max_print_line=2000 && latexmk'
     else
       let cmd .= ' && max_print_line=2000 latexmk'
     endif
@@ -439,6 +441,8 @@ function! s:latexmk_build_cmd() " {{{1
     if has('win32')
       let cmd .= ' >'  . tmp
       let cmd = 'cmd /s /c "' . cmd . '"'
+    elseif fnamemodify(&shell, ':t') ==# 'tcsh'
+      let cmd .= ' >' . tmp . ' |& cat'
     else
       let cmd .= ' >' . tmp . ' 2>&1'
     endif

--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -76,7 +76,11 @@ function! vimtex#util#execute(exe) " {{{1
     endif
   else
     if null
-      let cmd .= ' >/dev/null 2>&1'
+      if fnamemodify(&shell, ':t') ==# 'tcsh'
+        let cmd .= ' >/dev/null |& cat'
+      else
+        let cmd .= ' >/dev/null 2>&1'
+      endif
     endif
     if bg
       let cmd .= ' &'


### PR DESCRIPTION
The syntax for shell commands for Linux/OSX assumed either bash or fish.
This PR adds a few if-statements to also support (t)csh.