### PR TITLE
Escaping '%' in latexmk command

### DIFF
--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -94,17 +94,17 @@ function! vimtex#util#execute(exe) " {{{1
     set shellquote& shellpipe& shellredir& shellslash&
   endif
 
-  if system
-    if silent
+  if exists('*system')
+    if exists(':silent')
       silent call system(cmd)
     else
       call system(cmd)
     endif
   else
-    if silent
-      silent execute '!' . cmd
+    if exists(':silent')
+      silent execute '! sh -c ' . shellescape(cmd, 1)
     else
-      execute '!' . cmd
+      execute '! sh -c ' . shellescape(cmd, 1)
     endif
 
     if !has('gui_running')


### PR DESCRIPTION
- In my version of Vim (7.4) both 'if system' and 'if silent' cannot correctly detect existence of these function/command.
- When adding rules to g:vimtex_latexmk_options, the wildcard used by latexmk (%S, %O, etc.) should be correctly escaped.