### PR TITLE
Updated SumatraPDF setting example

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -815,7 +815,7 @@ Options~
           Backward search must be set up from the viewer. >
 
   let g:vimtex_view_general_viewer = 'SumatraPDF'
-  let g:vimtex_view_general_options = '-forward-search @tex @line @pdf'
+  let g:vimtex_view_general_options = '-reuse-instance -forward-search @tex @line @pdf'
   let g:vimtex_view_general_options_latexmk = '-reuse-instance'
 <
           Note: It is possible to set up inverse search for SumatraPDF through


### PR DESCRIPTION
Currently, `g:vimtex_view_general_options` example for SumatraPDF doesn't contain `-reuse-instance`,
so even if a SumatraPDF window is already opened by `:VimtexCompile`, another window is opened by `:VimtexView`.
(By contrast, the example for Okular and qpdfview contains `--unique`, so opened window is reused.)

How about adding `-reuse-instance` to `g:vimtex_view_general_options` in the SumatraPDF setting example to avoid opening multiple windows?

