### PR TITLE
Use :silent before :doautocmd

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -73,7 +73,7 @@ function! vimtex#init() " {{{1
   " Allow custom configuration through an event hook
   "
   if exists('#User#VimtexEventInitPost')
-    doautocmd User VimtexEventInitPost
+    silent doautocmd User VimtexEventInitPost
   endif
 endfunction
 
@@ -720,7 +720,7 @@ function! s:buffer_deleted() " {{{1
         let b:vimtex_tmp = b:vimtex
       endif
       let b:vimtex = l:vimtex
-      doautocmd User VimtexEventQuit
+      silent doautocmd User VimtexEventQuit
       if exists('b:vimtex_tmp')
         unlet b:vimtex_tmp
       else


### PR DESCRIPTION
Manually emitting events that aren't caught by the user provoke a "No matching autocmds" message.

Compare `:doau User` to `:silent doau User`.