### PR TITLE
New general callback and expand @line for general_options_latexmk

### DIFF
--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -131,9 +131,18 @@ endfunction
 
 " }}}2
 function! s:general.latexmk_append_argument() dict " {{{2
+  let opts = g:vimtex_view_general_options_latexmk
+  let opts = substitute(opts, '@line', line('.'), 'g')
   return vimtex#latexmk#add_option('pdf_previewer',
         \   g:vimtex_view_general_viewer . ' '
-        \ . g:vimtex_view_general_options_latexmk)
+        \ . opts)
+endfunction
+
+" }}}2
+function! s:general.latexmk_callback() dict " {{{2
+  if exists("g:vimtex_view_general_callback")
+    exec "call " . g:vimtex_view_general_callback . "(b:vimtex.out())"
+  endif
 endfunction
 
 " }}}2

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -860,10 +860,18 @@ Options~
 
   Default value: '@pdf'
 
+*g:vimtex_view_general_callback*
+  Sets the function that is called within |vimtex#latexmk#callback| after compilation
+  has finished. The function should take one argument, the pdf filename. It
+  will be empty if it could not be compiled.
+
+  Default value: ''
+
 *g:vimtex_view_general_options_latexmk*
   Set options that are passed on to `latexmk` for the specified general
   viewer, see |vimtex_viewer_general|.  This allows to send options that
-  ensures a unique viewer, e.g. with |vimtex_viewer_qpdfview|.
+  ensures a unique viewer, e.g. with |vimtex_viewer_qpdfview|. Only the
+  `@line` escape is expanded.
 
   Default value: ''
 


### PR DESCRIPTION
Expanding the `@line` escape allows us to open the file in the previewer wherever the cursor is, and the
callback lets people implement scripts as they like it to open/update their favourite pdf viewer to wherever the cursor is after compilation. latexmk's pdf_update_command doesn't let us do that, it can only update the file, but this allows anyone to easily make their pdf viewer go to wherever the cursor currently is in vim.