### PR TITLE
Completion patterns for \cite, \ref and \includeonly etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/tags
 test/*
+*~

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -602,7 +602,7 @@ function! s:get_main_recurse(file) " {{{1
     let l:file_re = '\s*((.*)\/)?' . fnamemodify(a:file, ':t:r')
 
     let l:filter  = 'v:val =~# ''\v'
-    let l:filter .= '\\%(input|include)\{' . l:file_re
+    let l:filter .= '\\%(input|include%(only)?)\{' . l:file_re
     let l:filter .= '|\\subimport\{[^\}]*\}\{' . l:file_re
     let l:filter .= ''''
 

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -68,7 +68,7 @@ endfunction
 " {{{1 Bibtex
 
 let s:bib = {
-      \ 'pattern' : '\v\\\a*cite\a*%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*',
+      \ 'pattern' : '\v\\\a*cite\a*%(\[\s*[^\]\{\}]*\]){0,2}\s*\{[^\}]*',
       \ 'enabled' : 1,
       \ 'bibs' : '''\v%(%(\\@<!%(\\\\)*)@<=\%.*)@<!'
       \          . '\\(bibliography|add(bibresource|globalbib|sectionbib))'
@@ -223,7 +223,7 @@ endfunction
 " {{{1 Labels
 
 let s:ref = {
-      \ 'pattern' : '\v\\v?%(auto|eq|[cC]?%(page)?|labelc)?ref%(range)?\s*\{%([^\}]*%(\}\{)?)',
+      \ 'pattern' : '\v\\v?%(auto|eq|[cC]?%(page)?|labelc)?%(ref\{\s*[^\}]*|refrange\{\s*%([^,\}]*%(\}\{)?))',
       \ 'enabled' : 1,
       \}
 
@@ -321,7 +321,7 @@ endfunction
 " {{{1 Filenames (\includegraphics)
 
 let s:img = {
-      \ 'pattern' : '\v\\includegraphics\*?%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*',
+      \ 'pattern' : '\v\\includegraphics\*?%(\[\s*[^\]\{\}]*\]){0,2}\s*\{[^\}]*',
       \ 'enabled' : 1,
       \}
 

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -223,7 +223,7 @@ endfunction
 " {{{1 Labels
 
 let s:ref = {
-      \ 'pattern' : '\v\\v?%(auto|eq|page|[cC]|labelc)?ref%(range|name\{\w*\})?\s*\{%([^\}]*%(\}\{)?)',
+      \ 'pattern' : '\v\\v?%(auto|eq|[cC]?%(page)?|labelc)?ref%(range)?\s*\{%([^\}]*%(\}\{)?)',
       \ 'enabled' : 1,
       \}
 

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -68,7 +68,7 @@ endfunction
 " {{{1 Bibtex
 
 let s:bib = {
-      \ 'pattern' : '\v\\\a*cite\a*%(\s*\[[^]]*\])?\s*\{[^{}]*',
+      \ 'pattern' : '\v\\\a*cite\a*%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*',
       \ 'enabled' : 1,
       \ 'bibs' : '''\v%(%(\\@<!%(\\\\)*)@<=\%.*)@<!'
       \          . '\\(bibliography|add(bibresource|globalbib|sectionbib))'
@@ -223,7 +223,7 @@ endfunction
 " {{{1 Labels
 
 let s:ref = {
-      \ 'pattern' : '\v\\v?%(auto|eq|page|[cC]|labelc)?ref\s*\{[^{}]*',
+      \ 'pattern' : '\v\\v?%(auto|eq|page|[cC]|labelc)?ref\s*\{%([^\}]*%(\}\{)?)',
       \ 'enabled' : 1,
       \}
 
@@ -321,7 +321,7 @@ endfunction
 " {{{1 Filenames (\includegraphics)
 
 let s:img = {
-      \ 'pattern' : '\v\\includegraphics%(\s*\[[^]]*\])?\s*\{[^{}]*',
+      \ 'pattern' : '\v\\includegraphics\*?%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*',
       \ 'enabled' : 1,
       \}
 
@@ -354,7 +354,7 @@ endfunction
 " {{{1 Filenames (\input and \include)
 
 let s:inc = {
-      \ 'pattern' : '\v\\%(include|input)\s*\{[^{}]*',
+      \ 'pattern' : '\v\\%(include%(only)?|input)\s*\{[^\}]*',
       \ 'enabled' : 1,
       \}
 

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -223,7 +223,7 @@ endfunction
 " {{{1 Labels
 
 let s:ref = {
-      \ 'pattern' : '\v\\v?%(auto|eq|page|[cC]|labelc)?ref%(range|name\{\w\})?\s*\{%([^\}]*%(\}\{)?)',
+      \ 'pattern' : '\v\\v?%(auto|eq|page|[cC]|labelc)?ref%(range|name\{\w*\})?\s*\{%([^\}]*%(\}\{)?)',
       \ 'enabled' : 1,
       \}
 

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -223,7 +223,7 @@ endfunction
 " {{{1 Labels
 
 let s:ref = {
-      \ 'pattern' : '\v\\v?%(auto|eq|page|[cC]|labelc)?ref\s*\{%([^\}]*%(\}\{)?)',
+      \ 'pattern' : '\v\\v?%(auto|eq|page|[cC]|labelc)?ref%(range|name\{\w\})?\s*\{%([^\}]*%(\}\{)?)',
       \ 'enabled' : 1,
       \}
 

--- a/autoload/vimtex/parser.vim
+++ b/autoload/vimtex/parser.vim
@@ -9,7 +9,7 @@ endfunction
 
 " }}}1
 function! vimtex#parser#init_script() " {{{1
-  let s:input_line_tex = '\v^\s*\\%(input|include|subimport|subfile)\s*\{'
+  let s:input_line_tex = '\v^\s*\\%(input|include%(only)?|subimport|subfile)\s*\{'
   let s:input_line_aux = '\\@input{'
 endfunction
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1378,7 +1378,7 @@ documents with |neocomplete| and |vimtex|s omni completion function: >
   let g:neocomplete#sources#omni#input_patterns.tex =
         \ '\v\\%('
         \ . '\a*%(cite)\a*%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*'
-        \ . '\a*%(ref)%(range|name\{\w*\})?\s*\{%([^\}]*%(\}\{)?)'
+        \ . '\a*%(ref)%(range)?\s*\{%([^\}]*%(\}\{)?)'
         \ . '|includegraphics\*?%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*'
         \ . '|%(include%(only)?|input)\s*\{[^\}]*'
         \ . ')'
@@ -1405,7 +1405,7 @@ To enable automatic completion with |youcompleteme|, use the following options:
   endif
   let g:ycm_semantic_triggers.tex = [
         \ 're!\\[A-Za-z]*(cite)[A-Za-z]*([^\]]*\]?){0,2}\{[^\}]*',
-        \ 're!\\[A-Za-z]*(ref)(range|name\{\w*\})?\{([^\}]*(\}\{)?)',
+        \ 're!\\[A-Za-z]*(ref)(range)?\{([^\}]*(\}\{)?)',
         \ 're!\\includegraphics\*?([^\]]*\]?){0,2}\{[^\}]*',
         \ 're!\\(include(only)?|input)\{[^\}]*'
         \ ]

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1403,9 +1403,10 @@ To enable automatic completion with |youcompleteme|, use the following options:
     let g:ycm_semantic_triggers = {}
   endif
   let g:ycm_semantic_triggers.tex = [
-        \ 're!\\[A-Za-z]*(ref|cite)[A-Za-z]*([^]]*])?{([^}]*,?)*',
-        \ 're!\\includegraphics([^]]*])?{[^}]*',
-        \ 're!\\(include|input){[^}]*'
+        \ 're!\\[A-Za-z]*(cite)[A-Za-z]*([^\]]*\]?){0,2}\{[^\}]*',
+        \ 're!\\[A-Za-z]*(ref)\{([^\}]*(\}\{)?)',
+        \ 're!\\includegraphics\*?([^\]]*\]?){0,2}\{[^\}]*',
+        \ 're!\\(include(only)?|input)\{[^\}]*'
         \ ]
 
 ==============================================================================

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1377,9 +1377,10 @@ documents with |neocomplete| and |vimtex|s omni completion function: >
   endif
   let g:neocomplete#sources#omni#input_patterns.tex =
         \ '\v\\%('
-        \ . '\a*%(ref|cite)\a*%(\s*\[[^]]*\])?\s*\{[^{}]*'
-        \ . '|includegraphics%(\s*\[[^]]*\])?\s*\{[^{}]*'
-        \ . '|%(include|input)\s*\{[^{}]*'
+        \ . '\a*%(cite)\a*%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*'
+        \ . '\a*%(ref)%(range|name\{\w\})?\s*\{%([^\}]*%(\}\{)?)'
+        \ . '|includegraphics\*?%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*'
+        \ . '|%(include%(only)?|input)\s*\{[^\}]*'
         \ . ')'
 <
 YouCompleteMe~
@@ -1404,7 +1405,7 @@ To enable automatic completion with |youcompleteme|, use the following options:
   endif
   let g:ycm_semantic_triggers.tex = [
         \ 're!\\[A-Za-z]*(cite)[A-Za-z]*([^\]]*\]?){0,2}\{[^\}]*',
-        \ 're!\\[A-Za-z]*(ref)\{([^\}]*(\}\{)?)',
+        \ 're!\\[A-Za-z]*(ref)(range|name\{\w\})?\{([^\}]*(\}\{)?)',
         \ 're!\\includegraphics\*?([^\]]*\]?){0,2}\{[^\}]*',
         \ 're!\\(include(only)?|input)\{[^\}]*'
         \ ]

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1377,9 +1377,9 @@ documents with |neocomplete| and |vimtex|s omni completion function: >
   endif
   let g:neocomplete#sources#omni#input_patterns.tex =
         \ '\v\\%('
-        \ . '\a*%(cite)\a*%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*'
-        \ . '\a*%(ref)%(range)?\s*\{%([^\}]*%(\}\{)?)'
-        \ . '|includegraphics\*?%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*'
+        \ . '\a*%(cite)\a*%(\[\s*[^\]\{\}]*\]){0,2}\s*\{[^\}]*'
+        \ . '\a*%(ref\{\s*[^\}]*|refrange\{\s*%([^,\}]*%(\}\{)?))'
+        \ . '|includegraphics\*?%(\[\s*[^\]\{\}]*\]){0,2}\s*\{[^\}]*'
         \ . '|%(include%(only)?|input)\s*\{[^\}]*'
         \ . ')'
 <
@@ -1404,9 +1404,9 @@ To enable automatic completion with |youcompleteme|, use the following options:
     let g:ycm_semantic_triggers = {}
   endif
   let g:ycm_semantic_triggers.tex = [
-        \ 're!\\[A-Za-z]*(cite)[A-Za-z]*([^\]]*\]?){0,2}\{[^\}]*',
-        \ 're!\\[A-Za-z]*(ref)(range)?\{([^\}]*(\}\{)?)',
-        \ 're!\\includegraphics\*?([^\]]*\]?){0,2}\{[^\}]*',
+        \ 're!\\[A-Za-z]*(cite)[A-Za-z]*(\[[^\]\{\}]*\]){0,2}\{[^\}]*',
+        \ 're!\\[A-Za-z]*(ref\{[^\}]*|refrange\{([^,\}]*(\}\{)?))',
+        \ 're!\\includegraphics\*?(\[[^\]\{\}]*\]){0,2}\{[^\}]*',
         \ 're!\\(include(only)?|input)\{[^\}]*'
         \ ]
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1378,7 +1378,7 @@ documents with |neocomplete| and |vimtex|s omni completion function: >
   let g:neocomplete#sources#omni#input_patterns.tex =
         \ '\v\\%('
         \ . '\a*%(cite)\a*%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*'
-        \ . '\a*%(ref)%(range|name\{\w\})?\s*\{%([^\}]*%(\}\{)?)'
+        \ . '\a*%(ref)%(range|name\{\w*\})?\s*\{%([^\}]*%(\}\{)?)'
         \ . '|includegraphics\*?%(\s*[^\]]*\]?){0,2}\s*\{[^\}]*'
         \ . '|%(include%(only)?|input)\s*\{[^\}]*'
         \ . ')'
@@ -1405,7 +1405,7 @@ To enable automatic completion with |youcompleteme|, use the following options:
   endif
   let g:ycm_semantic_triggers.tex = [
         \ 're!\\[A-Za-z]*(cite)[A-Za-z]*([^\]]*\]?){0,2}\{[^\}]*',
-        \ 're!\\[A-Za-z]*(ref)(range|name\{\w\})?\{([^\}]*(\}\{)?)',
+        \ 're!\\[A-Za-z]*(ref)(range|name\{\w*\})?\{([^\}]*(\}\{)?)',
         \ 're!\\includegraphics\*?([^\]]*\]?){0,2}\{[^\}]*',
         \ 're!\\(include(only)?|input)\{[^\}]*'
         \ ]


### PR DESCRIPTION
Modified the patterns as they did not cover some forms of biblatex and cleveref commands such as, `\parencite[pre][post]{key}`, `\crefrange{label1}{label2}`, `\cpageref{label1}` and `\cpagerefrange{label1}{label2}`.