### PR TITLE
Fix file-line-error by letting latexmk deal with it

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -414,8 +414,7 @@ function! s:latexmk_build_cmd() " {{{1
   let cmd .= ' -verbose -pdf ' . g:vimtex_latexmk_options
 
   if g:vimtex_latexmk_file_line_error
-    let cmd .= ' -e ' . vimtex#util#shellescape(
-          \ '$pdflatex =~ s/ / -file-line-error /')
+    let cmd .= ' -file-line-error '
   endif
 
   if g:vimtex_latexmk_build_dir !=# ''


### PR DESCRIPTION
The current method can cause problems with a latexmkrc containing something like the following:

`$pdflatex = "env openout_any=a lualatex %O %S";`

In this case, a command like `env openout_any=a -file-line-error lualatex -file-line-error ...` will be run.

Instead we can just pass -file-line-error to latexmk, which will pass it one for us.