### PR TITLE
Add '@tex' to Skim 'g:vimtex_view_general_options'

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -832,7 +832,7 @@ Options~
 
             let g:vimtex_view_general_viewer
                   \ = '/Applications/Skim.app/Contents/SharedSupport/displayline'
-            let g:vimtex_view_general_options = '-r @line @pdf'
+            let g:vimtex_view_general_options = '-r @line @pdf @tex'
 
             " This adds a callback hook that updates Skim after compilation
             let g:vimtex_latexmk_callback_hooks = ['UpdateSkim']


### PR DESCRIPTION
I couldn't get forward search to work without the `@tex` flag.
Then, I found the solution in issue #204, I added it to the rc file and all went well.
So it may be worth adding it to the docs.