### PR TITLE
Check g:tex_fast before enabling additional highlighting.

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -22,21 +22,23 @@ syntax match texInputFile /\\includepdf\%(\[.\{-}\]\)\=\s*{.\{-}}/
 
 " {{{1 Italic font, bold font and conceals
 
-let conceal = (has('conceal') && get(g:, 'tex_conceal', 'b') =~# 'b')
-      \ ? 'concealends' : ''
+if get(g:, 'tex_fast', 'b') =~# 'b'
+  let conceal = (has('conceal') && get(g:, 'tex_conceal', 'b') =~# 'b')
+        \ ? 'concealends' : ''
 
-for [style, group, commands] in [
-      \ ['texItalStyle', 'texItalGroup', ['emph', 'textit']],
-      \ ['texBoldStyle', 'texBoldGroup', ['textbf']],
-      \]
-  for cmd in commands
-    execute 'syntax region' style 'matchgroup=texTypeStyle'
-          \ 'start="\\' . cmd . '\s*{" end="}"'
-          \ 'contains=@' . group
-          \ conceal
+  for [style, group, commands] in [
+        \ ['texItalStyle', 'texItalGroup', ['emph', 'textit']],
+        \ ['texBoldStyle', 'texBoldGroup', ['textbf']],
+        \]
+    for cmd in commands
+      execute 'syntax region' style 'matchgroup=texTypeStyle'
+            \ 'start="\\' . cmd . '\s*{" end="}"'
+            \ 'contains=@' . group
+            \ conceal
+    endfor
+    execute 'syntax cluster texMatchGroup add=' . style
   endfor
-  execute 'syntax cluster texMatchGroup add=' . style
-endfor
+endif
 
 " }}}1
 " {{{1 Add syntax highlighting for \url, \href, \hyperref
@@ -65,33 +67,37 @@ highlight link texHyperref     texRefZone
 
 " }}}1
 " {{{1 Improve support for cite commands
-syntax match texStatement
-      \ "\\\%(auto\|text\)\?cite\%([tp]\*\?\|author\)\?"
-      \ nextgroup=texRefOption,texCite
+if get(g:, 'tex_fast', 'r') =~# 'r'
+  syntax match texStatement
+        \ "\\\%(auto\|text\)\?cite\%([tp]\*\?\|author\)\?"
+        \ nextgroup=texRefOption,texCite
+endif
 
 " }}}1
 " {{{1 Add support for cleveref package
-syntax region texRefZone matchgroup=texStatement
-      \ start="\\\(\(label\)\?c\(page\)\?\|C\|auto\)ref{"
-      \ end="}\|%stopzone\>"
-      \ contains=@texRefGroup
+if get(g:, 'tex_fast', 'r') =~# 'r'
+  syntax region texRefZone matchgroup=texStatement
+        \ start="\\\(\(label\)\?c\(page\)\?\|C\|auto\)ref{"
+        \ end="}\|%stopzone\>"
+        \ contains=@texRefGroup
 
-" \crefrange, \cpagerefrange (these commands expect two arguments)
-syntax match texStatement
-      \ '\\c\(page\)\?refrange\>'
-      \ nextgroup=texRefRangeStart skipwhite skipnl
-syntax region texRefRangeStart
-      \ start="{"rs=s+1  end="}"
-      \ matchgroup=Delimiter
-      \ contained contains=texRefZone
-      \ nextgroup=texRefRangeEnd skipwhite skipnl
-syntax region texRefRangeEnd
-      \ start="{"rs=s+1 end="}"
-      \ matchgroup=Delimiter
-      \ contained contains=texRefZone
+  " \crefrange, \cpagerefrange (these commands expect two arguments)
+  syntax match texStatement
+        \ '\\c\(page\)\?refrange\>'
+        \ nextgroup=texRefRangeStart skipwhite skipnl
+  syntax region texRefRangeStart
+        \ start="{"rs=s+1  end="}"
+        \ matchgroup=Delimiter
+        \ contained contains=texRefZone
+        \ nextgroup=texRefRangeEnd skipwhite skipnl
+  syntax region texRefRangeEnd
+        \ start="{"rs=s+1 end="}"
+        \ matchgroup=Delimiter
+        \ contained contains=texRefZone
 
-highlight link texRefRangeStart texRefZone
-highlight link texRefRangeEnd   texRefZone
+  highlight link texRefRangeStart texRefZone
+  highlight link texRefRangeEnd   texRefZone
+endif
 
 " }}}1
 " {{{1 Add support for listings package

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1596,7 +1596,7 @@ highlighting.  However, |vimtex| does add some minor improvements:
 Before enabling additional syntax highlighting, |vimtex| also checks the
 |g:text_fast| variable (defined by |ft-tex-syntax|) that allows one to
 selectively enable or disable highlighting for specific groups.  If
-|g:tex_fast| is set, additonal syntax highlighting for bold, italic, and
+|g:tex_fast| is set, additional syntax highlighting for bold, italic, and
 reference groups are enabled only if they are explicitly allowed.
 
 ==============================================================================

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1594,7 +1594,7 @@ highlighting.  However, |vimtex| does add some minor improvements:
 - Nested syntax highlighting for `minted` (see |g:vimtex_syntax_minted|)
 
 Before enabling additional syntax highlighting, |vimtex| also checks the
-|g:text_fast| variable (defined by |ft-tex-syntax|) that allows one to
+|g:tex_fast| variable (defined by |ft-tex-syntax|) that allows one to
 selectively enable or disable highlighting for specific groups.  If
 |g:tex_fast| is set, additional syntax highlighting for bold, italic, and
 reference groups are enabled only if they are explicitly allowed.

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1583,8 +1583,8 @@ Associated settings:
 ==============================================================================
 SYNTAX HIGHLIGHTING                                             *vimtex-syntax*
 
-Vim ships with syntax hightlighting for LaTeX documents out of the box, please
-see ||ft-tex-syntax|.  |vimtex| therefore does not provide its own syntax
+Vim ships with syntax highlighting for LaTeX documents out of the box, please
+see |ft-tex-syntax|.  |vimtex| therefore does not provide its own syntax
 highlighting.  However, |vimtex| does add some minor improvements:
 
 - Support for `biblatex` and `natbib` package
@@ -1592,6 +1592,12 @@ highlighting.  However, |vimtex| does add some minor improvements:
 - Improved highlighting of `listings` package
 - Nested syntax highlighting for `dot2tex`
 - Nested syntax highlighting for `minted` (see |g:vimtex_syntax_minted|)
+
+Before enabling additional syntax highlighting, |vimtex| also checks the
+|g:text_fast| variable (defined by |ft-tex-syntax|) that allows one to
+selectively enable or disable highlighting for specific groups.  If
+|g:tex_fast| is set, additonal syntax highlighting for bold, italic, and
+reference groups are enabled only if they are explicitly allowed.
 
 ==============================================================================
 NAVIGATION                                                  *vimtex-navigation*


### PR DESCRIPTION
The default syntax highlighting script shipped with Vim defines the global variable `g:tex_fast` which allows one to selectively enable/disable highlighting for certain regions.  If it's set and does not contain the character `b`, bold/italic syntax highlighting should be disabled.  Similarly, if it doesn't contain the character `r`, texRefZone syntax highlighting should be disabled.