### PR TITLE
Use full list of arguments (line, pdf, and tex file (current buffer)) in the latexmk callback function for Skim.

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -840,16 +840,17 @@ Options~
               if !a:status | return | endif
 
               let l:out = b:vimtex.out()
+              let l:tex = expand('%:p')
               let l:cmd = [g:vimtex_view_general_viewer, '-r']
               if !empty(system('pgrep Skim'))
-                call extend(l:cmd, ['-g'])
+                call extend(l:cmd, ['-g', line('.'), l:out, l:tex])
               endif
               if has('nvim')
-                call jobstart(l:cmd + [line('.'), l:out])
+                call jobstart(l:cmd + [line('.'), l:out, l:tex])
               elseif has('job')
-                call job_start(l:cmd + [line('.'), l:out])
+                call job_start(l:cmd + [line('.'), l:out, l:tex])
               else
-                call system(join(l:cmd + [line('.'), shellescape(l:out)], ' '))
+                call system(join(l:cmd + [line('.'), shellescape(l:out), shellescape(l:tex)], ' '))
               endif
             endfunction
 <


### PR DESCRIPTION
This allows to correctly place the reading mark at the current line when
dealing with multifile projects. Beforehand, the initial placement was
wrong (for multifile projects).