### PR TITLE
Don't add line number, pdf, and (current) tex file twice to the list of options. 

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -824,7 +824,7 @@ Options~
               let l:tex = expand('%:p')
               let l:cmd = [g:vimtex_view_general_viewer, '-r']
               if !empty(system('pgrep Skim'))
-                call extend(l:cmd, ['-g', line('.'), l:out, l:tex])
+                call extend(l:cmd, ['-g'])
               endif
               if has('nvim')
                 call jobstart(l:cmd + [line('.'), l:out, l:tex])


### PR DESCRIPTION
We already do it when calling the command.