### PR TITLE
Order candicates in graphix autocompletion for better experience

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -362,12 +362,20 @@ function! s:img.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val !=# l:output')
 
   call map(self.candidates, 'strpart(v:val, len(b:vimtex.root)+1)')
-  call map(self.candidates, '{
-        \ ''abbr'' : v:val,
-        \ ''word'' : v:val,
-        \ ''menu'' : '' [graphics]'',
-        \ }')
+  let res = []
+  for fp in self.candidates
+    let cand = {
+        \ 'abbr' : fp,
+        \ 'word' : fp,
+        \ 'menu' : '[graphics]',
+        \}
+    if fp =~ a:regex
+      let cand.rank = 99
+    endif
+    call add(res, cand)
+  endfor
 
+  let self.candidates = res
   if g:vimtex_complete_img_use_tail
     for l:cand in self.candidates
       let l:cand.word = fnamemodify(l:cand.word, ':t')


### PR DESCRIPTION
This commit is to enhance the experience in the omni completion, for including graphics.
The candidates are ranked by a:regex, so that a file that matches the input has a priority in the completion list.