### PR TITLE
Relates to #472

### DIFF
--- a/autoload/vimtex/fold.vim
+++ b/autoload/vimtex/fold.vim
@@ -8,7 +8,7 @@ function! vimtex#fold#init_options() " {{{1
   call vimtex#util#set_default('g:vimtex_fold_enabled', 0)
   call vimtex#util#set_default('g:vimtex_fold_manual', 0)
   call vimtex#util#set_default('g:vimtex_fold_comments', 0)
-  call vimtex#util#set_default('g:vimtex_fold_section_character', '*')
+  call vimtex#util#set_default('g:vimtex_fold_levelmarker', '*')
   call vimtex#util#set_default('g:vimtex_fold_preamble', 1)
   call vimtex#util#set_default('g:vimtex_fold_envs', 1)
   call vimtex#util#set_default('g:vimtex_fold_parts',
@@ -237,7 +237,7 @@ function! vimtex#fold#text() " {{{1
   let line = getline(v:foldstart)
 
   let level = v:foldlevel > 1
-        \ ? repeat('-', v:foldlevel-2) . g:vimtex_fold_section_character
+        \ ? repeat('-', v:foldlevel-2) . g:vimtex_fold_levelmarker
         \ : ''
   let title = 'Not defined'
   let nt = 73

--- a/autoload/vimtex/fold.vim
+++ b/autoload/vimtex/fold.vim
@@ -8,6 +8,7 @@ function! vimtex#fold#init_options() " {{{1
   call vimtex#util#set_default('g:vimtex_fold_enabled', 0)
   call vimtex#util#set_default('g:vimtex_fold_manual', 0)
   call vimtex#util#set_default('g:vimtex_fold_comments', 0)
+  call vimtex#util#set_default('g:vimtex_fold_section_character', 0)
   call vimtex#util#set_default('g:vimtex_fold_preamble', 1)
   call vimtex#util#set_default('g:vimtex_fold_envs', 1)
   call vimtex#util#set_default('g:vimtex_fold_parts',
@@ -234,7 +235,12 @@ endfunction
 function! vimtex#fold#text() " {{{1
   " Initialize
   let line = getline(v:foldstart)
-  let level = v:foldlevel > 1 ? repeat('-', v:foldlevel-2) . '*' : ''
+
+  if type(g:vimtex_fold_section_character)
+    let level = v:foldlevel > 1 ? repeat('-', v:foldlevel-2) . g:vimtex_fold_section_character : g:vimtex_fold_section_character
+  else
+    let level = v:foldlevel > 1 ? repeat('-', v:foldlevel-2) . '*' : ''
+  endif
   let title = 'Not defined'
   let nt = 73
 

--- a/autoload/vimtex/fold.vim
+++ b/autoload/vimtex/fold.vim
@@ -8,7 +8,7 @@ function! vimtex#fold#init_options() " {{{1
   call vimtex#util#set_default('g:vimtex_fold_enabled', 0)
   call vimtex#util#set_default('g:vimtex_fold_manual', 0)
   call vimtex#util#set_default('g:vimtex_fold_comments', 0)
-  call vimtex#util#set_default('g:vimtex_fold_section_character', 0)
+  call vimtex#util#set_default('g:vimtex_fold_section_character', '')
   call vimtex#util#set_default('g:vimtex_fold_preamble', 1)
   call vimtex#util#set_default('g:vimtex_fold_envs', 1)
   call vimtex#util#set_default('g:vimtex_fold_parts',
@@ -236,11 +236,13 @@ function! vimtex#fold#text() " {{{1
   " Initialize
   let line = getline(v:foldstart)
 
-  if type(g:vimtex_fold_section_character)
-    let level = v:foldlevel > 1 ? repeat('-', v:foldlevel-2) . g:vimtex_fold_section_character : g:vimtex_fold_section_character
+  if empty(g:vimtex_fold_section_character)
+    let fold_character = '*'
   else
-    let level = v:foldlevel > 1 ? repeat('-', v:foldlevel-2) . '*' : ''
+    let fold_character = g:vimtex_fold_section_character
   endif
+
+  let level = v:foldlevel > 1 ? repeat('-', v:foldlevel-2) . fold_character : ''
   let title = 'Not defined'
   let nt = 73
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -427,7 +427,7 @@ Options~
 
   Default value: 0
 
-*g:vimtex_fold_section_character*
+*g:vimtex_fold_levelmarker*
 
   Use custom section symbol for folding.
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -427,6 +427,12 @@ Options~
 
   Default value: 0
 
+*g:vimtex_fold_section_character*
+
+  Use custom section symbol for folding.
+
+  Default value: 0
+
 *g:vimtex_fold_envs*
   Control whether or not to fold environments.
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -431,7 +431,7 @@ Options~
 
   Use custom section symbol for folding.
 
-  Default value: 0
+  Default value: ''
 
 *g:vimtex_fold_envs*
   Control whether or not to fold environments.


### PR DESCRIPTION
Rename `vimtex_fold_section_character` to `vimtex_fold_levelmarker`.