### PR TITLE
fix #480: Use absolute paths, pt. 2

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -541,8 +541,8 @@ function! s:get_main_from_specifier(spec) " {{{1
         if filereadable(l:filename) | return l:filename | endif
       else
         for l:candidate in [
-              \ expand('%:p:h')             . '/' . l:filename,
-              \ fnamemodify(getcwd(), ':p') . '/' . l:filename
+              \ fnamemodify(expand('%:p:h') . '/' . l:filename, ':p'),
+              \ fnamemodify(getcwd() . '/' . l:filename, ':p')
               \]
           if filereadable(l:candidate) | return l:candidate | endif
         endfor


### PR DESCRIPTION
The string in the specifier was not part of `fnamemodify`, so no effect. Also in my case the first string of the array was used, so my `b:vimtex.tex` was still "C:/path/to/main/subfolder/../main.tex".