### PR TITLE
Drop -pdf as the default option to pass to latexmk.

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -424,7 +424,7 @@ function! s:latexmk_build_cmd() " {{{1
   if !empty(g:vimtex_latexmk_options)
     let cmd .= ' ' . g:vimtex_latexmk_options
   else
-    let cmd .= ' -verbose -pdf -file-line-error'
+    let cmd .= ' -verbose -file-line-error'
     let cmd .= ' -synctex=1 -interaction=nonstopmode'
   endif
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -665,7 +665,6 @@ Options~
 *g:vimtex_latexmk_options*
   By default, |vimtex| passes the following options to `latexmk`: >
 
-     -pdf                     -- Compile to pdf documents
      -verbose                 -- More verbose output
      -file-line-error         -- Enable file:line:error style messages
      -synctex=1               -- Generate synctex data


### PR DESCRIPTION
Hi. First, thanks for making this awesome plugin.

This commit drops the `-pdf` option from the defaults for `g:vimtex_latexmk_options` . I made this change because it would be better to specify the kind of output you want in your latexmkrc file instead of your vim configuration file . This is important for some people in non-English speaking countries where people might use two different variants of TeX, one for their native language and the other for English.

In my case, I use a TeX engine called p-TeX, which is widely used in Japan. Unlike most TeX engines widely used for creating English documents, p-TeX doesn't directly output PDF. I have a problem with the current default because it overrides the option I specified in the latexmkrc file, and tries to output PDF directly. So if I want to have different kinds of output for each document depending on the language, I would have to change my vim configuration each time, which is a little tedious. 

Additionally, dropping `-pdf` from the defaults would make the output of `VimtexCompile` more consistent with what you would get when you type `$ latexmk` on the command line, leading to fewer surprises.