### PR TITLE
Match \cite* and \Cite

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -79,7 +79,7 @@ if get(g:, 'tex_fast', 'r') =~# 'r'
   "
   execute 'syntax match texStatement /\v\\%(' . join([
         \   '[Cc]iteauthor\*?',
-        \   'cite%(title|year|date)\*?',
+        \   '[Cc]ite%(title|year|date)?\*?',
         \   'citeurl',
         \   '[Pp]arencite\*?',
         \   'foot%(full)?cite%(text)?',


### PR DESCRIPTION
Those two commands still weren't highlighted properly, now they are.