### PR TITLE
Change order of arguments in s:zathura.start

### DIFF
--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -346,10 +346,11 @@ endfunction
 " }}}2
 function! s:zathura.start(outfile) dict " {{{2
   let exe = {}
-  let exe.cmd  = 'zathura ' .  g:vimtex_view_zathura_options
+  let exe.cmd  = 'zathura '
   let exe.cmd .= ' -x "' . g:vimtex_latexmk_progname
         \ . ' --servername ' . v:servername
         \ . ' --remote +\%{line} \%{input}"'
+  let exe.cmd .= ' ' .  g:vimtex_view_zathura_options
   let exe.cmd .= ' ' . vimtex#util#shellescape(a:outfile)
   call vimtex#util#execute(exe)
   let self.cmd_start = exe.cmd


### PR DESCRIPTION
Hi Karl

### Explain the issue

I am trying to set up reverse synctex support in the zathura PDF viewer. Specifically, I would like to use `g:vimtex_view_zathura_options` to supply a custom `-x` option to zathura.

Currently, vimtex essentially hard-codes this option because the vimtex default value is added to the command line that is executed to start zathura _after_ `g:vimtex_view_zathura_options`. This overrides anything specified for `-x` via the vimtex option. You hinted at the problem in #454 [(specific comment)](https://github.com/lervag/vimtex/issues/454#issuecomment-219425818).

#### Steps to reproduce

1. Supply the `-x`/`--synctex-editor-command` command line option via `g:vimtex_view_zathura_options`, e.g. the following test setup:

    ```vim
    let g:vimtex_view_method = 'zathura'
    let g:vimtex_view_zathura_options = '-x firefox'
    ```

2. Open the viewer from vimtex by hitting `lv`.
NB: close all open instances of zathura such that a new instance is launched by vimtex.

3. Hit `Shit-left mouse click` in the opened PDF to have zathura do the reverse lookup.

#### Expected behaviour

Firefox opens.

#### Observed behaviour

Depending on whether you use vim or neovim, the file opens or nothing happens.

### Proposed fix

The fix I propose changes the order in which the command line for starting zathura is built. This allows definitions of `-x` supplied via `g:vimtex_view_zathura_options` to override the vimtex default. At the same time, the behaviour of vimtex should not change for all users who do not specifically include a `-x` in their definition of `g:vimtex_view_zathura_options`.

Just FYI, this is the setup I actually use and that works well after the small change to `s:zathura.start`:

```vim
let g:vimtex_view_method = 'zathura'
let g:vimtex_view_zathura_options = '-x '''
    \ . 'nvr --servername "' . v:servername . '"'
    \ . ' --remote-send "<C-\><C-n>:buffer \"\%{input}\"<CR>:\%{line}<CR>:normal\! ztzv<CR>"'''
```