### PR TITLE
Use correct gnuplot environment for nested syntax (#514)

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -194,8 +194,8 @@ let b:current_syntax = 'tex'
 unlet b:current_syntax
 syntax include @GNUPLOT syntax/gnuplot.vim
 syntax region texZone
-      \ start='\\begin{gnuplottex}\(\_s*\[\_[\]]\{-}\]\)\?'rs=s
-      \ end='\\end{gnuplottex}'re=e
+      \ start='\\begin{gnuplot}\(\_s*\[\_[\]]\{-}\]\)\?'rs=s
+      \ end='\\end{gnuplot}'re=e
       \ keepend
       \ transparent
       \ contains=texBeginEnd,texBeginEndModifier,@GNUPLOT

--- a/test/features/syntax/test-syntax.tex
+++ b/test/features/syntax/test-syntax.tex
@@ -27,9 +27,9 @@ testing
   }
 \end{dot2tex}
 
-\begin{gnuplottex}[terminal=..., terminaloptions=...]
+\begin{gnuplot}[terminal=..., terminaloptions=...]
     plot file using 1:2 with lines
-\end{gnuplottex}
+\end{gnuplot}
 
 \begin{minted}{python}
 def function(arg):


### PR DESCRIPTION
Thanks for adding the nested Gnuplot syntax. I've only changed the environment from `gnuplottex` to `gnuplot`, which is what the `gnuplottex` Latex package uses.