### PR TITLE
Escape path for lcd

### DIFF
--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -170,7 +170,7 @@ endfunction
 
 " }}}1
 function! vimtex#util#kpsewhich(file, ...) " {{{1
-  execute 'lcd' escape(b:vimtex.root, ' ')
+  execute 'lcd' . fnameescape(b:vimtex.root)
   let cmd  = 'kpsewhich '
   let cmd .= a:0 > 0 ? a:1 : ''
   let cmd .= ' "' . a:file . '"'

--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -170,7 +170,7 @@ endfunction
 
 " }}}1
 function! vimtex#util#kpsewhich(file, ...) " {{{1
-  execute 'lcd' b:vimtex.root
+  execute 'lcd' escape(b:vimtex.root, ' ')
   let cmd  = 'kpsewhich '
   let cmd .= a:0 > 0 ? a:1 : ''
   let cmd .= ' "' . a:file . '"'


### PR DESCRIPTION
Fixes error, when lcd tries to change folder to Root folder containing spaces.