### PR TITLE
Add warning if .bib file hasn't been opened from .tex file

### DIFF
--- a/autoload/vimtex/toc.vim
+++ b/autoload/vimtex/toc.vim
@@ -117,6 +117,11 @@ endfunction
 " }}}1
 
 function! vimtex#toc#open() " {{{1
+  let l:bib_warning = 'In order to use the ToC the .bib file has to be opened from within a .tex document!'
+  if !exists('g:vimtex_data[get(b:, "vimtex_id")].root')
+    call vimtex#echo#warning(bib_warning)
+    return
+  endif
   if vimtex#index#open(s:name) | return | endif
 
   if !exists('b:vimtex')
@@ -155,6 +160,11 @@ endfunction
 
 " }}}1
 function! vimtex#toc#toggle() " {{{1
+  let l:bib_warning = 'In order to use the ToC the .bib file has to be opened from within a .tex document!'
+  if !exists('g:vimtex_data[get(b:, "vimtex_id")].root')
+    call vimtex#echo#warning(bib_warning)
+    return
+  endif
   if vimtex#index#open(s:name)
     call vimtex#index#close(s:name)
   else

--- a/ftplugin/bib.vim
+++ b/ftplugin/bib.vim
@@ -21,12 +21,28 @@ function! s:map(mode, lhs, rhs, ...)
 endfunction
 
 if get(g:, 'vimtex_toc_enabled', 1)
-  command! -buffer VimtexTocOpen   call vimtex#toc#open()
-  command! -buffer VimtexTocToggle call vimtex#toc#toggle()
-  nnoremap <buffer> <plug>(vimtex-toc-open)   :call vimtex#toc#open()<cr>
-  nnoremap <buffer> <plug>(vimtex-toc-toggle) :call vimtex#toc#toggle()<cr>
-  call s:map('n', '<localleader>lt', '<plug>(vimtex-toc-open)')
-  call s:map('n', '<localleader>lT', '<plug>(vimtex-toc-toggle)')
+  if exists('g:vimtex_data[get(b:, "vimtex_id")].root')
+    command! -buffer VimtexTocOpen   call vimtex#toc#open()
+    command! -buffer VimtexTocToggle call vimtex#toc#toggle()
+    nnoremap <buffer> <plug>(vimtex-toc-open)   :call vimtex#toc#open()<cr>
+    nnoremap <buffer> <plug>(vimtex-toc-toggle) :call vimtex#toc#toggle()<cr>
+    call s:map('n', '<localleader>lt', '<plug>(vimtex-toc-open)')
+    call s:map('n', '<localleader>lT', '<plug>(vimtex-toc-toggle)')
+  else
+    let bib_warning = 'In order to use the ToC the .bib file has to be opened from within a .tex document!'
+    command! -buffer VimtexTocOpen
+          \ call vimtex#echo#warning(bib_warning)
+    command! -buffer VimtexTocToggle
+          \ call vimtex#echo#warning(bib_warning)
+    nnoremap <buffer> <plug>(vimtex-toc-open)
+          \ :call vimtex#echo#warning(bib_warning)<CR>
+    nnoremap <buffer> <plug>(vimtex-toc-toggle)
+          \ :call vimtex#echo#warning(bib_warning)<CR>
+    call s:map('n', '<localleader>lt', '<plug>(vimtex-toc-open)')
+    call s:map('n', '<localleader>lT', '<plug>(vimtex-toc-toggle)')
+    unlet bib_warning
+  endif
+
 endif
 
 " vim: fdm=marker sw=2

--- a/ftplugin/bib.vim
+++ b/ftplugin/bib.vim
@@ -21,28 +21,12 @@ function! s:map(mode, lhs, rhs, ...)
 endfunction
 
 if get(g:, 'vimtex_toc_enabled', 1)
-  if exists('g:vimtex_data[get(b:, "vimtex_id")].root')
-    command! -buffer VimtexTocOpen   call vimtex#toc#open()
-    command! -buffer VimtexTocToggle call vimtex#toc#toggle()
-    nnoremap <buffer> <plug>(vimtex-toc-open)   :call vimtex#toc#open()<cr>
-    nnoremap <buffer> <plug>(vimtex-toc-toggle) :call vimtex#toc#toggle()<cr>
-    call s:map('n', '<localleader>lt', '<plug>(vimtex-toc-open)')
-    call s:map('n', '<localleader>lT', '<plug>(vimtex-toc-toggle)')
-  else
-    let bib_warning = 'In order to use the ToC the .bib file has to be opened from within a .tex document!'
-    command! -buffer VimtexTocOpen
-          \ call vimtex#echo#warning(bib_warning)
-    command! -buffer VimtexTocToggle
-          \ call vimtex#echo#warning(bib_warning)
-    nnoremap <buffer> <plug>(vimtex-toc-open)
-          \ :call vimtex#echo#warning(bib_warning)<CR>
-    nnoremap <buffer> <plug>(vimtex-toc-toggle)
-          \ :call vimtex#echo#warning(bib_warning)<CR>
-    call s:map('n', '<localleader>lt', '<plug>(vimtex-toc-open)')
-    call s:map('n', '<localleader>lT', '<plug>(vimtex-toc-toggle)')
-    unlet bib_warning
-  endif
-
+  command! -buffer VimtexTocOpen   call vimtex#toc#open()
+  command! -buffer VimtexTocToggle call vimtex#toc#toggle()
+  nnoremap <buffer> <plug>(vimtex-toc-open)   :call vimtex#toc#open()<cr>
+  nnoremap <buffer> <plug>(vimtex-toc-toggle) :call vimtex#toc#toggle()<cr>
+  call s:map('n', '<localleader>lt', '<plug>(vimtex-toc-open)')
+  call s:map('n', '<localleader>lT', '<plug>(vimtex-toc-toggle)')
 endif
 
 " vim: fdm=marker sw=2


### PR DESCRIPTION
I am not completely satisfied with the PR, because the keybindings stay if you open a .tex document after opening the .bib file and open the bib file from that .tex document without closing the buffer.


As an alternative I tried adding

```
if exists('g:vimtex_data[get(b:, "vimtex_id")].root')
  finish
endif
```

before

```
if exists('b:did_ftplugin')
  finish
endif
let b:did_ftplugin = 1
```
(I could add the keybinding warnings this way as well of course...)

but it seems bib.vim is only parsed once, when the buffer opens.
Do you have a idea to fix this issue or  do you think it doesn't matter?