### PR TITLE
Avoid doautocmd warning

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -207,7 +207,9 @@ function! vimtex#latexmk#compile() " {{{1
     call s:latexmk_set_pid()
     call vimtex#echo#status(['latexmk compile: ',
           \ ['VimtexSuccess', 'started continuous mode']])
-    doautocmd User VimtexEventCompileStarted
+    if exists('#User#VimtexEventCompileStarted')
+      doautocmd User VimtexEventCompileStarted
+    endif
   else
     if get(l:exe, 'bg', 1)
       call vimtex#echo#status(['latexmk compile: ',
@@ -523,7 +525,9 @@ function! vimtex#latexmk#stop() " {{{1
     call s:latexmk_kill(b:vimtex)
     call vimtex#echo#status(['latexmk compile: ',
           \ ['VimtexSuccess', 'stopped (' . b:vimtex.base . ')']])
-    doautocmd User VimtexEventCompileStopped
+    if exists('#User#VimtexEventCompileStopped')
+      doautocmd User VimtexEventCompileStopped
+    endif
   else
     call vimtex#echo#status(['latexmk compile: ',
           \ ['VimtexWarning', 'no process to stop (' . b:vimtex.base . ')']])


### PR DESCRIPTION
If users don't define autocmd for VimtexEventCompileStarted or  VimtexEventCompileStopped,
Vim gives error message (and maybe also hit-enter) as follows.

![ss](https://cloud.githubusercontent.com/assets/9126033/18870031/d97d5afc-84e9-11e6-910b-aec0e22b282a.png)
