### PR TITLE
Make 'insert new command' work also after non-^ and non-\s regex

### DIFF
--- a/autoload/vimtex/cmd.vim
+++ b/autoload/vimtex/cmd.vim
@@ -105,7 +105,7 @@ function! vimtex#cmd#delete() " {{{1
 endfunction
 
 function! vimtex#cmd#create() " {{{1
-  let l:re = '\v%(^|\s)\zs\w+\ze%(\s|$)'
+  let l:re = '\v%(^|\A)\zs\w+\ze%(\s|$)'
   let l:c0 = col('.') - (mode() ==# 'i')
 
   let [l:l1, l:c1] = searchpos(l:re, 'bcn', line('.'))


### PR DESCRIPTION
The insert new command functionality, mapped on <F7> by default, doesn't work when the word is preceded by non-space and non-start-of-line character. This commit allows insertion after any non-letter, since LaTeX commands cannot contain other charaters than a-zA-Z

[There's something wrong in the comparison of the two files. I changed only the line 108 from
`let l:re = '\v%(^|\s)\zs\w+\ze%(\s|$)'`
to
`let l:re = '\v%(^|\A)\zs\w+\ze%(\s|$)'`,
but in the comparison it seems that the line number is wrong (in fact line 60 is split in two in the comparison tool of GitHub. Don't know, but I think the commit is clear.]