### PR TITLE
Infinite recursive main discovery

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -637,7 +637,7 @@ function! s:get_main_recurse(...) " {{{1
   "
   " Gather candidate files
   "
-  let l:path = expand('%:p:h')
+  let l:path = fnamemodify(l:file, ':p:h')
   let l:dirs = l:path
   while l:path != fnamemodify(l:path, ':h')
     let l:path = fnamemodify(l:path, ':h')


### PR DESCRIPTION
Main discovery always ended up starting on the base file when recursing.
To fix this we use the file stored in l:file instead of % (current file).

Trying to echo out l:file and seeing which directories it traverses makes me believe this is what was actually intended.