### PR TITLE
Option to enable %-movement within comments

### DIFF
--- a/autoload/vimtex/motion.vim
+++ b/autoload/vimtex/motion.vim
@@ -9,6 +9,7 @@ function! vimtex#motion#init_options() " {{{1
   if !g:vimtex_motion_enabled | return | endif
 
   call vimtex#util#set_default('g:vimtex_motion_matchparen', 1)
+  call vimtex#util#set_default('g:vimtex_motion_incomments', 0)
 endfunction
 
 " }}}1
@@ -92,7 +93,7 @@ function! vimtex#motion#find_matching_pair(...) " {{{1
     normal! gv
   endif
 
-  if vimtex#util#in_comment() | return | endif
+  if !g:vimtex_motion_incomments && vimtex#util#in_comment() | return | endif
 
   let delim = vimtex#delim#get_current('all', 'both')
   if empty(delim)

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -688,6 +688,11 @@ Options~
 
   Default value: 1
 
+*g:vimtex_motion_incomments*
+  Enable the use of % to move between 'matchpairs' inside comments.
+
+  Default value: 1
+
 *g:vimtex_latexmk_enabled*
   Use this option to disable/enable the `latexmk` interface |vimtex-latexmk|.
 


### PR DESCRIPTION
Rationale:
  Folds are often delimited using patterns in comments, like:

    %{-{1
    ...
    %}-}1

  and it is useful to be able to skip between the delimiters.