### PR TITLE
Corrected Okular options in documentation

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -921,7 +921,7 @@ Options~
           and backward search. Recommended settings are: >
 
             let g:vimtex_view_general_viewer = 'okular'
-            let g:vimtex_view_general_options = '--unique @pdf\#src:@line@tex'
+            let g:vimtex_view_general_options = '--unique file:@pdf\#src:@line@tex'
             let g:vimtex_view_general_options_latexmk = '--unique'
 
 <          Backward search must be set up from the viewer through


### PR DESCRIPTION
When I was setting up the synctex forward search to Okular I noticed an issue with the documentation which led to a bit of confusion. 

You must use `file:@pdf` rather than just `@pdf` in the `g:vimtex_view_general_options` string, otherwise Okular will not be able to open the file.

I've just amended the documentation to reflect this, no other changes are required.