### PR TITLE
Use `strchars` for calculating line length

### DIFF
--- a/autoload/vimtex/format.vim
+++ b/autoload/vimtex/format.vim
@@ -110,7 +110,7 @@ function! s:format(top, bottom) " {{{1
     endif
 
     " Handle long lines
-    if len(l:line) > s:textwidth
+    if strchars(l:line) > s:textwidth
       let l:bottom += s:format_build_lines(l:current, l:mark)
       let l:mark = l:current-1
     endif
@@ -160,7 +160,7 @@ function! s:format_build_lines(start, end) " {{{1
   let l:lnum = a:start-1
   let l:current = repeat(' ', indent(a:start))
   for l:word in l:words
-    if len(l:word) + len(l:current) > s:textwidth
+    if strchars(l:word) + strchars(l:current) > s:textwidth
       call append(l:lnum, substitute(l:current, '\s$', '', ''))
       let l:lnum += 1
       let l:current = repeat(' ', VimtexIndent(a:start))


### PR DESCRIPTION
The original, which use `len` to calculate the line length, cause multibyte characters, (such as UTF-8 characters outside the ASCII range) to count as 2 characters or more. And thus visually, the lines look shorter than expected after formatting.

Compare, (`tw = 79`)

New formatting
```
It was in July, 1805, and the speaker was the well-known Anna Pávlovna Schérer,
maid of honor and favorite of the Empress Márya Fëdorovna. With these words she
greeted Prince Vasíli Kurágin, a man of high rank and importance, who was the
first to arrive at her reception. Anna Pávlovna had had a cough for some days.
She was, as she said, suffering from \emph{la grippe;} \emph{grippe} being then
a new word in St.~Petersburg, used only by the elite.
```

Old formatting
```
It was in July, 1805, and the speaker was the well-known Anna Pávlovna
Schérer, maid of honor and favorite of the Empress Márya Fëdorovna. With these
words she greeted Prince Vasíli Kurágin, a man of high rank and importance, who
was the first to arrive at her reception. Anna Pávlovna had had a cough for
some days. She was, as she said, suffering from \emph{la grippe;} \emph{grippe}
being then a new word in St.~Petersburg, used only by the elite.
```