### PR TITLE
Improved parsing of equation numbers and omni-completion for subfile command

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -366,7 +366,8 @@ function! s:ref.parse_number(num_tree) dict " {{{2
       return self.parse_number(a:num_tree[l:index])
     endif
   else
-    return str2nr(a:num_tree) > 0 ? a:num_tree : '-'
+    let l:matches = matchlist(a:num_tree, '\v(^|.*\s)((\u|\d+)(\.\d+)*)($|\s.*)')
+    return len(l:matches) > 3 ? l:matches[2] : '-'
   endif
 endfunction
 
@@ -438,7 +439,7 @@ endfunction
 " {{{1 Filenames (\input and \include)
 
 let s:inc = {
-      \ 'patterns' : ['\v\\%(include%(only)?|input)\s*\{[^}]*$'],
+      \ 'patterns' : ['\v\\%(include%(only)?|input|subfile)\s*\{[^}]*$'],
       \}
 
 function! s:inc.complete(regex) dict " {{{2


### PR DESCRIPTION
1. The parsing of equation numbers did not work in documents where the numbers for example include the chapter number, e.g. things like 1.3 or, for appendices A.3.
Further, with some classes a "\relax" ends up in front of the label, which also causes the parsing to fail.
These problems are fixed by checking the entry from the aux-file against a regular expression.

2. in light of the support for the subfiles package, the \subfile{} command should also be supported by the omnicompletion. I therefore added it as an alternative to \include{} and \input{}