### PR TITLE
Modified latexmk.vim to allow empty option

### DIFF
--- a/autoload/vimtex/latexmk.vim
+++ b/autoload/vimtex/latexmk.vim
@@ -15,7 +15,8 @@ function! vimtex#latexmk#init_options() " {{{1
   call vimtex#util#set_default('g:vimtex_latexmk_background', 0)
   call vimtex#util#set_default('g:vimtex_latexmk_callback', 1)
   call vimtex#util#set_default('g:vimtex_latexmk_continuous', 1)
-  call vimtex#util#set_default('g:vimtex_latexmk_options', '')
+  call vimtex#util#set_default('g:vimtex_latexmk_options',
+        \ '-verbose -pdf -file-line-error -synctex=1 -interaction=nonstopmode')
   call vimtex#util#set_default('g:vimtex_quickfix_autojump', '0')
   call vimtex#util#set_default('g:vimtex_quickfix_ignore_all_warnings', 0)
   call vimtex#util#set_default('g:vimtex_quickfix_ignored_warnings', [])
@@ -580,13 +581,7 @@ function! s:latexmk_build_cmd() " {{{1
     endif
   endif
 
-  " Add general options for latexmk
-  if !empty(g:vimtex_latexmk_options)
-    let cmd .= ' ' . g:vimtex_latexmk_options
-  else
-    let cmd .= ' -verbose -pdf -file-line-error'
-    let cmd .= ' -synctex=1 -interaction=nonstopmode'
-  endif
+  let cmd .= ' ' . g:vimtex_latexmk_options
 
   if g:vimtex_latexmk_build_dir !=# ''
     let cmd .= ' -outdir=' . g:vimtex_latexmk_build_dir
@@ -667,13 +662,7 @@ function! s:latexmk_build_cmd_selected(fname) " {{{1
     endif
   endif
 
-  " Add general options for latexmk
-  if !empty(g:vimtex_latexmk_options)
-    let cmd .= ' ' . g:vimtex_latexmk_options
-  else
-    let cmd .= ' -verbose -pdf -file-line-error'
-    let cmd .= ' -synctex=1 -interaction=nonstopmode'
-  endif
+  let cmd .= ' ' . g:vimtex_latexmk_options
 
   let cmd .= ' ' . vimtex#util#shellescape(a:fname)
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -763,8 +763,8 @@ Options~
      -synctex=1               -- Generate synctex data
      -interaction=nonstopmode -- Disable interactive mode
 
-<  However, if `g:vimtex_latexmk_options` is defined and is nonzero, it will
-  override the above with the user supplied options.
+<  However, if `g:vimtex_latexmk_options` is defined, it will override the
+  above with the user supplied options.
 
   Note: Options may also be specified indirectly to `latexmk` through
         both a global and a project specific `.latexmkrc` file. One should
@@ -773,7 +773,8 @@ Options~
         one has to set `g:vimtex_latexmk_options` to a string that contains
         the desired options.
 
-  Default value: ''
+  Default value:
+    '-verbose -pdf -file-line-error -synctex=1 -interaction=nonstopmode'
 
 *g:vimtex_latexmk_progname*
   Path to vim executable.  This is used for the callback functionality, and it
@@ -2002,9 +2003,9 @@ to go from a specific position in the pdf file to the corresponding position
 in vim (inverse/backward search).
 
 To make synctex work, it must be enabled. vimtex enables this by default by
-passing `-synctex=1` on the command line, unless the user sets the option
-|g:vimtex_latexmk_options| to a nonempty value. In the latter case, the user
-should ensure that the synctex flag is passed, i.e. with: >
+passing `-synctex=1` on the command line, unless the user overrides the option
+|g:vimtex_latexmk_options|. In the latter case, the user should ensure that the
+synctex flag is passed, i.e. with: >
 
   let g:vimtex_latexmk_options = '... -synctex=1 ...'
 


### PR DESCRIPTION
This PR changes the default value of `g:vimtex_latexmk_options`.

The new code explicitly sets the options by default instead of implicitly modifying the value.
The empty value passed to the option now simply means that the user does not want to pass any options to latexmk.

Note: Those who have `let g:vimtex_latexmk_options = ''` in their `.vimrc` are affected by this change.