### PR TITLE
Delete environment along with begin/end lines

### DIFF
--- a/autoload/vimtex/env.vim
+++ b/autoload/vimtex/env.vim
@@ -103,6 +103,12 @@ function! vimtex#env#delete(type) " {{{1
   if empty(l:open) | return | endif
 
   call vimtex#env#change(l:open, l:close, '')
+  if (getline(l:close.lnum) =~ "^ *$")
+    execute l:close.lnum . 'd'
+  endif
+  if (getline(l:open.lnum) =~ "^ *$")
+    execute l:open.lnum . 'd'
+  endif
 endfunction
 
 function! vimtex#env#toggle_star() " {{{1

--- a/test/vader/env.vader
+++ b/test/vader/env.vader
@@ -41,3 +41,22 @@ Expect tex (Verify):
 
 Before:
 After:
+
+Given tex (Environments: foo and bar):
+  \begin{equation}
+    f(x) = \begin{bmatrix}
+        1 & 2 \\
+        3 & 4 \\
+      \end{bmatrix}
+  \end{equation}
+
+Do (Delete env: foo (TODO)):
+  jfmdse
+
+Expect tex (Verify):
+  \begin{equation}
+    f(x) = 
+        1 & 2 \\
+        3 & 4 \\
+  \end{equation}
+


### PR DESCRIPTION
A change is made to `vimtex#env#delete` in a way that it deletes `\begin{...}` and `\end{...}` lines. Before this change the command `dse` used to leave empty lines in place of `begin`/`end` lines or, had options been present, the `[...]` part in place on the whole `begin` line.
(It does not make use of `vimtex#evc#change anymore`.)