### PR TITLE
Delete environment into black hole register

### DIFF
--- a/autoload/vimtex/env.vim
+++ b/autoload/vimtex/env.vim
@@ -107,10 +107,10 @@ function! vimtex#env#delete(type) " {{{1
 
   " If the lines are empty afterwords, then we also delete the lines
   if getline(l:close.lnum) =~# '^\s*$'
-    execute l:close.lnum . 'd'
+    execute l:close.lnum . 'd _'
   endif
   if getline(l:open.lnum) =~# '^\s*$'
-    execute l:open.lnum . 'd'
+    execute l:open.lnum . 'd _'
   endif
 endfunction
 


### PR DESCRIPTION
If `dse` removes lines, it deletes them into the black hole register (`_`), thus not wasting the registers " and 1, nor losing the register 9.

I've found no other situations in which such a change is needed. Sometimes, e.g. for the `vimtex#cmd#create_ask` function, VimTeX *has to* keep the deleted text in some register, since it is reused afterwards.