### PR TITLE
Fix to insert command

### DIFF
--- a/autoload/vimtex/cmd.vim
+++ b/autoload/vimtex/cmd.vim
@@ -114,7 +114,7 @@ endfunction
 function! vimtex#cmd#create_insert() " {{{1
   if mode() !=# 'i' | return | endif
 
-  let l:re = '\v%(^|\A)\zs\w+\ze%(\A|$)'
+  let l:re = '\v%(^|\A)\zs\a+\ze%(\A|$)'
   let l:c0 = col('.') - 1
 
   let [l:l1, l:c1] = searchpos(l:re, 'bcn', line('.'))


### PR DESCRIPTION
This commit is somewhat related to the commit merged from [this PR](https://github.com/lervag/vimtex/pull/596) and is coherent with the definition of a LaTeX command ([egreg](http://tex.stackexchange.com/a/34383/87996)): it avoids, for instance, `_text<F7>` to become `\_text{`.