### PR TITLE
Use system() by default

### DIFF
--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -159,6 +159,19 @@ function! s:compiler.start_single() abort dict " {{{1
 
   let self.process = s:init_process(l:opts)
   call self.process.run()
+
+  if !l:opts.continuous
+    if self.background
+      call vimtex#echo#status(['latexmk compile: ',
+            \ ['VimtexSuccess', 'started in background!']])
+    else
+      if !has('gui') | redraw | endif
+      call vimtex#echo#status(['latexmk compile: ',
+            \ vimtex#qf#inquire(self.target)
+            \   ? ['VimtexWarning', 'fail']
+            \   : ['VimtexSuccess', 'success']])
+    endif
+  endif
 endfunction
 
 " }}}1

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -293,9 +293,6 @@ function! s:init_process(opts) abort " {{{1
   let l:process.name = 'latexmk'
   let l:process.continuous = a:opts.continuous
   let l:process.background = a:opts.background
-  if !l:process.background
-    let l:process.silent = 0
-  endif
   let l:process.cmd = s:build_cmd(a:opts)
 
   if l:process.continuous

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -146,10 +146,7 @@ function! s:completer_bib.search(regexp) dict " {{{2
           \ ], tmp.aux)
 
     " Create the temporary bbl file
-    call vimtex#process#run('bibtex -terse ' . tmp.aux, {
-          \ 'background' : 0,
-          \ 'use_system' : 1,
-          \})
+    call vimtex#process#run('bibtex -terse ' . tmp.aux, {'null' : 1})
 
     " Parse temporary bbl file
     let lines = map(readfile(tmp.bbl), 's:tex2unicode(v:val)')

--- a/autoload/vimtex/process.vim
+++ b/autoload/vimtex/process.vim
@@ -33,13 +33,12 @@ endfunction
 
 let s:process = {
       \ 'cmd' : '',
+      \ 'workdir' : '',
       \ 'pid' : 0,
-      \ 'background' : 1,
       \ 'continuous' : 0,
+      \ 'background' : 1,
       \ 'silent' : 1,
       \ 'null' : 0,
-      \ 'workdir' : '',
-      \ 'use_system' : 0,
       \}
 
 function! s:process.run() abort dict " {{{1
@@ -67,24 +66,14 @@ function! s:process.run() abort dict " {{{1
   endif
 
   " Run the command
-  if self.use_system
-    if self.silent && self.background
+  if self.background
+    if self.silent
       silent call system(self.cmd)
     else
       call system(self.cmd)
     endif
   else
-    if self.silent && self.background
-      silent execute '!' . self.cmd
-    else
-      execute '!' . self.cmd
-    endif
-
-    if self.silent || self.background
-      if !has('gui_running')
-        redraw!
-      endif
-    endif
+    execute '!' . self.cmd
   endif
 
   " Capture the pid if relevant

--- a/autoload/vimtex/process.vim
+++ b/autoload/vimtex/process.vim
@@ -37,7 +37,6 @@ let s:process = {
       \ 'pid' : 0,
       \ 'continuous' : 0,
       \ 'background' : 1,
-      \ 'silent' : 1,
       \ 'null' : 0,
       \}
 
@@ -67,11 +66,7 @@ function! s:process.run() abort dict " {{{1
 
   " Run the command
   if self.background
-    if self.silent
-      silent call system(self.cmd)
-    else
-      call system(self.cmd)
-    endif
+    call system(self.cmd)
   else
     execute '!' . self.cmd
   endif
@@ -194,7 +189,6 @@ function! s:process.pprint_items() abort dict " {{{1
   call add(l:list, ['configuration', {
         \ 'background': self.background,
         \ 'continuous': self.continuous,
-        \ 'silent': self.silent,
         \ 'null': self.null,
         \}])
 


### PR DESCRIPTION
Cf. #651. This changes the process.vim interface so that it uses `system()` by default. The only time that `:!` is used is when one wants a process to run in the foreground (i.e. if the option `background = 0`).

This also provides some minor fixes to other process related stuff and to the compiler layer.