### PR TITLE
Preserve root dir when changing to local file

### DIFF
--- a/autoload/vimtex/state.vim
+++ b/autoload/vimtex/state.vim
@@ -63,6 +63,12 @@ function! vimtex#state#toggle_main() " {{{1
           \ : b:vimtex_local.main_id
     let b:vimtex = vimtex#state#get(b:vimtex_id)
 
+    " Reset the root dir to dir from main file
+    let b:vimtex.root = vimtex#state#get(b:vimtex_local.main_id).root
+    " Get the active file realtive to the root dir
+	" (only working when the tex-root dir is the same as the vim cwd)
+    let b:vimtex.base = fnamemodify(b:vimtex.tex,':p:.')
+
     call vimtex#echo#status(['vimtex: ',
           \ ['Normal', 'Changed to `'],
           \ ['VimtexSuccess', b:vimtex.base],


### PR DESCRIPTION
Dear lervag
I had the same problem as in #630 that i have multiple files in subdirs. I tried your patch #742. Unfortunately this wasn't working as aspect. So I wrote a small workaround. 

My problem: I never wrote something in vimscript before. So I don't know how to compare two strings to get the file path relative to the tex root dir. The workaround is only working in the case where you can switch the cwd from vim to the project folder.

I hope it will help you to solve this problem.