### PR TITLE
Add Denite support.

### DIFF
--- a/rplugin/python3/denite/source/labels.py
+++ b/rplugin/python3/denite/source/labels.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from .base import Base
+
+
+class Source(Base):
+
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'vimtex_labels'
+        self.kind = 'file'
+
+    @staticmethod
+    def create_candidate(e):
+        return {'word': e['title'],
+                'abbr': e['title'][:60],
+                'action__path': e['file'],
+                'action__line': e.get('line', 0)}
+
+    def gather_candidates(self, context):
+        entries = self.vim.eval('vimtex#labels#get_entries()')
+        return [Source.create_candidate(e) for e in entries]

--- a/rplugin/python3/denite/source/toc.py
+++ b/rplugin/python3/denite/source/toc.py
@@ -13,7 +13,7 @@ class Source(Base):
 
     @staticmethod
     def format_number(n):
-        if not n or n['frontmatter'] or n['backmatter']:
+        if not n or not type(n) is dict or n['frontmatter'] or n['backmatter']:
             return ''
 
         num = [str(n[k]) for k in [
@@ -32,7 +32,7 @@ class Source(Base):
 
     @staticmethod
     def create_candidate(e, depth):
-        indent = (' ' * 2*(depth - e['level']) + e['title'])[:60]
+        indent = (' ' * 2*(int(depth) - int(e['level'])) + e['title'])[:60]
         number = Source.format_number(e['number'])
         abbr = '{:65}{:10}'.format(indent, number)
         return {'word': e['title'],
@@ -42,5 +42,5 @@ class Source(Base):
 
     def gather_candidates(self, context):
         entries = self.vim.eval('vimtex#toc#get_entries()')
-        depth = max([e['level'] for e in entries])
+        depth = max([int(e['level']) for e in entries])
         return [Source.create_candidate(e, depth) for e in entries]

--- a/rplugin/python3/denite/source/toc.py
+++ b/rplugin/python3/denite/source/toc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from .base import Base
+
+
+class Source(Base):
+
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'vimtex_toc'
+        self.kind = 'file'
+
+    @staticmethod
+    def format_number(n):
+        if not n or n['frontmatter'] or n['backmatter']:
+            return ''
+
+        num = [str(n[k]) for k in [
+               'part',
+               'chapter',
+               'section',
+               'subsection',
+               'subsubsection',
+               'subsubsubsection'] if n[k] is not 0]
+
+        if n['appendix']:
+            num[0] = chr(int(num[0]) + 64)
+
+        fnum = '.'.join(num)
+        return fnum
+
+    @staticmethod
+    def create_candidate(e, depth):
+        indent = (' ' * 2*(depth - e['level']) + e['title'])[:60]
+        number = Source.format_number(e['number'])
+        abbr = '{:65}{:10}'.format(indent, number)
+        return {'word': e['title'],
+                'abbr': abbr,
+                'action__path': e['file'],
+                'action__line': e.get('line', 0)}
+
+    def gather_candidates(self, context):
+        entries = self.vim.eval('vimtex#toc#get_entries()')
+        depth = max([e['level'] for e in entries])
+        return [Source.create_candidate(e, depth) for e in entries]


### PR DESCRIPTION
The active development on unite.vim has stopped. I know you can use unite.vim sources in Denite, but it requires you to have unite.vim installed. I thought it would be cool to have the vimtex sources available without this requirement.
This was tested on Linux/neovim 0.1.7.