### PR TITLE
Set did_indent flag only if enabled

### DIFF
--- a/indent/bib.vim
+++ b/indent/bib.vim
@@ -7,9 +7,10 @@
 if exists('b:did_indent')
   finish
 endif
-let b:did_indent = 1
 
 if !get(g:, 'vimtex_indent_bib_enabled', 1) | finish | endif
+
+let b:did_indent = 1
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -7,10 +7,11 @@
 if exists('b:did_indent')
   finish
 endif
-let b:did_indent = 1
-let b:did_vimtex_indent = 1
 
 if !get(g:, 'vimtex_indent_enabled', 1) | finish | endif
+
+let b:did_vimtex_indent = 1
+let b:did_indent = 1
 
 let s:cpo_save = &cpoptions
 set cpoptions&vim


### PR DESCRIPTION
Otherwise there is no way to have vimtex installed and use the built-in
indentexpr because did_indent would be set to 1 eventhough no indentexpr
was actually set