### PR TITLE
Improved index, toc and labels (solves #782)

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -165,6 +165,7 @@ function! s:init_options() " {{{1
   call s:init_option('vimtex_motion_enabled', 1)
 
   call s:init_option('vimtex_labels_enabled', 1)
+  call s:init_option('vimtex_labels_refresh_always', 1)
 
   call s:init_option('vimtex_quickfix_method', 'latexlog')
   call s:init_option('vimtex_quickfix_autojump', '0')

--- a/autoload/vimtex/index.vim
+++ b/autoload/vimtex/index.vim
@@ -83,7 +83,6 @@ function! s:index.create() abort dict " {{{1
 
   if has_key(self, 'hook_init_post')
     call self.hook_init_post()
-    unlet self.hook_init_post
   endif
 endfunction
 

--- a/autoload/vimtex/state.vim
+++ b/autoload/vimtex/state.vim
@@ -27,6 +27,7 @@ function! vimtex#state#init() " {{{1
     call vimtex#compiler#init_state(b:vimtex)
     call vimtex#qf#init_state(b:vimtex)
     call vimtex#toc#init_state(b:vimtex)
+    call vimtex#labels#init_state(b:vimtex)
   endif
 endfunction
 
@@ -53,6 +54,7 @@ function! vimtex#state#init_local() " {{{1
     call vimtex#compiler#init_state(l:vimtex)
     call vimtex#qf#init_state(l:vimtex)
     call vimtex#toc#init_state(l:vimtex)
+    call vimtex#labels#init_state(l:vimtex)
   endif
 
   let b:vimtex_local = {
@@ -166,7 +168,7 @@ function! s:get_main() " {{{1
     if l:id >= 0
       return s:vimtex_states[l:id].tex
     else
-      let s:disabled_modules = ['latexmk', 'view', 'toc']
+      let s:disabled_modules = ['latexmk', 'view', 'toc', 'labels']
       return expand('%:p')
     endif
   endif

--- a/autoload/vimtex/state.vim
+++ b/autoload/vimtex/state.vim
@@ -26,6 +26,7 @@ function! vimtex#state#init() " {{{1
     call vimtex#view#init_state(b:vimtex)
     call vimtex#compiler#init_state(b:vimtex)
     call vimtex#qf#init_state(b:vimtex)
+    call vimtex#toc#init_state(b:vimtex)
   endif
 endfunction
 
@@ -51,6 +52,7 @@ function! vimtex#state#init_local() " {{{1
     call vimtex#view#init_state(l:vimtex)
     call vimtex#compiler#init_state(l:vimtex)
     call vimtex#qf#init_state(l:vimtex)
+    call vimtex#toc#init_state(l:vimtex)
   endif
 
   let b:vimtex_local = {
@@ -164,7 +166,7 @@ function! s:get_main() " {{{1
     if l:id >= 0
       return s:vimtex_states[l:id].tex
     else
-      let s:disabled_modules = ['latexmk', 'view']
+      let s:disabled_modules = ['latexmk', 'view', 'toc']
       return expand('%:p')
     endif
   endif

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1145,6 +1145,18 @@ Options~
   Set to 0 to manually refresh ToC entries. This may be useful for very large
   projects where generating the ToC entries becomes slow.
 
+  It may be useful to combine manually refreshing with a |BufWritePost|
+  autocommand, e.g.: >
+
+    augroup vimtex
+      autocmd!
+      autocmd BufWritePost *.tex call vimtex#toc#refresh()
+    augroup END
+<
+  Or, if preferred, one may use a mapping such as: >
+
+    nnoremap <silent> <localleader>lf :call vimtex#toc#refresh()
+<
   Default value: 1
 
 *g:vimtex_toc_secnumdepth*

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -966,6 +966,24 @@ Options~
 
   Default value: 1
 
+*g:vimtex_labels_refresh_always*
+  Set to 0 to manually refresh entries in the table of labels. This may be
+  useful for very large projects where generating the entries becomes slow.
+
+  It may be useful to combine manually refreshing with a |BufWritePost|
+  autocommand, e.g.: >
+
+    augroup vimtex
+      autocmd!
+      autocmd BufWritePost *.tex call vimtex#labels#refresh()
+    augroup END
+<
+  Or, if preferred, one may use a mapping such as: >
+
+    nnoremap <silent> <localleader>lf :call vimtex#labels#refresh()
+<
+  Default value: 1
+
 *g:vimtex_quickfix_method*
   This option sets the quickfix method. The following methods are available:
 

--- a/test/issues/782/main.tex
+++ b/test/issues/782/main.tex
@@ -1,0 +1,11 @@
+\documentclass{book}
+\input{preamble}
+
+\begin{document}
+
+\input{sections}
+
+\section{Test 3}
+\label{sec:3}
+
+\end{document}

--- a/test/issues/782/minivimrc
+++ b/test/issues/782/minivimrc
@@ -1,0 +1,19 @@
+set nocompatible
+let &rtp  = '~/.vim/bundle/vimtex,' . &rtp
+let &rtp .= ',~/.vim/bundle/vimtex/after'
+filetype plugin indent on
+syntax enable
+
+let g:tex_flavor = 'latex'
+
+let g:vimtex_toc_refresh_always = 0
+let g:vimtex_labels_refresh_always = 0
+
+set hidden
+let g:vimtex_index_split_pos = 'full'
+
+augroup vimtex
+  autocmd!
+  autocmd BufWritePost *.tex call vimtex#toc#refresh()
+  autocmd BufWritePost *.tex call vimtex#labels#refresh()
+augroup END

--- a/test/issues/782/preamble.tex
+++ b/test/issues/782/preamble.tex
@@ -1,0 +1,3 @@
+% Commands
+\usepackage{color}
+\usepackage{hyperref}

--- a/test/issues/782/sections.tex
+++ b/test/issues/782/sections.tex
@@ -1,0 +1,15 @@
+\section{Test 1}
+\label{sec:1}
+
+Hello world
+
+\begin{equation}
+  f(x) = 1
+  \label{eq:1}
+\end{equation}
+
+\section{Test 2}
+\label{sec:2}
+
+Hello moon
+


### PR DESCRIPTION
This PR adds possibility of caching ToC and table of labels entries and doing manual updates of the entries, thus solving #782. At the same time, it improves the `index.vim` implementation and makes the code more robust and better structured.