### PR TITLE
pplatex-based logfile parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ disabled if desired.
 - Document compilation with
   [latexmk](http://users.phys.psu.edu/~collins/software/latexmk-jcc/) or
   [latexrun](https://github.com/aclements/latexrun)
+- LaTeX log parsing for quickfix entries using
+  - internal method
+  - [pplatex](https://github.com/stefanhepp/pplatex)
 - Compilation of selected part of document
 - Support for several PDF viewers with forward search
   - [MuPDF](http://www.mupdf.com/)

--- a/autoload/vimtex/qf/pplatex.vim
+++ b/autoload/vimtex/qf/pplatex.vim
@@ -1,0 +1,76 @@
+" vimtex - LaTeX plugin for Vim
+"
+" Maintainer:   Karl Yngve Lervåg
+" Email:        karl.yngve@gmail.com
+" Initial work: Johannes Wienke
+" Email:        languitar@semipol.de
+"
+
+function! vimtex#qf#pplatex#new() " {{{1
+  return deepcopy(s:qf)
+endfunction
+
+" }}}1
+
+
+let s:qf = {
+      \ 'name' : 'LaTeX logfile using pplatex',
+      \}
+
+function! s:qf.init() abort dict "{{{1
+  " Each new item starts with two asterics followed by the file,
+  " potentially a line number and sometimes even the message itself is on the
+  " same line. Please note that the trailing whitspaces in the error formats
+  " are intentional as pplatex produces these.
+
+  " Start of new items with file and line number, message on next line(s).
+  setlocal errorformat=%E**\ Error\ \ \ in\ %f\\,\ Line\ %l:\ 
+  setlocal errorformat+=%W**\ Warning\ in\ %f\\,\ Line\ %l:\ 
+  setlocal errorformat+=%I**\ BadBox\ \ in\ %f\\,\ Line\ %l:\ 
+
+  " Start of new items with only a file.
+  setlocal errorformat+=%E**\ Error\ \ \ in\ %f:\ 
+  setlocal errorformat+=%W**\ Warning\ in\ %f:\ 
+  setlocal errorformat+=%I**\ BadBox\ \ in\ %f:\ 
+
+  " Start of items with with file and message on the same line. There are
+  " no BadBoxes reported this way.
+  setlocal errorformat+=**\ Error\ in\ %f:\ %m
+  setlocal errorformat+=**\ Warning\ in\ %f:\ %m
+
+  " Anything that starts with three spaces is part of the message from a
+  " previously started multiline error item.
+  setlocal errorformat+=%C\ \ \ %m
+
+  " Items are terminated with two newlines.
+  setlocal errorformat+=%-Z
+
+  " Skip statistical results at the bottom of the output.
+  setlocal errorformat+=%-GResult%.%#
+  setlocal errorformat+=%-G
+endfunction
+
+function! s:qf.setqflist(base, jump) abort dict "{{{1
+  if empty(a:base)
+    let l:log = b:vimtex.log()
+  else
+    let l:log = fnamemodify(a:base, ':r') . '.log'
+  endif
+
+  if empty(l:log)
+    call setqflist([])
+    throw 'Vimtex: No log file found'
+  endif
+
+  execute "setlocal" "makeprg=pplatex\\ -i\\ " . l:log
+
+  if a:jump
+    silent make l:log %:S
+  else
+    silent make! l:log %:S
+  endif
+endfunction
+
+" }}}1
+
+" vim: fdm=marker sw=2

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -93,6 +93,9 @@ Feature overview~
                                                               *vimtex-features*
 
 - Document compilation with `latexmk` or `latexrun`
+- LaTeX log parsing for quickfix entries using
+  - internal method
+  - `pplatex`
 - Compilation of selected part of document
 - Support for several PDF viewers with forward search
   - `MuPDF`
@@ -990,6 +993,16 @@ Options~
   latexlog~
     This is the standard method which parses the normal LaTeX output. See
     |g:vimtex_quickfix_latexlog| for configuration.
+
+  pplatex~
+    Uses `pplatex` to parse the LaTeX output file. `pplatex` is a command line
+    utility used to pretify the output of the LaTeX compiler. It is available
+    at:
+    https://github.com/stefanhepp/pplatex
+
+    `pplatex` requires that
+    `-file-line-error` is NOT passed to the LaTeX compiler. Adapt
+    |g:vimtex_compiler_latexmk| as necessary.
 
   lacheck~
     This is a simple method that uses `lacheck` to parse the TeX file for


### PR DESCRIPTION
This PR adds support for using `pplatex` to parse log files, which is more stable in detecting the real source file in multi-file documents in my cases.

`pplatex` requires that `-file-line-error` is NOT passed to the LaTeX compiler. Otherwise, errors are missed. I have documented this, but maybe there is a more automatic way to set this?

I have tested this with a recent git version of pplatex. One thing that remains is that I am unable to ignore the last few empty lines in the generated output using `errorformat`. Maybe someone who has more knowledge of this can have a look at what I have done wrong with the patterns?