### PR TITLE
Folding 'single': allow optional arguments of cmd

### DIFF
--- a/autoload/vimtex/fold.vim
+++ b/autoload/vimtex/fold.vim
@@ -295,7 +295,7 @@ endfunction
 " }}}1
 
 function! s:cmd_single(cmds) " {{{1
-  let l:re = '\v^\s*\\%(' . join(a:cmds, '|') . ')\*?'
+  let l:re = '\v^\s*\\%(' . join(a:cmds, '|') . ')\*?\s*%(\[.*\])?'
 
   let l:fold = {}
   let l:fold.re = {


### PR DESCRIPTION
```tex
\pgfplotstableread[col sep=semicolon,trim cells]{
x    ; y    ; z   ; type  ;
0.01 ; 1.00 ; nan ; type1 ;
0.02 ; 2.00 ; nan ; type2 ;
0.03 ; 3.00 ; nan ; type3 ;
}
\datatable
```

folds to
```tex
\pgfplotstableread[col sep=semicolon,trim cells]{...}---------------------------------------
\datatable
```