### PR TITLE
Recursive exploration fix

### DIFF
--- a/autoload/vimtex/parser.vim
+++ b/autoload/vimtex/parser.vim
@@ -192,7 +192,7 @@ function! s:parser.input_line_parser_tex(line, file, re) abort dict " {{{1
   let l:subimport = 0
   if l:file =~# '\v\\%(sub)?%(import|%(input|include)from)'
     let l:candidate = self.input_parser(
-          \ substitute(l:file, '\\\w*\s*{[^{}]*}\s*', '', ''),
+          \ substitute(l:file, '\\\w*\s*\({[^{}]*}\)\s*', '\1', ''),
           \ a:file, '\v^\s*\{')
     if !empty(l:candidate) | return l:candidate | endif
 


### PR DESCRIPTION
Vimtex discarded the first part of the subimport command, which wont do
for recursive searching. For the project i'm working on that meant we
ran into an infinite loop when you have recursive subimporting