### PR TITLE
Improve shellescape to handle apostrophes in paths

### DIFF
--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -32,7 +32,7 @@ function! vimtex#util#shellescape(cmd) " {{{1
     let &shellslash = l:shellslash
     return l:cmd
   else
-    return shellescape(a:cmd)
+    return escape(shellescape(a:cmd), '\')
   endif
 endfunction
 


### PR DESCRIPTION
I was working in a directory tree on Ubuntu that happened to have an apostrophe somewhere in its path, i.e., ```/why/would/anyone's/folders/be/named/thus.tex```. vimtex failed to open the resulting pdf, so I dug a little and found that after all the shellescapes and substitutions, the viewer call looked something like
```
xdg-open '/why/would/anyone'''s/folders/be/named/thus.pdf'
```
It seems like the bad things are happening on line 57 in ```autoload/vimtex/view/general.vim``` (and probably similar lines for the other viewers):
```vim
let l:cmd = substitute(l:cmd, '@pdf', vimtex#util#shellescape(outfile), 'g')
```
Actually, the output of ```vimtex#util#shellescape(outfile)``` looks OK, however the requisite escape character is removed by the outer call to ```substitute```.

The solution I've implemented here is to explicitly escape the escape character in ```shellescape```, like you're already doing on win32 systems. I haven't thought deeply about potential gotchas with this workaround, or done any tests except on this particular document, but since you're already doing this on Windows I figured it might not be too bad.

Btw., I've since repented and renamed my directories in a less pathological fashion, so I don't depend on this fix myself. But in case you'd like to support these edge cases, seeing as such paths are after all valid, here's a possible fix.