### PR TITLE
Improve package detection

### DIFF
--- a/autoload/vimtex/parser.vim
+++ b/autoload/vimtex/parser.vim
@@ -21,6 +21,19 @@ function! vimtex#parser#aux(file, ...) " {{{1
 endfunction
 
 " }}}1
+function! vimtex#parser#fls(file, ...) " {{{1
+  let l:options = a:0 > 0 ? a:1 : {}
+  call extend(l:options, {
+        \ 'detailed' : 0,
+        \ 'type' : 'fls',
+        \ 'input_re_fls' : 'nomatch^',
+        \}, 'keep')
+
+  let l:parser = s:parser.new(l:options)
+  return l:parser.parse(a:file)
+endfunction
+
+" }}}1
 function! vimtex#parser#get_externalfiles() " {{{1
   let l:preamble = vimtex#parser#tex(b:vimtex.tex, {
         \ 're_stop' : '\\begin{document}',


### PR DESCRIPTION
Package detection is currently deficient as it cannot handle lists such as
`\usepackage{one, two}`, or even multiple `\usepackage` statements on a
single line such as `\usepackage{one}\usepackage{two}`.  A more complex
regular expression is provided to allow packages to be detected in a
greater number of instances.

`vimtex` also does not currently recognize packages required by other
packages.  In principle, `vimtex`'s recursive parsing capability could be
used to detect such packages.  However, in this PR suggests a more robust
method, to detect the presence of an `fls` file, and simply use the `.sty` 
files listed there as the correct package list.

This PR changes package detection in two ways;

 - If an `fls` file exists (e.g., created by `latexmk`), it is parsed to 
      obtain a list of packages.  In this case, the packages found by 
      parsing the preamble will be ignored.
 - Preamble parsing is improved to handle multiple packages on one line

Additionally, this PR will also

 - Add documentclass to vimtex info
 - Add fls filename to vimtex info

Further known deficiencies:

 - The preamble package parsing does not recognize `\usepackage` spread
    over multiple lines, e.g.,
```      
   \usepackage[option1,
            option2]{package}
```
   I don't know how to get around this in the current parsing framework 
 - does not recognize hidden code in `\begin{comment}` or `\if` statements.  This is probably not worth the effort.

