### PR TITLE
Bug in `s:qf_is_open()` fixed

### DIFF
--- a/autoload/vimtex/qf.vim
+++ b/autoload/vimtex/qf.vim
@@ -119,9 +119,9 @@ function! s:qf_is_open() abort " {{{1
   silent! ls!
   redir END
 
-  call filter(l:buflist, 'v:val =~# ''Quickfix''')
+  let l:buflist = filter(split(l:buflist, '\n'), 'v:val =~# ''Quickfix''')
 
-  for l:line in split(l:buflist, '\n')
+  for l:line in l:buflist
     let l:bufnr = str2nr(matchstr(l:line, '^\s*\zs\d\+'))
     if bufwinnr(l:bufnr) >= 0
           \ && getbufvar(l:bufnr, '&buftype', '') ==# 'quickfix'


### PR DESCRIPTION
The `filter()` function accepts a List or Dictionary as the first
argument, so `l:buflist` has to be first transformed into a list by
means of `split()` and then can be passed to `filter()`. (Btw, the former
is executed "in situ" in the latter.)