### PR TITLE
Ensure that glossaries files are parsed

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -564,7 +564,7 @@ function! s:completer_gls.parse_glossaries() dict " {{{2
 
   for l:line in filter(vimtex#parser#tex(b:vimtex.tex, {
         \   'detailed' : 0,
-        \   'input_re' : g:vimtex#re#tex_input . '|^\s*\\loadglsentries',
+        \   'input_re_tex' : g:vimtex#re#tex_input . '|^\s*\\loadglsentries',
         \ }), 'v:val =~# ''\\newglossaryentry''')
     let l:entries = matchstr(l:line, '\\newglossaryentry\s*{\zs[^{}]*')
     call add(self.candidates, {


### PR DESCRIPTION
Specifying `input_re` directly for a parser does not work as `parser.new` will replace the regex with `input_re + parser_type`. As this parser is of type `tex`, the completion file needs to specify `input_re_tex` with the extended input patterns for `loadglsentries`.

This would fix #883. However, maybe the logic in `parser.new` is wrong itself.