### PR TITLE
Keep cursor in the LaTeX window when opening quickfix with g:vimtex_quickfix_mode=2

### DIFF
--- a/autoload/vimtex/qf.vim
+++ b/autoload/vimtex/qf.vim
@@ -38,6 +38,7 @@ function! vimtex#qf#open(force) abort " {{{1
   if !exists('b:vimtex.qf.setqflist') | return | endif
   cclose
 
+  call s:window_save()
   try
     call b:vimtex.qf.setqflist('', g:vimtex_quickfix_autojump)
   catch /Vimtex: No log file found/
@@ -66,7 +67,6 @@ function! vimtex#qf#open(force) abort " {{{1
         \     && (s:qf_has_errors() || g:vimtex_quickfix_open_on_warning))
 
   if l:do_open
-    call s:window_save()
     botright cwindow
     if g:vimtex_quickfix_mode == 2
       call s:window_restore()

--- a/autoload/vimtex/qf/latexlog.vim
+++ b/autoload/vimtex/qf/latexlog.vim
@@ -144,6 +144,7 @@ function! s:qf.setqflist(base, jump) abort dict "{{{1
   "
   if self.config.fix_paths
     let s:main = l:tex
+    let s:root = b:vimtex.root
     let s:title = 'Vimtex errors (' . self.name . ')'
     augroup vimtex_qf_tmp
       autocmd!
@@ -192,7 +193,7 @@ function! s:fix_paths() abort " {{{1
     " The buffer names of all file:line type errors are relative to the root of
     " the main LaTeX file.
     let l:file = fnamemodify(
-          \ simplify(b:vimtex.root . '/' . bufname(l:qf.bufnr)), ':.')
+          \ simplify(s:root . '/' . bufname(l:qf.bufnr)), ':.')
     if !filereadable(l:file) | continue | endif
     if !bufexists(l:file)
       execute 'badd' l:file


### PR DESCRIPTION
Hi,

I noticed that vimtex did not honour the `g:vimtex_quickfix_mode=2` option, in the sense that the cursor would jump to the quickfix window as soon as compilation finished (in continuous mode). This was quite annoying as it broke my workflow. I had a look at the code and I discovered (I think) two minor bugs:

1. The `s:fix_paths()` function cannot access `b:vimtex.root` because, by the time it is called, vim has already switched to the quickfix buffer and `b:vimtex` is not defined;
2. For the same reason, the `s:window_save()` function is being called too late.

This pull request fixes the bugs above and restores the expected behaviour of `g:vimtex_quickfix_mode=2`. Please let me know if you think this makes sense. Perhaps I should have opened an issue first?

Davide