### PR TITLE
Add call in compiler callback to parse fls on compilation

### DIFF
--- a/autoload/vimtex/compiler.vim
+++ b/autoload/vimtex/compiler.vim
@@ -73,6 +73,10 @@ function! vimtex#compiler#callback(status) abort " {{{1
   call vimtex#echo#status(['compiler: ',
         \ a:status ? ['VimtexSuccess', 'success'] : ['VimtexWarning', 'fail']])
 
+  if a:status
+    call b:vimtex.parse_packages_from_fls()
+  endif
+
   for l:hook in g:vimtex_compiler_callback_hooks
     execute 'call' l:hook . '(' . a:status . ')'
   endfor

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -36,6 +36,7 @@ CONTENTS                                                      *vimtex-contents*
     Support for multi-file projects             |vimtex-multi-file|
     Comment on internal tex plugin              |vimtex-comment-internal|
     Support for TeX specifiers                  |vimtex-tex-directives|
+    Package detection                           |vimtex-package-detection|
   Usage                                         |vimtex-usage|
     Default mappings                            |vimtex-default-mappings|
     Options                                     |vimtex-options|
@@ -164,7 +165,7 @@ provided by vimtex, but that are instead provided by other plugins.
       `neomake`     https://github.com/neomake/neomake
       `syntastic`   https://github.com/vim-syntastic/syntastic
 
-    All of the above plugins supoorts `lacheck` [0], `chktex` [1], `proselint` [2].
+    All of the above plugins support `lacheck` [0], `chktex` [1], `proselint` [2].
     `neomake` also supports `rubberinfo` [3].
 
     [0]: https://www.ctan.org/pkg/lacheck
@@ -218,7 +219,7 @@ The following is a list of specific requirements for the key features of
     latexmk page.]  For more info, see |vimtex-latexmk|.
       `latexrun` is similar to `latexmk` in that it runs the desired LaTeX
     engine an appropriate number of times, including `bibtex`/`biber`.
-    However, it differes in philosophy in that it only does the build part. It
+    However, it differs in philosophy in that it only does the build part. It
     does not support continuous builds, nor automatic starting of the viewer.
     However, it does parse the output log in order to provide a more concise
     list of relevant warnings and error messages (this has currently not been
@@ -364,11 +365,39 @@ Here `program` may be one of the following: >
   context (luatex)
   context (xetex)
 
-The implementation was inspired by @andymass [1]. See also [2].
+See also [0,1].
 
-[0]: http://tex.stackexchange.com/q/78101/34697
-[1]: https://gist.github.com/andymass/ea7e381d51387e205f44c0c43aca7225
-[2]: https://github.com/lervag/vimtex/issues/713
+[0]: https://tex.stackexchange.com/q/78101/34697
+[1]: https://github.com/lervag/vimtex/issues/713
+
+------------------------------------------------------------------------------
+Package detection~
+                                                     *vimtex-package-detection*
+
+vimtex maintains a list of latex packages required by the current project in
+order to determine which commands to suggest during command completion (see
+|vimtex-complete-commands|) and which packages to look up documentation for
+(see |vimtex-doc-package|). The list can be viewed with |:VimtexInfo|.
+
+The package list is determined in two ways: >
+
+1. If a `.fls` file exists having the name of the main file, it is scanned.
+   This file is created by the tex program (e.g., pdflatex) during compilation
+   and might not be supported by all tex programs.  Parsing the `.fls` file is
+   done both at vimtex initialization and after each successful compilation,
+   if supported (see Note below)
+
+   Note: If you are using single shot compilation with background compilation
+         and the process backend (see *g:vimtex_compiler_latexrun* and
+         *g:vimtex_compiler_latexmk* for an explanation of these options),
+         the `.fls` will not be parsed after each compilation
+
+2. Otherwise, the preamble and files included in the preamble are parsed for
+   `\usepackage` statements. This is slower and less accurate than `.fls` file
+   parsing. Therefore, it is only done during vimtex initialization.  If
+   desired one may manually reload vimtex in order to parse the preamble again
+   during an editing session. See |VimtexReload| and |<plug>(vimtex-reload)|
+   (by default mapped to `<localleader>lx`).
 
 ==============================================================================
 USAGE                                                            *vimtex-usage*
@@ -522,7 +551,7 @@ Options~
 
 *g:vimtex_compiler_latexmk*
   This is a dictionary that allows customization of the |vimtex-latexmk|
-  compiler. The values set by the user will take precedense over the default
+  compiler. The values set by the user will take precedence over the default
   values.
 
   Default value: >
@@ -554,7 +583,7 @@ Options~
       `jobs`     Uses |job| to control the processes. This is available on
                modern Vim installations. Note that this will start every job
                in the background, regardless of the value of the `background`
-               key. The output may be viewed through |VimtexOutput|.
+               key. The output may be viewed through |VimtexCompileOutput|.
       `nvim`     This uses the neovim |job-control| system to control the
                compiler process. It is very similar to the `jobs` backend.
 
@@ -1673,9 +1702,9 @@ Commands~
 
                           Note: This always works linewise!
 
-                                             *VimtexOutput*
+                                             *VimtexCompileOutput*
                                              *<plug>(vimtex-compile-output)*
-:VimtexOutput             Open file where compiler output is redirected.
+:VimtexCompileOutput      Open file where compiler output is redirected.
 
                                              *VimtexStop*
                                              *<plug>(vimtex-stop)*
@@ -2091,7 +2120,7 @@ listing.
 Complete file names for figures~
                                                        *vimtex-complete-images*
 
-File name completion for figures is triggered by '\includegraphic{' commands.
+File name completion for figures is triggered by '\includegraphics{' commands.
 
 By default, the paths are completed relative to the root path of the main
 file. One can use the option |g:vimtex_complete_img_use_tail| to instead
@@ -2450,7 +2479,7 @@ Associated commands:
     |VimtexCompileSS|
     |VimtexCompileSS!|
     |VimtexCompileSelected|
-    |VimtexOutput|
+    |VimtexCompileOutput|
     |VimtexStatus|
     |VimtexStatus!|
     |VimtexStop|
@@ -2637,7 +2666,7 @@ LaTeX. One should also know about the Comprehensive TeX Archive Network, or
 CTAN [1], which is the central place for all kinds of material around TeX.
 
 [0]: https://en.wikibooks.org/wiki/LaTeX
-[1]: http://ctan.org/
+[1]: https://ctan.org/
 
 ------------------------------------------------------------------------------
 Offline~


### PR DESCRIPTION
This simple change causes vimtex to attempt to parse the fls file (if it exists) after each compilation, which updates the package list.  Cf. #863.  Note, I do not check to see if compilation was successful because this matches the behavior of opening a project that has an fls file.  I think the performance impact should be small because matching on the fls file is simple (unlike preamble parsing).
