### PR TITLE
changed command to call texcount on windows

### DIFF
--- a/autoload/vimtex/misc.vim
+++ b/autoload/vimtex/misc.vim
@@ -46,6 +46,9 @@ function! vimtex#misc#wc(type, detailed, ...) abort range " {{{1
   " Run texcount, save output to lines variable
   let cmd  = 'cd ' . vimtex#util#shellescape(l:file.root)
   let cmd .= '; texcount -nosub -sum '
+  if has("win32")
+    let cmd .= '& texcount -nosub -sum '
+  endif
   let cmd .= a:0 > 0 ? '-letter ' : ''
   let cmd .= a:detailed > 0 ? '-inc ' : '-merge '
   let cmd .= vimtex#util#shellescape(l:file.base)


### PR DESCRIPTION
Issue:
- On issuing `VimtexCountWords`, I get "The system cannot find the path specified."
- `texcount` is in path and can be called via commandline as well as via `!texcount`
- issue persist with minimal `vimrc`.
- Windows 10 Pro x64, TeXLive 2017

Change:
- changed command separator (from ';' to '&') for windows to allow proper calling of texcount.