### PR TITLE
Add an ignorecase option for bib completion?

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -158,7 +158,11 @@ function! s:completer_bib.search(regexp) dict " {{{2
     let lines = split(substitute(join(lines, "\n"),
           \ '\n\n\@!\(\s\=\)\s*\|{\|}', '\1', 'g'), "\n")
 
-    for line in filter(lines, 'v:val =~ a:regexp')
+    let l:icopt = get(g:, 'vimtex_complete_bib_ignorecase', -1)
+    let l:oper = (l:icopt == 0 ? '=~#'
+             \ : (l:icopt == 1 ? '=~?' : '=~'))
+
+    for line in filter(lines, 'v:val '.l:oper.' a:regexp')
       let matches = matchlist(line,
             \ '^\(.*\)||\(.*\)||\(.*\)||\(.*\)||\(.*\)')
       if !empty(matches) && !empty(matches[1])

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -729,6 +729,14 @@ Options~
 
   Default value: 0
 
+*g:vimtex_complete_bib_ignorecase*
+  If this option is set to 1, vimtex will ignore case when completing
+  bibliography entries.  When set to 0, case will be matched.  If unset or set
+  to any other value, bibliography completion will be done according to the
+  user's 'ignorecase' option.
+
+  Default value: follows the 'ignorecase' option
+
 *g:vimtex_delim_list*
   A dictionary that defines the pairs of delimiters that are recognized by
   |vimtex| for various commands and functions. The dictionary contains 5 sub
@@ -2138,6 +2146,7 @@ Associated settings:
   |g:vimtex_complete_enabled|
   |g:vimtex_complete_close_braces|
   |g:vimtex_complete_recursive_bib|
+  |g:vimtex_complete_bib_ignorecase|
 
 ------------------------------------------------------------------------------
 Complete citations~


### PR DESCRIPTION
What do you think about allowing a setting for ignoring case while completing bibliography entries?  Default behavior (case is matched according to '&ignorecase') is preserved.