### PR TITLE
Improve indent alignment on ampersands

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -43,9 +43,13 @@ function! VimtexIndent(lnum) " {{{1
 
   " Align on ampersands
   if get(g:, 'vimtex_indent_on_ampersands', 1)
-        \ && l:line =~# '^\s*&'
-        \ && l:prev_line =~# '\\\@<!&.*'
-    return indent(a:lnum) + match(l:prev_line, '\\\@<!&') - stridx(l:line, '&')
+        \ && l:line =~# s:amper_align
+        \ && l:prev_line =~# s:ampersand
+    let l:indent_prev = strdisplaywidth(strpart(l:prev_line, 0,
+      \ match(l:prev_line, s:ampersand)))
+    let l:indent_cur = strdisplaywidth(strpart(l:line, 0,
+      \ match(l:line, s:ampersand)))
+    return max([indent(a:lnum) - l:indent_cur + l:indent_prev, 0])
   endif
 
   " Use previous indentation for comments
@@ -76,13 +80,16 @@ function! s:get_prev_line(lnum, ignore_amps) " {{{1
   while l:lnum != 0
         \ && (l:prev =~# '^\s*%'
         \     || s:is_verbatim(l:prev, l:lnum)
-        \     || a:ignore_amps && match(l:prev, '^\s*&') >= 0)
+        \     || a:ignore_amps && match(l:prev, s:amper_align) >= 0)
     let l:lnum = prevnonblank(l:lnum - 1)
     let l:prev = getline(l:lnum)
   endwhile
 
   return l:lnum
 endfunction
+
+let s:ampersand = g:vimtex#re#not_bslash . '\&'
+let s:amper_align = '^[ \t\\]*' . s:ampersand
 
 " }}}1
 function! s:is_verbatim(line, lnum) " {{{1


### PR DESCRIPTION
Cf. [comment](https://github.com/lervag/vimtex/issues/949#issuecomment-331747897) on issue #949.

The `indentexpr` does not correctly compute the ampersand position when `set noexpandtab`, because it uses `stridx()`.  Along the way to fixing this, I came up with another annoyance in the following example:

```tex
\documentclass{minimal}
\begin{document}
\begin{align}
      x&= (x+5)(x+2)
          \\ &= x^2 + 5x + 2x + 10      % will not align due to '\\ '
    \\&= x            % vimtex thinks this is an escaped &
\end{align}
\end{document}
```

I generally put `\\` before the `&` instead of at the end of the previous line because it allows one to delete equations more easily.

This PR aims to:
        - Compute offsets correctly when `noexpandtab` is set
        - Allow `\\&` to be aligned
        - Better checking for escaped & with backslashes

Future work: it would be nice if ampersands would align to multiple lines above, not just on the immediately previous line:

```tex
\begin{align}
      x&= (x+5)(x+2)
          + x^2 + 5x + 2x + 10
    \\&= x            % will not align
\end{align}
```



