### PR TITLE
update errorformat for blg files

### DIFF
--- a/autoload/vimtex/qf/bibtex.vim
+++ b/autoload/vimtex/qf/bibtex.vim
@@ -43,8 +43,8 @@ function! s:bibtex.prepare() abort " {{{1
 
   let self.errorformat_saved = &l:errorformat
 
-  setlocal errorformat=%+WRepeated\ entry---line\ %l\ of\ file\ %f
-  setlocal errorformat+=%+E%.%#---line\ %l\ of\ file\ %f
+  setlocal errorformat=%+E%.%#---line\ %l\ of\ file\ %f
+  setlocal errorformat+=%+EI\ found\ %.%#---while\ reading\ file\ %f
   setlocal errorformat+=%+WWarning--empty\ %.%#\ in\ %.%m
   setlocal errorformat+=%+WWarning--entry\ type\ for%m
   setlocal errorformat+=%-C--line\ %l\ of\ file\ %f


### PR DESCRIPTION
#964 

- `Repeated entry` should be an error.
- A new error is added. (no bibliographystyle)

```latex
\documentclass{article}

\begin{document}

\cite{bib}

%\bibliographystyle{plain}
\bibliography{ref}
\end{document}
```

```
@article{bib,
	author={a},
	title={t},
	journal={j},
	year={2017},
}
```