### PR TITLE
add todonotes package support to match \todo in toc

### DIFF
--- a/autoload/vimtex/toc.vim
+++ b/autoload/vimtex/toc.vim
@@ -66,6 +66,7 @@ function! s:toc.new() abort dict " {{{1
         \ g:vimtex#toc#matchers#titlepage,
         \ g:vimtex#toc#matchers#bibliography,
         \ g:vimtex#toc#matchers#todos,
+        \ g:vimtex#toc#matchers#todonotes,
         \]
   let l:toc.matchers += g:vimtex_toc_custom_matchers
 

--- a/autoload/vimtex/toc/matchers.vim
+++ b/autoload/vimtex/toc/matchers.vim
@@ -243,6 +243,21 @@ function! g:vimtex#toc#matchers#todos.get_entry(context) abort dict " {{{1
         \ }
 endfunction
 
+let g:vimtex#toc#matchers#todonotes = {
+      \ 're' : '\\todo\(\[.*\]\)\?{\zs.*\ze}',
+      \ 'in_preamble' : 0,
+      \}
+function! g:vimtex#toc#matchers#todonotes.get_entry(context) abort dict " {{{1
+  return {
+        \ 'title'  : printf('TODO: %s', matchstr(a:context.line, self.re)),
+        \ 'number' : deepcopy(a:context.level),
+        \ 'file'   : a:context.file,
+        \ 'line'   : a:context.lnum,
+        \ 'level'  : a:context.level.current,
+        \ 'todo'   : 1,
+        \ 'rank'   : a:context.lnum_total,
+        \ }
+endfunction
 " }}}1
 
 "


### PR DESCRIPTION
The [todonotes](https://ctan.org/pkg/todonotes) package provides handy commands to create todo's that also appear in the document as balloons in the page margin. This PR adds a matcher for the TOC that matches the `\todo{}` commands.