### PR TITLE
Completion: Autocompletion for acronyms defined through the glossaries package.

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -621,6 +621,8 @@ endfunction
 
 let s:completer_gls = {
       \ 'patterns' : ['\v\\(gls|Gls|GLS)(pl)?\s*\{[^}]*$'],
+      \ 'keywords' : ['newglossaryentry', 'longnewglossaryentry', 'newacronym', 
+                    \ 'newabbreviation', 'glsxtrnewsymbol'],
       \ 'candidates' : [],
       \}
 
@@ -636,9 +638,9 @@ function! s:completer_gls.parse_glossaries() dict " {{{2
   for l:line in filter(vimtex#parser#tex(b:vimtex.tex, {
         \   'detailed' : 0,
         \   'input_re' : g:vimtex#re#tex_input . '|^\s*\\loadglsentries',
-        \ }), 'v:val =~# ''\\\(newglossaryentry\|newacronym\)''')
+        \ }), 'v:val =~# ''\\\(' . join(self.keywords, '\|') . '\)''')
     let l:entries = matchstr(l:line,
-        \ '\\\(newglossaryentry\|newacronym\)\s*\(\[.*\]\)\=\s*{\zs[^{}]*')
+        \ '\\\(' . join(self.keywords, '\|') . '\)\s*\(\[.*\]\)\=\s*{\zs[^{}]*')
     call add(self.candidates, {
           \ 'word' : l:entries,
           \ 'abbr' : l:entries,

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -636,8 +636,9 @@ function! s:completer_gls.parse_glossaries() dict " {{{2
   for l:line in filter(vimtex#parser#tex(b:vimtex.tex, {
         \   'detailed' : 0,
         \   'input_re' : g:vimtex#re#tex_input . '|^\s*\\loadglsentries',
-        \ }), 'v:val =~# ''\\newglossaryentry''')
-    let l:entries = matchstr(l:line, '\\newglossaryentry\s*{\zs[^{}]*')
+        \ }), 'v:val =~# ''\\\(newglossaryentry\|newacronym\)''')
+    let l:entries = matchstr(l:line,
+        \ '\\\(newglossaryentry\|newacronym\)\s*\(\[.*\]\)\=\s*{\zs[^{}]*')
     call add(self.candidates, {
           \ 'word' : l:entries,
           \ 'abbr' : l:entries,


### PR DESCRIPTION
This change allows vimtex to parse completion candidates from acronym definitions like
`\newacronym{foo}{FOO}{foo is an acronym}`
as well as
`\newacronym[longplural={many FOOs}]{foo}{FOO}{foo is an acronym}`
in addition to normal glossary entries.
