### PR TITLE
Fix lcd/cd in last commit

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -811,8 +811,8 @@ function! s:load_candidates_from_packages(packages) " {{{1
   if empty(l:packages) | return | endif
 
   let l:save_pwd = getcwd()
-  let l:localdir = exists('*haslocaldir') ? haslocaldir() : 0
-  execute l:localdir ? 'cd' : 'lcd' fnameescape(s:complete_dir)
+  let l:localdir = exists('*haslocaldir') ? haslocaldir() : 1
+  execute l:localdir ? 'lcd' : 'cd' fnameescape(s:complete_dir)
 
   for l:unreadable in filter(copy(l:packages), '!filereadable(v:val)')
     let s:candidates_from_packages[l:unreadable] = {}
@@ -859,7 +859,7 @@ function! s:load_candidates_from_packages(packages) " {{{1
     let s:candidates_from_packages[l:package].environments += l:candidates
   endfor
 
-  execute l:localdir ? 'cd' : 'lcd' fnameescape(l:save_pwd)
+  execute l:localdir ? 'lcd' : 'cd' fnameescape(l:save_pwd)
 endfunction
 
 let s:candidates_from_packages = {}


### PR DESCRIPTION
Terribly sorry about this, and for catching it only after merge, but I realized I permuted lcd and cd in my PR 😞. The logic should be as follows:

- If *haslocaldir does not exist, assume `lcd` (as done prior to 80b96c1) 
- If window has a local dir, use `lcd`
- If window has no local dir use `cd`
