### PR TITLE
Extra quotes while preparing commands to run in windows

### DIFF
--- a/autoload/vimtex/process.vim
+++ b/autoload/vimtex/process.vim
@@ -159,7 +159,7 @@ if has('win32')
       let l:cmd = 'start /b "' . cmd . '"'
     endif
 
-    let self.prepared_cmd = l:cmd
+    let self.prepared_cmd = '"' . l:cmd . '"'
   endfunction
 
   " }}}1


### PR DESCRIPTION
Added extra quotes while preparing commands to run in windows. Fixes #1054.