### PR TITLE
Redraw vim after focusing in reverse_goto

### DIFF
--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -86,9 +86,12 @@ function! vimtex#view#reverse_goto(line, filename) " {{{1
   normal! zMzvzz
 
   if executable('pstree') && executable('xdotool')
-    let l:xwinids = reverse(split(system('pstree -s -p ' . getpid()), '\D\+'))
+    let l:pids = reverse(split(system('pstree -s -p ' . getpid()), '\D\+'))
 
-    call map(l:xwinids, "system('xdotool search --onlyvisible --pid ' . v:val)[:-2]")
+    let l:xwinids = []
+    call map(copy(l:pids), 'extend(l:xwinids, reverse(split('
+          \ . "system('xdotool search --onlyvisible --pid ' . v:val)"
+          \ . ')))')
     call filter(l:xwinids, '!empty(v:val)')
 
     if !empty(l:xwinids)

--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -93,6 +93,7 @@ function! vimtex#view#reverse_goto(line, filename) " {{{1
 
     if !empty(l:xwinids)
       call system('xdotool windowactivate ' . l:xwinids[0] . ' &')
+      call feedkeys("\<c-l>", 'tn')
     endif
   endif
 endfunction


### PR DESCRIPTION
I use the terminal emulator Konsole.  Since `reverse_goto` was re-written, backwards search from zathura does not update vim's visual file/scroll position, although the terminal is focused, the file is switched, and the real cursor position is moved correctly (just not visually).  I have to actually move the cursor to cause a redraw (I usually just do `jk`).  It's a very minor issue.

I realized recently that `<c-l>` always works properly to update the view.  So, I added a `feedkeys` after the `windowactivate`.  I suppose this is some weird Konsole-only quirk and that most terminals don't need this but it seems harmless in general.  Note `redraw`/`redraw!` do not work because the drawn cursor disappears completely.
