### PR TITLE
modified zathura startup behavior

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -240,6 +240,8 @@ function! s:init_options() " {{{1
   call s:init_option('vimtex_view_mupdf_options', '')
   call s:init_option('vimtex_view_mupdf_send_keys', '')
   call s:init_option('vimtex_view_zathura_options', '')
+  call s:init_option('vimtex_view_process_start', 1)
+  call s:init_option('vimtex_view_xwin_exists', 1)
 endfunction
 
 " }}}1

--- a/autoload/vimtex/view/common.vim
+++ b/autoload/vimtex/view/common.vim
@@ -116,7 +116,7 @@ function! s:xwin_template.xwin_get_id() dict " {{{1
   if self.xwin_id > 0 | return self.xwin_id | endif
 
   " Allow some time for the viewer to start properly
-  sleep 500m
+  sleep 50m
 
   "
   " Get the window ID

--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -30,20 +30,22 @@ let s:zathura = {
       \}
 
 function! s:zathura.start(outfile) dict " {{{1
-  let l:cmd  = 'zathura'
-  let l:cmd .= ' -x "' . g:vimtex_compiler_progname
-        \ . ' --servername ' . v:servername
-        \ . ' --remote-expr '
-        \ .     '\"vimtex#view#reverse_goto(%{line}, ''%{input}'')\""'
-  if g:vimtex_view_forward_search_on_start
-    let l:cmd .= ' --synctex-forward '
-          \ .  line('.')
-          \ .  ':' . col('.')
-          \ .  ':' . vimtex#util#shellescape(expand('%:p'))
+  if g:vimtex_view_process_start
+    let l:cmd  = 'zathura'
+    let l:cmd .= ' -x "' . g:vimtex_compiler_progname
+          \ . ' --servername ' . v:servername
+          \ . ' --remote-expr '
+          \ .     '\"vimtex#view#reverse_goto(%{line}, ''%{input}'')\""'
+    if g:vimtex_view_forward_search_on_start
+      let l:cmd .= ' --synctex-forward '
+            \ .  line('.')
+            \ .  ':' . col('.')
+            \ .  ':' . vimtex#util#shellescape(expand('%:p'))
+    endif
+    let l:cmd .= ' ' . g:vimtex_view_zathura_options
+    let l:cmd .= ' ' . vimtex#util#shellescape(a:outfile)
+    let self.process = vimtex#process#start(l:cmd)
   endif
-  let l:cmd .= ' ' . g:vimtex_view_zathura_options
-  let l:cmd .= ' ' . vimtex#util#shellescape(a:outfile)
-  let self.process = vimtex#process#start(l:cmd)
 
   call self.xwin_get_id()
   let self.outfile = a:outfile
@@ -82,7 +84,7 @@ function! s:zathura.compiler_callback(status) dict " {{{1
     "   recognized. Sometimes it is very quick, other times it may take
     "   a second. This way, we don't block longer than necessary.
     "
-    if !has_key(self, 'started_through_callback')
+    if !has_key(self, 'started_through_callback') && g:vimtex_view_xwin_exists
       for l:dummy in range(30)
         sleep 50m
         if self.xwin_exists() | break | endif


### PR DESCRIPTION
As discussed in #1063, I have made some experimental modifications to the zathura startup behavior.

The following changes make the modifications I wanted available as a config setting via
```vim
let g:vimtex_view_process_start = 0
let g:vimtex_view_xwin_exists = 0
```
(Note that the default is the opposite of this setting, so it is 1,1, this is what I put in `.vimrc`)

And I also changed the timer from 500m to 50m for `xwin_id`, since that is more than is needed.

So this pull request does not change the default behavior for any users, it only provides 2 additional options that skip some things I wanted to skip. The only change that would affect everyone is the change of the `xwin_id` timer to 50m from 500m, but that shouldn't cause any issues, right?

I know you said you don't want these extra settings, but since I was experimenting, I have them here, so if you'd like to merge, that would be great, but I understand you might not want to.

Regards,