### PR TITLE
Add an option to disable syntax highlighting.

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -4,6 +4,10 @@
 " Email:      karl.yngve@gmail.com
 "
 
+if !get(g:, 'vimtex_syntax_enabled', 1)
+  finish
+endif
+
 if !exists('b:current_syntax')
   let b:current_syntax = 'tex'
 elseif b:current_syntax !=# 'tex'

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1515,6 +1515,11 @@ Options~
 
   Default value: 1
 
+*g:vimtex_syntax_enabled*
+  Use this option to disable/enable |vimtex| improved syntax highlighting.
+
+  Default value: 1.
+
 *g:vimtex_syntax_minted*
   A list that contains dictionaries for each supported language.  A language
   dictionary should be something similar to the following: >


### PR DESCRIPTION
I just added an option to disable vimtex syntax highlighting.

The dependence on TexNewMathZone is a problem if one wants to use a different tex syntax file than the one bundled with vim, see [gi1242/vim-tex-syntax](https://github.com/gi1242/vim-tex-syntax.git) for instance.