### PR TITLE
Update example configuration for ncm2

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2762,7 +2762,6 @@ The following configuration should work well with `vimtex`: >
             \ 'complete_length': 1,
             \ 'scope': ['tex'],
             \ 'matcher': {'name': 'prefix', 'key': 'word'},
-            \ 'mark': 'tex',
             \ 'word_pattern': '\w+',
             \ 'complete_pattern': g:vimtex#re#ncm,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2757,7 +2757,7 @@ The following configuration should work well with `vimtex`: >
     autocmd BufEnter * call ncm2#enable_for_buffer()
     autocmd User Ncm2Plugin call ncm2#register_source({
             \ 'name': 'vimtex',
-            \ 'priority': 9,
+            \ 'priority': 8,
             \ 'subscope_enable': 1,
             \ 'complete_length': 1,
             \ 'scope': ['tex'],

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2761,6 +2761,7 @@ The following configuration should work well with `vimtex`: >
             \ 'subscope_enable': 1,
             \ 'complete_length': 1,
             \ 'scope': ['tex'],
+            \ 'matcher': {'name': 'prefix', 'key': 'word'},
             \ 'mark': 'tex',
             \ 'word_pattern': '\w+',
             \ 'complete_pattern': g:vimtex#re#ncm,

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2761,7 +2761,12 @@ The following configuration should work well with `vimtex`: >
             \ 'subscope_enable': 1,
             \ 'complete_length': 1,
             \ 'scope': ['tex'],
-            \ 'matcher': {'name': 'prefix', 'key': 'word'},
+            \ 'matcher': {'name': 'combine',
+            \             'matchers': [
+            \               {'name': 'prefix', 'key': 'word'},
+            \               {'name': 'substr', 'key': 'abbr'},
+            \               {'name': 'abbrfuzzy', 'key': 'menu'},
+            \             ]},
             \ 'word_pattern': '\w+',
             \ 'complete_pattern': g:vimtex#re#ncm,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],


### PR DESCRIPTION
The just merged pull request https://github.com/ncm2/ncm2/pull/23 introduces the possibility of using separate matchers for different fields in the completed items returned by vimtex's omni-completion. This makes ncm2's autocompletion behave more like omni-completion, e.g., by being able to match on author and title of BibTeX completion candidates rather than just the key. (Omni-completion is still a bit smarter since ncm2 can only match on the displayed fields, while omni-completion has the full BibTeX record available.) Similarly, matching on the printed string of a label (e.g., `(2.1)`) is now possible as well.

The kind of matchers -- `prefix` (match on start of field only), `substr` (match any exact substring), `abbrvfuzzy` (fuzzy matching) -- can be adjusted to taste. A separate pull-request #1165 is needed to actually make use of a stricter matching on `word` than on `abbr`.

cc @languitar 