### PR TITLE
Fill completed item fields more discriminately in complete.vim

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -432,7 +432,7 @@ function! s:completer_cmd.gather_candidates_from_newcommands() dict " {{{2
   call map(l:candidates, '{
         \ ''word'' : matchstr(v:val, ''\v\\(re)?newcommand\*?\{\\?\zs[^}]*''),
         \ ''mode'' : ''.'',
-        \ ''menu'' : ''[cmd: newcommand]'',
+        \ ''kind'' : ''[cmd: newcommand]'',
         \ }')
 
   let self.candidates_from_newcommands = l:candidates
@@ -449,12 +449,12 @@ function! s:completer_cmd.gather_candidates_from_lets() dict " {{{2
   let l:candidates = map(l:lets, '{
         \ ''word'' : matchstr(v:val, ''\\let[^\\]*\\\zs\w*''),
         \ ''mode'' : ''.'',
-        \ ''menu'' : ''[cmd: \let]'',
+        \ ''kind'' : ''[cmd: \let]'',
         \ }')
         \ + map(l:defs, '{
         \ ''word'' : matchstr(v:val, ''\\def[^\\]*\\\zs\w*''),
         \ ''mode'' : ''.'',
-        \ ''menu'' : ''[cmd: \def]'',
+        \ ''kind'' : ''[cmd: \def]'',
         \ }')
 
   let self.candidates_from_lets = l:candidates
@@ -518,7 +518,7 @@ function! s:completer_img.gather_candidates() dict " {{{2
       call add(self.candidates, {
             \ 'abbr': vimtex#paths#shorten_relative(l:file),
             \ 'word': vimtex#paths#relative(l:file, l:path),
-            \ 'menu': '[graphics]',
+            \ 'kind': '[graphics]',
             \})
     endfor
   endfor
@@ -541,7 +541,7 @@ function! s:completer_inc.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''menu'' : '' [input/include]'',
+        \ ''kind'' : '' [input/include]'',
         \}')
   return self.candidates
 endfunction
@@ -560,7 +560,7 @@ function! s:completer_pdf.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''menu'' : '' [includepdf]'',
+        \ ''kind'' : '' [includepdf]'',
         \}')
   return self.candidates
 endfunction
@@ -580,7 +580,7 @@ function! s:completer_sta.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''menu'' : '' [includestandalone]'',
+        \ ''kind'' : '' [includestandalone]'',
         \}')
   return self.candidates
 endfunction
@@ -645,7 +645,7 @@ function! s:completer_pck.gather_candidates() dict " {{{2
   if empty(self.candidates)
     let self.candidates = map(s:get_texmf_candidates('sty'), '{
           \ ''word'' : v:val,
-          \ ''menu'' : '' [package]'',
+          \ ''kind'' : '' [package]'',
           \}')
   endif
 
@@ -669,7 +669,7 @@ function! s:completer_doc.gather_candidates() dict " {{{2
   if empty(self.candidates)
     let self.candidates = map(s:get_texmf_candidates('cls'), '{
           \ ''word'' : v:val,
-          \ ''menu'' : '' [documentclass]'',
+          \ ''kind'' : '' [documentclass]'',
           \}')
   endif
 
@@ -719,7 +719,7 @@ function! s:completer_env.complete(regex) dict " {{{2
     if !empty(l:matching_env) && l:matching_env =~# a:regex
       return [{
             \ 'word': l:matching_env,
-            \ 'menu': '[env: matching]',
+            \ 'kind': '[env: matching]',
             \}]
     endif
   endif
@@ -772,7 +772,7 @@ function! s:completer_env.gather_candidates_from_newenvironments() dict " {{{2
   call map(l:candidates, '{
         \ ''word'' : matchstr(v:val, ''\v\\(re)?newenvironment\*?\{\\?\zs[^}]*''),
         \ ''mode'' : ''.'',
-        \ ''menu'' : ''[env: newenvironment]'',
+        \ ''kind'' : ''[env: newenvironment]'',
         \ }')
 
   let self.candidates_from_newenvironments = l:candidates
@@ -841,7 +841,8 @@ function! s:load_candidates_from_packages(packages) " {{{1
     call map(l:candidates, '{
           \ ''word'' : v:val[0],
           \ ''mode'' : ''.'',
-          \ ''menu'' : ''[cmd: '' . l:package . ''] '' . (get(v:val, 1, '''')),
+          \ ''kind'' : ''[cmd: '' . l:package . ''] '',
+          \ ''menu'' : (get(v:val, 1, '''')),
           \}')
     let s:candidates_from_packages[l:package].commands += l:candidates
 
@@ -849,7 +850,7 @@ function! s:load_candidates_from_packages(packages) " {{{1
     call map(l:candidates, '{
           \ ''word'' : substitute(v:val, ''^\\begin{\|}$'', '''', ''g''),
           \ ''mode'' : ''.'',
-          \ ''menu'' : ''[env: '' . l:package . ''] '',
+          \ ''kind'' : ''[env: '' . l:package . ''] '',
           \}')
     let s:candidates_from_packages[l:package].environments += l:candidates
   endfor

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -252,7 +252,6 @@ function! s:completer_ref.complete(regex) dict " {{{2
   for m in self.get_matches(a:regex)
     call add(self.candidates, {
           \ 'word' : m[0],
-          \ 'abbr' : m[0],
           \ 'menu' : printf('%7s [p. %s]', '('.m[1].')', m[2])
           \ })
   endfor
@@ -542,7 +541,6 @@ function! s:completer_inc.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''abbr'' : v:val,
         \ ''menu'' : '' [input/include]'',
         \}')
   return self.candidates
@@ -562,7 +560,6 @@ function! s:completer_pdf.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''abbr'' : v:val,
         \ ''menu'' : '' [includepdf]'',
         \}')
   return self.candidates
@@ -583,7 +580,6 @@ function! s:completer_sta.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''abbr'' : v:val,
         \ ''menu'' : '' [includestandalone]'',
         \}')
   return self.candidates
@@ -624,7 +620,6 @@ function! s:completer_gls.parse_glossaries() dict " {{{2
     let l:matches = matchlist(l:line, l:re_matcher)
     call add(self.candidates, {
           \ 'word' : l:matches[2],
-          \ 'abbr' : l:matches[2],
           \ 'menu' : self.key[l:matches[1]],
           \})
   endfor


### PR DESCRIPTION
(This pull request is needed to get the full benefit of #1164. )

When invoked, the omnicomplete function can return a dictionary rather than a simple string in `v:completed_item`. From `:he complete-items`:

>         word            the text that will be inserted, mandatory
>         abbr            abbreviation of "word"; when not empty it is used in
>                         the menu instead of "word"
>         menu            extra text for the popup menu, displayed after "word"
>                         or "abbr"
>         info            more information about the item, can be displayed in a
>                         preview window
>         kind            single letter indicating the type of completion

This pull request makes the following changes:

1. Only fill the `abbr` field if it's actually different from `word`. (Currently, vimtex copies `abbr` from `word` in all other cases.) This allows, e.g., command completion to use a stricter `word` matcher than a fuzzy `abbr` matcher (which would be useful for BibTeX and label completions). Note that https://github.com/ncm2/ncm2/issues/26 needs to be addressed before that will work completely.

2. Don't use the `menu` field for the type of completion (`cmd`, `environment`, `include`, etc.); use `kind` for this. (The help says that this should be a single letter and goes on to give a list of -- very C specific -- options, but this doesn't actually seem to be *required*; both vim (8.1+) and neovim (0.3.0+) handle strings just fine.) The `kind` field gets printed in the popup menu before the `menu` field, so there's no visible difference (apart from the unicode symbols in the list of command completions being more nicely aligned, in my opinion), but this allows excluding these strings from matching. (If this is desired, one can add an additional matcher for `kind` in the ncm2 source.) *Candidate* specific information (title for BibTeX, string for labels, symbol for command, glossary entries) are still put in `menu`.

I didn't notice any regressions for deoplete and omnicompletion with these changes, but there might be some [edge cases I have missed](https://xkcd.com/1172/)...

cc @languitar 