### PR TITLE
Ncm2: Force word letter triggering for command autocomplete

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -432,7 +432,7 @@ function! s:completer_cmd.gather_candidates_from_newcommands() dict " {{{2
   call map(l:candidates, '{
         \ ''word'' : matchstr(v:val, ''\v\\(re)?newcommand\*?\{\\?\zs[^}]*''),
         \ ''mode'' : ''.'',
-        \ ''menu'' : ''[cmd: newcommand]'',
+        \ ''kind'' : ''[cmd: newcommand]'',
         \ }')
 
   let self.candidates_from_newcommands = l:candidates
@@ -449,12 +449,12 @@ function! s:completer_cmd.gather_candidates_from_lets() dict " {{{2
   let l:candidates = map(l:lets, '{
         \ ''word'' : matchstr(v:val, ''\\let[^\\]*\\\zs\w*''),
         \ ''mode'' : ''.'',
-        \ ''menu'' : ''[cmd: \let]'',
+        \ ''kind'' : ''[cmd: \let]'',
         \ }')
         \ + map(l:defs, '{
         \ ''word'' : matchstr(v:val, ''\\def[^\\]*\\\zs\w*''),
         \ ''mode'' : ''.'',
-        \ ''menu'' : ''[cmd: \def]'',
+        \ ''kind'' : ''[cmd: \def]'',
         \ }')
 
   let self.candidates_from_lets = l:candidates
@@ -518,7 +518,7 @@ function! s:completer_img.gather_candidates() dict " {{{2
       call add(self.candidates, {
             \ 'abbr': vimtex#paths#shorten_relative(l:file),
             \ 'word': vimtex#paths#relative(l:file, l:path),
-            \ 'menu': '[graphics]',
+            \ 'kind': '[graphics]',
             \})
     endfor
   endfor
@@ -541,7 +541,7 @@ function! s:completer_inc.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''menu'' : '' [input/include]'',
+        \ ''kind'' : '' [input/include]'',
         \}')
   return self.candidates
 endfunction
@@ -560,7 +560,7 @@ function! s:completer_pdf.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''menu'' : '' [includepdf]'',
+        \ ''kind'' : '' [includepdf]'',
         \}')
   return self.candidates
 endfunction
@@ -580,7 +580,7 @@ function! s:completer_sta.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''menu'' : '' [includestandalone]'',
+        \ ''kind'' : '' [includestandalone]'',
         \}')
   return self.candidates
 endfunction
@@ -645,7 +645,7 @@ function! s:completer_pck.gather_candidates() dict " {{{2
   if empty(self.candidates)
     let self.candidates = map(s:get_texmf_candidates('sty'), '{
           \ ''word'' : v:val,
-          \ ''menu'' : '' [package]'',
+          \ ''kind'' : '' [package]'',
           \}')
   endif
 
@@ -669,7 +669,7 @@ function! s:completer_doc.gather_candidates() dict " {{{2
   if empty(self.candidates)
     let self.candidates = map(s:get_texmf_candidates('cls'), '{
           \ ''word'' : v:val,
-          \ ''menu'' : '' [documentclass]'',
+          \ ''kind'' : '' [documentclass]'',
           \}')
   endif
 
@@ -719,7 +719,7 @@ function! s:completer_env.complete(regex) dict " {{{2
     if !empty(l:matching_env) && l:matching_env =~# a:regex
       return [{
             \ 'word': l:matching_env,
-            \ 'menu': '[env: matching]',
+            \ 'kind': '[env: matching]',
             \}]
     endif
   endif
@@ -772,7 +772,7 @@ function! s:completer_env.gather_candidates_from_newenvironments() dict " {{{2
   call map(l:candidates, '{
         \ ''word'' : matchstr(v:val, ''\v\\(re)?newenvironment\*?\{\\?\zs[^}]*''),
         \ ''mode'' : ''.'',
-        \ ''menu'' : ''[env: newenvironment]'',
+        \ ''kind'' : ''[env: newenvironment]'',
         \ }')
 
   let self.candidates_from_newenvironments = l:candidates
@@ -841,7 +841,8 @@ function! s:load_candidates_from_packages(packages) " {{{1
     call map(l:candidates, '{
           \ ''word'' : v:val[0],
           \ ''mode'' : ''.'',
-          \ ''menu'' : ''[cmd: '' . l:package . ''] '' . (get(v:val, 1, '''')),
+          \ ''kind'' : ''[cmd: '' . l:package . ''] '',
+          \ ''menu'' : (get(v:val, 1, '''')),
           \}')
     let s:candidates_from_packages[l:package].commands += l:candidates
 
@@ -849,7 +850,7 @@ function! s:load_candidates_from_packages(packages) " {{{1
     call map(l:candidates, '{
           \ ''word'' : substitute(v:val, ''^\\begin{\|}$'', '''', ''g''),
           \ ''mode'' : ''.'',
-          \ ''menu'' : ''[env: '' . l:package . ''] '',
+          \ ''kind'' : ''[env: '' . l:package . ''] '',
           \}')
     let s:candidates_from_packages[l:package].environments += l:candidates
   endfor

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -252,7 +252,6 @@ function! s:completer_ref.complete(regex) dict " {{{2
   for m in self.get_matches(a:regex)
     call add(self.candidates, {
           \ 'word' : m[0],
-          \ 'abbr' : m[0],
           \ 'menu' : printf('%7s [p. %s]', '('.m[1].')', m[2])
           \ })
   endfor
@@ -542,7 +541,6 @@ function! s:completer_inc.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''abbr'' : v:val,
         \ ''menu'' : '' [input/include]'',
         \}')
   return self.candidates
@@ -562,7 +560,6 @@ function! s:completer_pdf.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''abbr'' : v:val,
         \ ''menu'' : '' [includepdf]'',
         \}')
   return self.candidates
@@ -583,7 +580,6 @@ function! s:completer_sta.complete(regex) dict " {{{2
   call filter(self.candidates, 'v:val =~# a:regex')
   let self.candidates = map(self.candidates, '{
         \ ''word'' : v:val,
-        \ ''abbr'' : v:val,
         \ ''menu'' : '' [includestandalone]'',
         \}')
   return self.candidates
@@ -624,7 +620,6 @@ function! s:completer_gls.parse_glossaries() dict " {{{2
     let l:matches = matchlist(l:line, l:re_matcher)
     call add(self.candidates, {
           \ 'word' : l:matches[2],
-          \ 'abbr' : l:matches[2],
           \ 'menu' : self.key[l:matches[1]],
           \})
   endfor

--- a/autoload/vimtex/re.vim
+++ b/autoload/vimtex/re.vim
@@ -80,6 +80,47 @@ let g:vimtex#re#ncm = [
       \ '\\end(\s*\[[^]]*\])?\s*\{[^}]*',
       \]
 
+let g:vimtex#re#ncm2 = [
+      \ '\\[A-Za-z]*',
+      \ '\\[A-Za-z]*cite[A-Za-z]*(\[[^]]*\]){0,2}{[^}]*',
+      \ '\\(text|block)cquote\*?(\[[^]]*\]){0,2}{[^}]*',
+      \ '\\(for|hy)[A-Za-z]*cquote\*?{[^}]*}(\[[^]]*\]){0,2}{[^}]*',
+      \ '\\[A-Za-z]*ref({[^}]*|range{([^,{}]*(}{)?))',
+      \ '\\hyperref\[[^]]*',
+      \ '\\includegraphics\*?(\[[^]]*\]){0,2}{[^}]*',
+      \ '\\(include(only)?|input|subfile){[^}]*',
+      \ '\\\a*(gls|Gls|GLS)(pl)?\a*(\s*\[[^]]*\]){0,2}\s*\{[^}]*',
+      \ '\\includepdf(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\includestandalone(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\usepackage(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\documentclass(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\begin(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\end(\s*\[[^]]*\])?\s*\{[^}]*',
+      \]
+let g:vimtex#re#ncm2#cmds = [
+      \ '\\[A-Za-z]*[^{]',
+      \ '\\usepackage(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\documentclass(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\begin(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\end(\s*\[[^]]*\])?\s*\{[^}]*',
+      \]
+let g:vimtex#re#ncm2#bibtex = [
+      \ '\\[A-Za-z]*cite[A-Za-z]*(\[[^]]*\]){0,2}{[^}]*',
+      \ '\\(text|block)cquote\*?(\[[^]]*\]){0,2}{[^}]*',
+      \ '\\(for|hy)[A-Za-z]*cquote\*?{[^}]*}(\[[^]]*\]){0,2}{[^}]*',
+      \]
+let g:vimtex#re#ncm2#labels = [
+      \ '\\[A-Za-z]*ref({[^}]*|range{([^,{}]*(}{)?))',
+      \ '\\hyperref\[[^]]*',
+      \ '\\\a*(gls|Gls|GLS)(pl)?\a*(\s*\[[^]]*\]){0,2}\s*\{[^}]*',
+      \]
+let g:vimtex#re#ncm2#files = [
+      \ '\\includegraphics\*?(\[[^]]*\]){0,2}{[^}]*',
+      \ '\\(include(only)?|input|subfile){[^}]*',
+      \ '\\includepdf(\s*\[[^]]*\])?\s*\{[^}]*',
+      \ '\\includestandalone(\s*\[[^]]*\])?\s*\{[^}]*',
+      \]
+
 let g:vimtex#re#youcompleteme = map(copy(g:vimtex#re#ncm), "'re!' . v:val")
 
 " }}}1

--- a/autoload/vimtex/re.vim
+++ b/autoload/vimtex/re.vim
@@ -63,7 +63,7 @@ let g:vimtex#re#deoplete = '\\(?:'
       \ .')'
 
 let g:vimtex#re#ncm2#cmds = [
-      \ '\\[A-Za-z]*',
+      \ '\\[A-Za-z]+',
       \ '\\usepackage(\s*\[[^]]*\])?\s*\{[^}]*',
       \ '\\documentclass(\s*\[[^]]*\])?\s*\{[^}]*',
       \ '\\begin(\s*\[[^]]*\])?\s*\{[^}]*',

--- a/autoload/vimtex/re.vim
+++ b/autoload/vimtex/re.vim
@@ -80,23 +80,6 @@ let g:vimtex#re#ncm = [
       \ '\\end(\s*\[[^]]*\])?\s*\{[^}]*',
       \]
 
-let g:vimtex#re#ncm2 = [
-      \ '\\[A-Za-z]*',
-      \ '\\[A-Za-z]*cite[A-Za-z]*(\[[^]]*\]){0,2}{[^}]*',
-      \ '\\(text|block)cquote\*?(\[[^]]*\]){0,2}{[^}]*',
-      \ '\\(for|hy)[A-Za-z]*cquote\*?{[^}]*}(\[[^]]*\]){0,2}{[^}]*',
-      \ '\\[A-Za-z]*ref({[^}]*|range{([^,{}]*(}{)?))',
-      \ '\\hyperref\[[^]]*',
-      \ '\\includegraphics\*?(\[[^]]*\]){0,2}{[^}]*',
-      \ '\\(include(only)?|input|subfile){[^}]*',
-      \ '\\\a*(gls|Gls|GLS)(pl)?\a*(\s*\[[^]]*\]){0,2}\s*\{[^}]*',
-      \ '\\includepdf(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\includestandalone(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\usepackage(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\documentclass(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\begin(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\end(\s*\[[^]]*\])?\s*\{[^}]*',
-      \]
 let g:vimtex#re#ncm2#cmds = [
       \ '\\[A-Za-z]*',
       \ '\\usepackage(\s*\[[^]]*\])?\s*\{[^}]*',
@@ -120,6 +103,11 @@ let g:vimtex#re#ncm2#files = [
       \ '\\includepdf(\s*\[[^]]*\])?\s*\{[^}]*',
       \ '\\includestandalone(\s*\[[^]]*\])?\s*\{[^}]*',
       \]
+
+let g:vimtex#re#ncm2 = g:vimtex#re#ncm2#cmds +
+            \ g:vimtex#re#ncm2#bibtex + 
+            \ g:vimtex#re#ncm2#labels + 
+            \ g:vimtex#re#ncm2#files
 
 let g:vimtex#re#youcompleteme = map(copy(g:vimtex#re#ncm), "'re!' . v:val")
 

--- a/autoload/vimtex/re.vim
+++ b/autoload/vimtex/re.vim
@@ -98,7 +98,7 @@ let g:vimtex#re#ncm2 = [
       \ '\\end(\s*\[[^]]*\])?\s*\{[^}]*',
       \]
 let g:vimtex#re#ncm2#cmds = [
-      \ '\\[A-Za-z]*[^{]',
+      \ '\\[A-Za-z]*',
       \ '\\usepackage(\s*\[[^]]*\])?\s*\{[^}]*',
       \ '\\documentclass(\s*\[[^]]*\])?\s*\{[^}]*',
       \ '\\begin(\s*\[[^]]*\])?\s*\{[^}]*',

--- a/autoload/vimtex/re.vim
+++ b/autoload/vimtex/re.vim
@@ -62,24 +62,6 @@ let g:vimtex#re#deoplete = '\\(?:'
       \ . '|\w*'
       \ .')'
 
-let g:vimtex#re#ncm = [
-      \ '\\[A-Za-z]*',
-      \ '\\[A-Za-z]*cite[A-Za-z]*(\[[^]]*\]){0,2}{[^}]*',
-      \ '\\(text|block)cquote\*?(\[[^]]*\]){0,2}{[^}]*',
-      \ '\\(for|hy)[A-Za-z]*cquote\*?{[^}]*}(\[[^]]*\]){0,2}{[^}]*',
-      \ '\\[A-Za-z]*ref({[^}]*|range{([^,{}]*(}{)?))',
-      \ '\\hyperref\[[^]]*',
-      \ '\\includegraphics\*?(\[[^]]*\]){0,2}{[^}]*',
-      \ '\\(include(only)?|input|subfile){[^}]*',
-      \ '\\\a*(gls|Gls|GLS)(pl)?\a*(\s*\[[^]]*\]){0,2}\s*\{[^}]*',
-      \ '\\includepdf(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\includestandalone(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\usepackage(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\documentclass(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\begin(\s*\[[^]]*\])?\s*\{[^}]*',
-      \ '\\end(\s*\[[^]]*\])?\s*\{[^}]*',
-      \]
-
 let g:vimtex#re#ncm2#cmds = [
       \ '\\[A-Za-z]*',
       \ '\\usepackage(\s*\[[^]]*\])?\s*\{[^}]*',
@@ -108,6 +90,8 @@ let g:vimtex#re#ncm2 = g:vimtex#re#ncm2#cmds +
             \ g:vimtex#re#ncm2#bibtex + 
             \ g:vimtex#re#ncm2#labels + 
             \ g:vimtex#re#ncm2#files
+
+let g:vimtex#re#ncm = copy(g:vimtex#re#ncm2)
 
 let g:vimtex#re#youcompleteme = map(copy(g:vimtex#re#ncm), "'re!' . v:val")
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2766,8 +2766,8 @@ The following simple configuration should work well with `vimtex`: >
             \ })
   augroup END
 <
-To have autocomplete behave more intelligently like omni-complete, use the
-following setup instead: >
+To have more intelligent autocompletion like omni-complete, use the following 
+setup (in your init.vim or a personal ftplugin) instead: >
 
   augroup my_cm_setup
     autocmd!

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2804,7 +2804,7 @@ following setup instead: >
             \ 'matcher': {'name': 'combine',
             \             'matchers': [
             \               {'name': 'abbrfuzzy', 'key': 'word'},
-            \               {'name': 'abbrfuzzy', 'key': 'menu'},
+            \               {'name': 'abbrfuzzy', 'key': 'abbr'},
             \             ]},
             \ 'word_pattern': '\w+',
             \ 'complete_pattern': g:vimtex#re#ncm2#files,

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2766,7 +2766,7 @@ The following simple configuration should work well with `vimtex`: >
             \ })
   augroup END
 <
-To have more intelligent autocompletion like omni-complete, use the following 
+To have more intelligent, omni-complete-like, autocompletion, use the following 
 setup (in your init.vim or a personal ftplugin) instead: >
 
   augroup my_cm_setup

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2766,8 +2766,8 @@ The following simple configuration should work well with `vimtex`: >
             \ })
   augroup END
 <
-To have more intelligent, omni-complete-like, autocompletion, use the following 
-setup (in your init.vim or a personal ftplugin) instead: >
+For more lenient, omni-complete-like, filtering of completion candidates, 
+use the following setup (in your init.vim or a personal ftplugin) instead: >
 
   augroup my_cm_setup
     autocmd!

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2744,7 +2744,7 @@ ncm2~
 supposed to be a "Slim, Fast and Hackable Completion Framework for Neovim":
 https://github.com/ncm2/ncm2
 
-The following configuration should work well with `vimtex`: >
+The following simple configuration should work well with `vimtex`: >
 
   " include the following plugins (here using junnegun/vim-plug)
   Plug 'roxma/nvim-yarp'
@@ -2757,13 +2757,72 @@ The following configuration should work well with `vimtex`: >
     autocmd BufEnter * call ncm2#enable_for_buffer()
     autocmd User Ncm2Plugin call ncm2#register_source({
             \ 'name': 'vimtex',
-            \ 'priority': 9,
-            \ 'subscope_enable': 1,
-            \ 'complete_length': 1,
+            \ 'priority': 8,
             \ 'scope': ['tex'],
             \ 'mark': 'tex',
             \ 'word_pattern': '\w+',
-            \ 'complete_pattern': g:vimtex#re#ncm,
+            \ 'complete_pattern': g:vimtex#re#ncm2,
+            \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
+            \ })
+  augroup END
+<
+To have autocomplete behave more intelligently like omni-complete, use the
+following setup instead: >
+
+  augroup my_cm_setup
+    autocmd!
+    autocmd BufEnter * call ncm2#enable_for_buffer()
+    autocmd User Ncm2Plugin call ncm2#register_source({
+            \ 'name' : 'vimtex-cmds',
+            \ 'priority': 8, 
+            \ 'complete_length': -1,
+            \ 'scope': ['tex'],
+            \ 'matcher': {'name': 'prefix', 'key': 'word'},
+            \ 'word_pattern': '\w+',
+            \ 'complete_pattern': g:vimtex#re#ncm2#cmds,
+            \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
+            \ })
+    autocmd User Ncm2Plugin call ncm2#register_source({
+            \ 'name' : 'vimtex-labels',
+            \ 'priority': 8, 
+            \ 'complete_length': -1,
+            \ 'scope': ['tex'],
+            \ 'matcher': {'name': 'combine',
+            \             'matchers': [
+            \               {'name': 'substr', 'key': 'word'},
+            \               {'name': 'substr', 'key': 'menu'},
+            \             ]},
+            \ 'word_pattern': '\w+',
+            \ 'complete_pattern': g:vimtex#re#ncm2#labels,
+            \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
+            \ })
+    autocmd User Ncm2Plugin call ncm2#register_source({
+            \ 'name' : 'vimtex-files',
+            \ 'priority': 8, 
+            \ 'complete_length': -1,
+            \ 'scope': ['tex'],
+            \ 'matcher': {'name': 'combine',
+            \             'matchers': [
+            \               {'name': 'abbrfuzzy', 'key': 'word'},
+            \               {'name': 'abbrfuzzy', 'key': 'menu'},
+            \             ]},
+            \ 'word_pattern': '\w+',
+            \ 'complete_pattern': g:vimtex#re#ncm2#files,
+            \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
+            \ })
+    autocmd User Ncm2Plugin call ncm2#register_source({
+            \ 'name' : 'bibtex',
+            \ 'priority': 8, 
+            \ 'complete_length': -1,
+            \ 'scope': ['tex'],
+            \ 'matcher': {'name': 'combine',
+            \             'matchers': [
+            \               {'name': 'prefix', 'key': 'word'},
+            \               {'name': 'abbrfuzzy', 'key': 'abbr'},
+            \               {'name': 'abbrfuzzy', 'key': 'menu'},
+            \             ]},
+            \ 'word_pattern': '\w+',
+            \ 'complete_pattern': g:vimtex#re#ncm2#bibtex,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
             \ })
   augroup END

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2755,7 +2755,7 @@ The following simple configuration should work well with `vimtex`: >
   augroup my_cm_setup
     autocmd!
     autocmd BufEnter * call ncm2#enable_for_buffer()
-    autocmd Syntax tex call ncm2#register_source({
+    autocmd Filetype tex call ncm2#register_source({
             \ 'name': 'vimtex',
             \ 'priority': 8,
             \ 'scope': ['tex'],
@@ -2772,7 +2772,7 @@ following setup instead: >
   augroup my_cm_setup
     autocmd!
     autocmd BufEnter * call ncm2#enable_for_buffer()
-    autocmd Syntax tex call ncm2#register_source({
+    autocmd Filetype tex call ncm2#register_source({
             \ 'name' : 'vimtex-cmds',
             \ 'priority': 8, 
             \ 'complete_length': -1,
@@ -2782,7 +2782,7 @@ following setup instead: >
             \ 'complete_pattern': g:vimtex#re#ncm2#cmds,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
             \ })
-    autocmd Syntax tex call ncm2#register_source({
+    autocmd Filetype tex call ncm2#register_source({
             \ 'name' : 'vimtex-labels',
             \ 'priority': 8, 
             \ 'complete_length': -1,
@@ -2796,7 +2796,7 @@ following setup instead: >
             \ 'complete_pattern': g:vimtex#re#ncm2#labels,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
             \ })
-    autocmd Syntax tex call ncm2#register_source({
+    autocmd Filetype tex call ncm2#register_source({
             \ 'name' : 'vimtex-files',
             \ 'priority': 8, 
             \ 'complete_length': -1,
@@ -2810,7 +2810,7 @@ following setup instead: >
             \ 'complete_pattern': g:vimtex#re#ncm2#files,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
             \ })
-    autocmd Syntax tex call ncm2#register_source({
+    autocmd Filetype tex call ncm2#register_source({
             \ 'name' : 'bibtex',
             \ 'priority': 8, 
             \ 'complete_length': -1,

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2755,7 +2755,7 @@ The following simple configuration should work well with `vimtex`: >
   augroup my_cm_setup
     autocmd!
     autocmd BufEnter * call ncm2#enable_for_buffer()
-    autocmd User Ncm2Plugin call ncm2#register_source({
+    autocmd Syntax tex call ncm2#register_source({
             \ 'name': 'vimtex',
             \ 'priority': 8,
             \ 'scope': ['tex'],
@@ -2772,7 +2772,7 @@ following setup instead: >
   augroup my_cm_setup
     autocmd!
     autocmd BufEnter * call ncm2#enable_for_buffer()
-    autocmd User Ncm2Plugin call ncm2#register_source({
+    autocmd Syntax tex call ncm2#register_source({
             \ 'name' : 'vimtex-cmds',
             \ 'priority': 8, 
             \ 'complete_length': -1,
@@ -2782,7 +2782,7 @@ following setup instead: >
             \ 'complete_pattern': g:vimtex#re#ncm2#cmds,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
             \ })
-    autocmd User Ncm2Plugin call ncm2#register_source({
+    autocmd Syntax tex call ncm2#register_source({
             \ 'name' : 'vimtex-labels',
             \ 'priority': 8, 
             \ 'complete_length': -1,
@@ -2796,7 +2796,7 @@ following setup instead: >
             \ 'complete_pattern': g:vimtex#re#ncm2#labels,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
             \ })
-    autocmd User Ncm2Plugin call ncm2#register_source({
+    autocmd Syntax tex call ncm2#register_source({
             \ 'name' : 'vimtex-files',
             \ 'priority': 8, 
             \ 'complete_length': -1,
@@ -2810,7 +2810,7 @@ following setup instead: >
             \ 'complete_pattern': g:vimtex#re#ncm2#files,
             \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
             \ })
-    autocmd User Ncm2Plugin call ncm2#register_source({
+    autocmd Syntax tex call ncm2#register_source({
             \ 'name' : 'bibtex',
             \ 'priority': 8, 
             \ 'complete_length': -1,


### PR DESCRIPTION
pro: doesn't trigger on `\\`
con: doesn't trigger on `\` (need to type a single letter after `\` to start autocomplete)

(also pro: smallest pull request ever :))