### PR TITLE
Parse $pdf_mode variable in latexmkrc

### DIFF
--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -86,8 +86,8 @@ endfunction
 
 " }}}1
 function! s:compiler.init_pdf_mode_option() abort dict " {{{1
-  "
-  " Check if .latexmkrc sets the pdf_mode - if so this should be respected
+  " If the TeX program directive was not set, and if the pdf_mode is set in a
+  " .latexmkrc file, then deduce the compiler engine from the value of pdf_mode.
 
   " Parse the pdf_mode option. If not found, it is set to -1.
   let l:pdf_mode = s:parse_latexmkrc_option(self.root, 'pdf_mode', 1, -1)
@@ -104,14 +104,16 @@ function! s:compiler.init_pdf_mode_option() abort dict " {{{1
     return
   endif
 
-  if self.tex_program !=# '_' && self.tex_program !=# l:tex_program
+  if self.tex_program ==# '_'  " the TeX program directive was not specified
+      let self.tex_program = l:tex_program
+  elseif self.tex_program !=# l:tex_program
     call vimtex#log#warning(
-          \ 'Setting pdf_mode from latexmkrc overrides tex_program!',
-          \ 'Changed tex_program from: ' . self.tex_program,
-          \ 'Changed tex_program to: ' . l:tex_program)
+          \ 'Value of pdf_mode from latexmkrc is inconsistent with ' .
+          \ 'TeX program directive!',
+          \ 'TeX program: ' . self.tex_program,
+          \ 'pdf_mode:    ' . l:tex_program,
+          \ 'The value of pdf_mode will be ignored.')
   endif
-
-  let self.tex_program = l:tex_program
 endfunction
 
 " }}}1

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -51,6 +51,7 @@ function! s:compiler.init(options) abort dict " {{{1
 
   call self.init_check_requirements()
   call self.init_build_dir_option()
+  call self.init_pdf_mode_option()
 
   call extend(self, deepcopy(s:compiler_{self.backend}))
 
@@ -110,6 +111,36 @@ function! s:compiler.init_build_dir_option() abort dict " {{{1
     endif
     let self.build_dir = l:out_dir
   endif
+endfunction
+
+" }}}1
+function! s:compiler.init_pdf_mode_option() abort dict " {{{1
+  "
+  " Check if .latexmkrc sets the pdf_mode - if so this should be respected
+
+  " Parse the pdf_mode option. If not found, it is set to -1.
+  let l:pdf_mode = self.init_parse_option('pdf_mode', 1, -1)
+
+  " If pdf_mode has a supported value (1: pdflatex, 4: lualatex, 5: xelatex),
+  " override the value of self.tex_program.
+  if l:pdf_mode == 1
+    let l:tex_program = 'pdflatex'
+  elseif l:pdf_mode == 4
+    let l:tex_program = 'lualatex'
+  elseif l:pdf_mode == 5
+    let l:tex_program = 'xelatex'
+  else
+    return
+  endif
+
+  if self.tex_program !=# '_' && self.tex_program !=# l:tex_program
+    call vimtex#log#warning(
+          \ 'Setting pdf_mode from latexmkrc overrides tex_program!',
+          \ 'Changed tex_program from: ' . self.tex_program,
+          \ 'Changed tex_program to: ' . l:tex_program)
+  endif
+
+  let self.tex_program = l:tex_program
 endfunction
 
 " }}}1

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -66,6 +66,35 @@ function! s:compiler.init(options) abort dict " {{{1
 endfunction
 
 " }}}1
+function! s:compiler.init_parse_option(option, is_integer, default) abort dict " {{{1
+  "
+  " Parse option from .latexmkrc, returning its value if the option was
+  " present or a default value if not.
+  " The option may represent an integer or a string value.
+
+  let l:value_pattern = a:is_integer ? '\(\d\+\)' : '[''"]\(.\+\)[''"]'
+  let l:pattern =
+        \ '^\s*\$' . a:option . '\s*=\s*' . l:value_pattern . '\s*;\?\s*$'
+  let l:files = [
+        \ self.root . '/latexmkrc',
+        \ self.root . '/.latexmkrc',
+        \ fnamemodify('~/.latexmkrc', ':p'),
+        \ expand('$XDG_CONFIG_HOME/latexmk/latexmkrc'),
+        \]
+
+  for l:file in l:files
+    if filereadable(l:file)
+      let l:match = matchlist(readfile(l:file), l:pattern)
+      if len(l:match) > 1
+        return l:match[1]
+      end
+    endif
+  endfor
+
+  return a:default
+endfunction
+
+" }}}1
 function! s:compiler.init_build_dir_option() abort dict " {{{1
   "
   " Check if .latexmkrc sets the build_dir - if so this should be respected

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -71,7 +71,7 @@ function! s:compiler.init_build_dir_option() abort dict " {{{1
   "
   " Check if .latexmkrc sets the build_dir - if so this should be respected
   "
-  let l:out_dir = s:parse_latexmkrc_option(self.root, 'out_dir', 0, '')
+  let l:out_dir = s:parse_latexmkrc_option(self.root, 'out_dir', 0, '')[0]
 
   if !empty(l:out_dir)
     if !empty(self.build_dir)
@@ -90,7 +90,8 @@ function! s:compiler.init_pdf_mode_option() abort dict " {{{1
   " .latexmkrc file, then deduce the compiler engine from the value of pdf_mode.
 
   " Parse the pdf_mode option. If not found, it is set to -1.
-  let l:pdf_mode = s:parse_latexmkrc_option(self.root, 'pdf_mode', 1, -1)
+  let [l:pdf_mode, l:is_local] =
+        \ s:parse_latexmkrc_option(self.root, 'pdf_mode', 1, -1)
 
   " If pdf_mode has a supported value (1: pdflatex, 4: lualatex, 5: xelatex),
   " override the value of self.tex_program.
@@ -106,7 +107,7 @@ function! s:compiler.init_pdf_mode_option() abort dict " {{{1
 
   if self.tex_program ==# '_'  " the TeX program directive was not specified
       let self.tex_program = l:tex_program
-  elseif self.tex_program !=# l:tex_program
+  elseif l:is_local && self.tex_program !=# l:tex_program
     call vimtex#log#warning(
           \ 'Value of pdf_mode from latexmkrc is inconsistent with ' .
           \ 'TeX program directive!',
@@ -574,30 +575,39 @@ endfunction
 " }}}1
 function! s:parse_latexmkrc_option(root, option, is_integer, default) abort " {{{1
   "
-  " Parse option from .latexmkrc, returning its value if the option was
-  " present or a default value if not.
+  " Parse option from .latexmkrc.
   " The option may represent an integer or a string value.
+  "
+  " Returns a list containing the parsed option value, and an integer
+  " determining whether the latexmkrc file is local to the project or not.
+  "
+  " If the option is not found, returns the default value given as input.
 
+  let l:output = [a:default, 0]  " [option value, latexmkrc is local to project]
   let l:value_pattern = a:is_integer ? '\(\d\+\)' : '[''"]\(.\+\)[''"]'
   let l:pattern = '^\s*\$' . a:option . '\s*=\s*' . l:value_pattern
               \ . '\s*;\?\s*\(#.*\)\?$'
+
+  " Each element is a pair [path_to_file, is_local_rc_file].
   let l:files = [
-        \ a:root . '/latexmkrc',
-        \ a:root . '/.latexmkrc',
-        \ fnamemodify('~/.latexmkrc', ':p'),
-        \ expand('$XDG_CONFIG_HOME/latexmk/latexmkrc'),
+        \ [a:root . '/latexmkrc', 1],
+        \ [a:root . '/.latexmkrc', 1],
+        \ [fnamemodify('~/.latexmkrc', ':p'), 0],
+        \ [expand('$XDG_CONFIG_HOME/latexmk/latexmkrc'), 0],
         \]
 
-  for l:file in l:files
+  for [l:file, l:is_local] in l:files
     if filereadable(l:file)
       let l:match = matchlist(readfile(l:file), l:pattern)
       if len(l:match) > 1
-        return l:match[1]
+        let l:output[0] = l:match[1]
+        let l:output[1] = l:is_local
+        break
       end
     endif
   endfor
 
-  return a:default
+  return l:output
 endfunction
 
 " }}}1

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -99,30 +99,17 @@ function! s:compiler.init_build_dir_option() abort dict " {{{1
   "
   " Check if .latexmkrc sets the build_dir - if so this should be respected
   "
+  let l:out_dir = self.init_parse_option('out_dir', 0, '')
 
-  let l:pattern = '^\s*\$out_dir\s*=\s*[''"]\(.\+\)[''"]\s*;\?\s*$'
-  let l:files = [
-        \ self.root . '/latexmkrc',
-        \ self.root . '/.latexmkrc',
-        \ fnamemodify('~/.latexmkrc', ':p'),
-        \ expand('$XDG_CONFIG_HOME/latexmk/latexmkrc'),
-        \]
-
-  for l:file in l:files
-    if filereadable(l:file)
-      let l:out_dir = matchlist(readfile(l:file), l:pattern)
-      if len(l:out_dir) > 1
-        if !empty(self.build_dir)
-          call vimtex#log#warning(
-                \ 'Setting out_dir from latexmkrc overrides build_dir!',
-                \ 'Changed build_dir from: ' . self.build_dir,
-                \ 'Changed build_dir to: ' . l:out_dir[1])
-        endif
-        let self.build_dir = l:out_dir[1]
-        return
-      endif
+  if !empty(l:out_dir)
+    if !empty(self.build_dir)
+      call vimtex#log#warning(
+            \ 'Setting out_dir from latexmkrc overrides build_dir!',
+            \ 'Changed build_dir from: ' . self.build_dir,
+            \ 'Changed build_dir to: ' . l:out_dir)
     endif
-  endfor
+    let self.build_dir = l:out_dir
+  endif
 endfunction
 
 " }}}1

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -74,8 +74,8 @@ function! s:compiler.init_parse_option(option, is_integer, default) abort dict "
   " The option may represent an integer or a string value.
 
   let l:value_pattern = a:is_integer ? '\(\d\+\)' : '[''"]\(.\+\)[''"]'
-  let l:pattern =
-        \ '^\s*\$' . a:option . '\s*=\s*' . l:value_pattern . '\s*;\?\s*$'
+  let l:pattern = '^\s*\$' . a:option . '\s*=\s*' . l:value_pattern 
+              \ . '\s*;\?\s*\(#.*\)\?$'
   let l:files = [
         \ self.root . '/latexmkrc',
         \ self.root . '/.latexmkrc',

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -800,10 +800,10 @@ Options~
   program. The `_` key defines the default engine.
 
   Note: If the TeX program directive is not specified within the main project
-        file, and if `$pdf_mode` is added to `.latexmkrc`, then the compiler
-        engine will be deduced from the value of `$pdf_mode`. The supported
-        values of `$pdf_mode` are 0 (pdflatex), 4 (lualatex) and 5 (xelatex).
-        See the latexmk documentation for details.
+        file, and if `$pdf_mode` is added to a project-specific `.latexmkrc`
+        file, then the compiler engine will be deduced from the value of
+        `$pdf_mode`. The supported values of `$pdf_mode` are 0 (pdflatex), 4
+        (lualatex) and 5 (xelatex). See the latexmk documentation for details.
 
   Default value: >
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -799,10 +799,11 @@ Options~
   compiler engine. This is used by |vimtex-latexmk| to define the LaTeX
   program. The `_` key defines the default engine.
 
-  Note: If `$pdf_mode` is added to `.latexmkrc`, then the `.latexmkrc` setting
-        will have priority. The supported values of `$pdf_mode` are 0
-        (pdflatex), 4 (lualatex) and 5 (xelatex). See the latexmk
-        documentation for details.
+  Note: If the TeX program directive is not specified within the main project
+        file, and if `$pdf_mode` is added to `.latexmkrc`, then the compiler
+        engine will be deduced from the value of `$pdf_mode`. The supported
+        values of `$pdf_mode` are 0 (pdflatex), 4 (lualatex) and 5 (xelatex).
+        See the latexmk documentation for details.
 
   Default value: >
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -799,6 +799,11 @@ Options~
   compiler engine. This is used by |vimtex-latexmk| to define the LaTeX
   program. The `_` key defines the default engine.
 
+  Note: If `$pdf_mode` is added to `.latexmkrc`, then the `.latexmkrc` setting
+        will have priority. The supported values of `$pdf_mode` are 0
+        (pdflatex), 4 (lualatex) and 5 (xelatex). See the latexmk
+        documentation for details.
+
   Default value: >
 
     let g:vimtex_compiler_latexmk_engines = {

--- a/test/features/latexmk-pdfmode/latexmkrc
+++ b/test/features/latexmk-pdfmode/latexmkrc
@@ -1,0 +1,1 @@
+$pdf_mode = 4;  # compile with lualatex

--- a/test/features/latexmk-pdfmode/main.tex
+++ b/test/features/latexmk-pdfmode/main.tex
@@ -1,0 +1,9 @@
+% The following TeX program directive is not consistent with the value of
+% $pdf_mode in latexmkrc, therefore a warning message is expected.
+
+%! TEX program = xelatex
+
+\documentclass{minimal}
+\begin{document}
+Hello world!
+\end{document}


### PR DESCRIPTION
This PR adds support for parsing the `$pdf_mode` variable in a latexmkrc file, in a similar way as it was already done with the `$out_dir` variable.

Previously, the value of `$pdf_mode` was ignored by vimtex. In particular, when `$pdf_mode` was set and a TeX directive was *not* given, vimtex would use the default latexmk engine (the value of `g:vimtex_compiler_latexmk_engines['_']`, by default `-pdf`, i.e. pdflatex) instead of `$pdf_mode`. This is probably not the outcome expected by the user, especially if they had not set the default latexmk engine explicitly.

The value of `$pdf_mode` now has priority over TeX directives found in the source files, and a warning is shown if both values are given and are inconsistent (in the same way as it was already done with `build_dir / $out_dir`).

I tried to follow the existent code convention and the `CONTRIBUTING.md` file, but there may be better ways to implement this PR, in particular because I'm not very fluent in vimscript.

I also added a small test associated to the PR. I'm not sure if the location of the test files is the best, so feel free to (re)move them as needed.