### PR TITLE
activate skim after VimtexView

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -224,6 +224,7 @@ function! vimtex#init_options() " {{{1
   call s:init_option('vimtex_view_mupdf_options', '')
   call s:init_option('vimtex_view_mupdf_send_keys', '')
   call s:init_option('vimtex_view_skim_activate', 0)
+  call s:init_option('vimtex_view_skim_reading_bar', 1)
   call s:init_option('vimtex_view_zathura_options', '')
 endfunction
 

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -223,6 +223,7 @@ function! vimtex#init_options() " {{{1
   call s:init_option('vimtex_view_general_options_latexmk', '')
   call s:init_option('vimtex_view_mupdf_options', '')
   call s:init_option('vimtex_view_mupdf_send_keys', '')
+  call s:init_option('vimtex_view_skim_activate', 0)
   call s:init_option('vimtex_view_zathura_options', '')
 endfunction
 

--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -41,10 +41,6 @@ function! s:skim.view(file) dict " {{{1
   endif
   if vimtex#view#common#not_readable(outfile) | return | endif
 
-  let l:activate = ''
-  if g:vimtex_view_skim_activate
-    let l:activate = '-e ''activate'''
-  endif
   let l:cmd = join([
         \ 'osascript',
         \ '-e ''set theLine to ' . line('.') . ' as integer''',
@@ -58,8 +54,8 @@ function! s:skim.view(file) dict " {{{1
         \ '-e ''end try''',
         \ '-e ''open theFile''',
         \ '-e ''tell front document to go to TeX line theLine from theSource',
-        \ '     showing reading bar true''',
-        \ l:activate,
+        \ g:vimtex_view_skim_reading_bar ? 'showing reading bar true''' : '''',
+        \ g:vimtex_view_skim_activate ? '-e ''activate''' : '',
         \ '-e ''end tell''',
         \])
 
@@ -94,7 +90,6 @@ function! s:skim.compiler_callback(status) dict " {{{1
         \ '-e ''open theFile''',
         \ '-e ''end tell''',
         \])
-
 
   let self.process = vimtex#process#start(l:cmd)
 

--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -41,23 +41,42 @@ function! s:skim.view(file) dict " {{{1
   endif
   if vimtex#view#common#not_readable(outfile) | return | endif
 
-  let l:cmd = join([
-        \ 'osascript',
-        \ '-e ''set theLine to ' . line('.') . ' as integer''',
-        \ '-e ''set theFile to POSIX file "' . outfile . '"''',
-        \ '-e ''set thePath to POSIX path of (theFile as alias)''',
-        \ '-e ''set theSource to POSIX file "' . expand('%:p') . '"''',
-        \ '-e ''tell application "Skim"''',
-        \ '-e ''try''',
-        \ '-e ''set theDocs to get documents whose path is thePath''',
-        \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
-        \ '-e ''end try''',
-        \ '-e ''open theFile''',
-        \ '-e ''tell front document to go to TeX line theLine from theSource',
-        \ '     showing reading bar true''',
-        \ '-e ''activate''',
-        \ '-e ''end tell''',
-        \])
+  if !g:vimtex_view_skim_activate
+    let l:cmd = join([
+          \ 'osascript',
+          \ '-e ''set theLine to ' . line('.') . ' as integer''',
+          \ '-e ''set theFile to POSIX file "' . outfile . '"''',
+          \ '-e ''set thePath to POSIX path of (theFile as alias)''',
+          \ '-e ''set theSource to POSIX file "' . expand('%:p') . '"''',
+          \ '-e ''tell application "Skim"''',
+          \ '-e ''try''',
+          \ '-e ''set theDocs to get documents whose path is thePath''',
+          \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
+          \ '-e ''end try''',
+          \ '-e ''open theFile''',
+          \ '-e ''tell front document to go to TeX line theLine from theSource',
+          \ '     showing reading bar true''',
+          \ '-e ''end tell''',
+          \])
+  else
+    let l:cmd = join([
+          \ 'osascript',
+          \ '-e ''set theLine to ' . line('.') . ' as integer''',
+          \ '-e ''set theFile to POSIX file "' . outfile . '"''',
+          \ '-e ''set thePath to POSIX path of (theFile as alias)''',
+          \ '-e ''set theSource to POSIX file "' . expand('%:p') . '"''',
+          \ '-e ''tell application "Skim"''',
+          \ '-e ''try''',
+          \ '-e ''set theDocs to get documents whose path is thePath''',
+          \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
+          \ '-e ''end try''',
+          \ '-e ''open theFile''',
+          \ '-e ''tell front document to go to TeX line theLine from theSource',
+          \ '     showing reading bar true''',
+          \ '-e ''activate''',
+          \ '-e ''end tell''',
+          \])
+  endif
 
   let self.process = vimtex#process#start(l:cmd)
 
@@ -90,6 +109,7 @@ function! s:skim.compiler_callback(status) dict " {{{1
         \ '-e ''open theFile''',
         \ '-e ''end tell''',
         \])
+
   
   let self.process = vimtex#process#start(l:cmd)
 

--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -55,6 +55,7 @@ function! s:skim.view(file) dict " {{{1
         \ '-e ''open theFile''',
         \ '-e ''tell front document to go to TeX line theLine from theSource',
         \ '     showing reading bar true''',
+        \ '-e ''activate''',
         \ '-e ''end tell''',
         \])
 

--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -11,7 +11,7 @@ function! vimtex#view#skim#new() " {{{1
         \ '''tell application "Finder" to POSIX path of ',
         \ '(get application file id (id of application "Skim") as alias)''',
         \])
-  
+
   if system(l:cmd)
     call vimtex#log#error('Skim is not installed!')
     return {}
@@ -41,42 +41,27 @@ function! s:skim.view(file) dict " {{{1
   endif
   if vimtex#view#common#not_readable(outfile) | return | endif
 
-  if !g:vimtex_view_skim_activate
-    let l:cmd = join([
-          \ 'osascript',
-          \ '-e ''set theLine to ' . line('.') . ' as integer''',
-          \ '-e ''set theFile to POSIX file "' . outfile . '"''',
-          \ '-e ''set thePath to POSIX path of (theFile as alias)''',
-          \ '-e ''set theSource to POSIX file "' . expand('%:p') . '"''',
-          \ '-e ''tell application "Skim"''',
-          \ '-e ''try''',
-          \ '-e ''set theDocs to get documents whose path is thePath''',
-          \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
-          \ '-e ''end try''',
-          \ '-e ''open theFile''',
-          \ '-e ''tell front document to go to TeX line theLine from theSource',
-          \ '     showing reading bar true''',
-          \ '-e ''end tell''',
-          \])
-  else
-    let l:cmd = join([
-          \ 'osascript',
-          \ '-e ''set theLine to ' . line('.') . ' as integer''',
-          \ '-e ''set theFile to POSIX file "' . outfile . '"''',
-          \ '-e ''set thePath to POSIX path of (theFile as alias)''',
-          \ '-e ''set theSource to POSIX file "' . expand('%:p') . '"''',
-          \ '-e ''tell application "Skim"''',
-          \ '-e ''try''',
-          \ '-e ''set theDocs to get documents whose path is thePath''',
-          \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
-          \ '-e ''end try''',
-          \ '-e ''open theFile''',
-          \ '-e ''tell front document to go to TeX line theLine from theSource',
-          \ '     showing reading bar true''',
-          \ '-e ''activate''',
-          \ '-e ''end tell''',
-          \])
+  let l:activate = ''
+  if g:vimtex_view_skim_activate
+    let l:activate = '-e ''activate'''
   endif
+  let l:cmd = join([
+        \ 'osascript',
+        \ '-e ''set theLine to ' . line('.') . ' as integer''',
+        \ '-e ''set theFile to POSIX file "' . outfile . '"''',
+        \ '-e ''set thePath to POSIX path of (theFile as alias)''',
+        \ '-e ''set theSource to POSIX file "' . expand('%:p') . '"''',
+        \ '-e ''tell application "Skim"''',
+        \ '-e ''try''',
+        \ '-e ''set theDocs to get documents whose path is thePath''',
+        \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
+        \ '-e ''end try''',
+        \ '-e ''open theFile''',
+        \ '-e ''tell front document to go to TeX line theLine from theSource',
+        \ '     showing reading bar true''',
+        \ l:activate,
+        \ '-e ''end tell''',
+        \])
 
   let self.process = vimtex#process#start(l:cmd)
 
@@ -110,7 +95,7 @@ function! s:skim.compiler_callback(status) dict " {{{1
         \ '-e ''end tell''',
         \])
 
-  
+
   let self.process = vimtex#process#start(l:cmd)
 
   if has_key(self, 'hook_callback')

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2054,7 +2054,8 @@ Options~
   Default value: ''
 
 *g:vimtex_view_skim_activate*
-  Use this option to enable/disable activate skim after VimtexView.
+  Set this option to 1 make Skim have focus after commond :VimtexView in
+  addition to being moved to the foreground.
 
   Default value: 0
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2060,7 +2060,8 @@ Options~
   Default value: 0
 
 *g:vimtex_view_skim_reading_bar*
-  Set this option to 0 to hidden reading bar after command |:VimtexView|.
+  Set this option to 1 to highlight current line in PDF after command
+  |:VimtexView|.
 
   Default value: 1
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2053,6 +2053,11 @@ Options~
 
   Default value: ''
 
+*g:vimtex_view_skim_activate*
+  Use this option to enable/disable activate skim after VimtexView.
+
+  Default value: 0
+
 *g:vimtex_view_zathura_options*
   Set options for zathura (|vimtex_viewer_zathura|).
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2054,10 +2054,15 @@ Options~
   Default value: ''
 
 *g:vimtex_view_skim_activate*
-  Set this option to 1 make Skim have focus after commond :VimtexView in
+  Set this option to 1 to make Skim have focus after command |:VimtexView| in
   addition to being moved to the foreground.
 
   Default value: 0
+
+*g:vimtex_view_skim_reading_bar*
+  Set this option to 0 to hidden reading bar after command |:VimtexView|.
+
+  Default value: 1
 
 *g:vimtex_view_zathura_options*
   Set options for zathura (|vimtex_viewer_zathura|).


### PR DESCRIPTION
As I said in [Issue #1177](https://github.com/lervag/vimtex/issues/1177), activating skim after pressing \lv should be the default setting. Because skim have been able to update automatically after saving, the skim should always be expected to be focused after pressing \lv for forward search. I will pull a request for this setting.