### PR TITLE
Try has('mac') before system('uname') =~# 'Darwin'

### DIFF
--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -22,7 +22,7 @@ function! vimtex#util#get_os() " {{{1
   if has('win32') || has('win32unix')
     return 'win'
   elseif has('unix')
-    if system('uname') =~# 'Darwin'
+    if has('mac') || system('uname') =~# 'Darwin'
       return 'mac'
     else
       return 'linux'


### PR DESCRIPTION
has('mac') returns true for MacVim and vim installed via homebrew .
This is faster than invoking system('uname') and improves init time
of vimtex for them.