### PR TITLE
Autoclose the QuickFix window (default: off)

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -189,6 +189,7 @@ function! vimtex#init_options() " {{{1
   call s:init_option('vimtex_quickfix_mode', '2')
   call s:init_option('vimtex_quickfix_open_on_warning', '1')
   call s:init_option('vimtex_quickfix_blgparser', {})
+  call s:init_option('vimtex_quickfix_autoclose_after_keystrokes', '0')
 
   call s:init_option('vimtex_texcount_custom_arg', '')
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1559,6 +1559,17 @@ Options~
 
   Default value: 2
 
+*g:vimtex_quickfix_autoclose_after_keystrokes*
+  If set to value greater than zero, then the quickfix window will close after
+  this number of motions (i.e. |CursorMoved| and |CursorMovedI| events). This
+  is most useful if one sets |g:vimtex_quickfix_mode| to 2, in which case this
+  option allows one to continue editing and removing the distraction of the
+  quickfix window automatically.
+
+  Note: The count is reset when the quickfix window is entered.
+
+  Default value: 0
+
 *g:vimtex_quickfix_open_on_warning*
   Control whether or not to automatically open the |quickfix| window in case
   there are warning messages and no error messages.


### PR DESCRIPTION
The integer option `g:vimtex_quickfix_autoclose_after_keystrokes` sets
the initial number for a countdown of cumulative movements, edits, etc,
at the end of which the QuickFix window automatically closes if the user
has not jumped into it. The countdown is only paused: if the user jumps
back out of the QuickFix window, the countdown continues. The described
behavior does not depend on `g:vimtex_quickfix_mode`. The new option is
off by default (`g:vimtex_quickfix_autoclose_after_keystrokes == -1`).

The countdown is delegated to the new function
`s:qf_check_editing_persistence`, which is called by an `autocmd`
defined in an `augroup`, the latter created whenever the QuickFix window
is opened and deleted by the aforementioned function itself when the
countdown reaches zero (_i.e._ when the QuickFix autocloses).

The triggering events are maybe redundant and should be trimmed.