### PR TITLE
Fix `csc` command broken when new name is very short

### DIFF
--- a/autoload/vimtex/pos.vim
+++ b/autoload/vimtex/pos.vim
@@ -5,7 +5,7 @@
 "
 
 function! vimtex#pos#set_cursor(...) " {{{1
-  call cursor(s:parse_args(a:000))
+  call cursor(map(s:parse_args(a:000), 'v:val < 0 ? 0 : v:val'))
 endfunction
 
 " }}}1


### PR DESCRIPTION
Consider this minimal `vimrc`:

    set rtp^=/path/to/vimtex
    set rtp+=/path/to/vimtex/after
    filetype plugin indent on

And this tex file:

    \usepackage[utf8]{inputenc}

Press `csc` to change the command while your cursor is on the first character of the line.  
Insert `a` while the plugin asks for your input, and press Enter to validate.  
The following error is raised:

    > aError detected while processing function vimtex#cmd#change[31]..vimtex#pos#set_cursor:
    line    1:
    E474: Invalid argument

![gif](https://user-images.githubusercontent.com/8505073/46704566-e5735100-cc2b-11e8-864e-2d760ede83be.gif)


The issue seems to be influenced by several factors, including the cursor position on the command name, and the length of the user's input. Depending on those factors, the error may or may not be raised.  
However, if you prefix `csc` with a count, the error is always raised.  
I think it's due to the `vimtex#pos#set_cursor()` function which calls the `cursor()` function.  
Sometimes, the byte index of the column position in the list passed as an argument may be negative.

This PR tries to make sure it's reset to `0` when that happens.  
In my limited testing, it seems to fix the issue.  

I use `map()` to reset any negative number to `0`, because:

 - I had various errors, sometimes the negative number was in the 2nd position in the list, sometimes in the 3rd (I could be wrong about the exact positions, but they vary)
 - I don't think any negative number makes sense in a list describing a position in a buffer
