### PR TITLE
Remove `vim-repeat` dependency to fix issue #1238

### DIFF
--- a/autoload/vimtex/cmd.vim
+++ b/autoload/vimtex/cmd.vim
@@ -230,12 +230,12 @@ endfunction
 function! s:setup_operator(operator) abort " {{{1
   let &opfunc = s:snr() . 'opfunc'
   let s:operator = a:operator
-  if s:operator isnot# 'change' && s:operator isnot# 'create_ask' | return | endif
-  if s:operator is# 'change' && empty(vimtex#cmd#get_current()) | return | endif
+  if s:operator !=# 'change' && s:operator !=# 'create_ask' | return | endif
+  if s:operator ==# 'change' && empty(vimtex#cmd#get_current()) | return | endif
   let s:cmd_name_{a:operator} = vimtex#echo#input({
         \ 'info' : ['Change command: ',
         \   ['VimtexWarning',
-        \     a:operator is# 'change' ? vimtex#cmd#get_current().name : '(empty to cancel)']],
+        \     a:operator ==# 'change' ? vimtex#cmd#get_current().name : '(empty to cancel)']],
         \})
   let s:cmd_name_{a:operator} = substitute(s:cmd_name_{a:operator}, '^\\', '', '')
 endfunction

--- a/autoload/vimtex/cmd.vim
+++ b/autoload/vimtex/cmd.vim
@@ -228,7 +228,7 @@ endfunction
 " }}}1
 
 function! s:setup_operator(operator) abort " {{{1
-  let &opfunc = s:snr().'opfunc'
+  let &opfunc = s:snr() . 'opfunc'
   let s:operator = a:operator
   if s:operator isnot# 'change' && s:operator isnot# 'create_ask' | return | endif
   if s:operator is# 'change' && empty(vimtex#cmd#get_current()) | return | endif
@@ -242,7 +242,7 @@ endfunction
 
 " }}}1
 function! s:opfunc(_) abort " {{{1
-  execute 'call vimtex#cmd#'.{
+  execute 'call vimtex#cmd#' . {
         \   'change': 'change(get(s:, "cmd_name_change", ""))',
         \   'create_ask': 'create_ask(0)',
         \   'delete': 'delete()',

--- a/autoload/vimtex/delim.vim
+++ b/autoload/vimtex/delim.vim
@@ -222,7 +222,7 @@ endfunction
 " }}}1
 function! s:opfunc(_) abort " {{{1
   if s:operator ==# 'toggle_modifier'
-    call vimtex#delim#toggle_modifier[s:toggle_modifier_dir]
+    call vimtex#delim#toggle_modifier(s:toggle_modifier_dir)
   else
     execute 'call vimtex#delim#'
           \ . {'change': 'change(get(s:, "new_delim", ""))',

--- a/autoload/vimtex/delim.vim
+++ b/autoload/vimtex/delim.vim
@@ -6,10 +6,12 @@
 
 function! vimtex#delim#init_buffer() " {{{1
   nnoremap <silent><buffer> <plug>(vimtex-delim-toggle-modifier)
-        \ :<c-u>call vimtex#delim#toggle_modifier()<cr>
+        \ :<c-u>call <sid>setup_operator('toggle_modifier')
+        \ <bar> normal! <c-r>=v:count ? v:count : ''<cr>g@l<cr>
 
   nnoremap <silent><buffer> <plug>(vimtex-delim-toggle-modifier-reverse)
-        \ :<c-u>call vimtex#delim#toggle_modifier({'dir': -1})<cr>
+        \ :<c-u>call <sid>setup_operator('toggle_modifier', {'dir': -1})
+        \ <bar> normal! <c-r>=v:count ? v:count : ''<cr>g@l<cr>
 
   xnoremap <silent><buffer> <plug>(vimtex-delim-toggle-modifier)
         \ :<c-u>call vimtex#delim#toggle_modifier_visual()<cr>
@@ -18,10 +20,10 @@ function! vimtex#delim#init_buffer() " {{{1
         \ :<c-u>call vimtex#delim#toggle_modifier_visual({'dir': -1})<cr>
 
   nnoremap <silent><buffer> <plug>(vimtex-delim-change-math)
-        \ :call vimtex#delim#change()<cr>
+        \ :<c-u>call <sid>setup_operator('change')<bar>normal! g@l<cr>
 
   nnoremap <silent><buffer> <plug>(vimtex-delim-delete)
-        \ :call vimtex#delim#delete()<cr>
+        \ :<c-u>call <sid>setup_operator('delete')<bar>normal! g@l<cr>
 
   inoremap <silent><buffer> <plug>(vimtex-delim-close)
         \ <c-r>=vimtex#delim#close()<cr>
@@ -118,11 +120,6 @@ function! vimtex#delim#toggle_modifier(...) " {{{1
         \ . strpart(line, l:cnum + len(l:close.mod) - 1)
   call setline(l:close.lnum, line)
 
-  if l:args.repeat
-    silent! call repeat#set("\<plug>(vimtex-delim-toggle-modifier"
-          \ . (l:direction < 0 ? '-reverse' : '') .')', l:args.count)
-  endif
-
   return newmods
 endfunction
 
@@ -202,6 +199,46 @@ endfunction
 
 " }}}1
 
+function! s:setup_operator(operator, ...) abort " {{{1
+  let &opfunc = s:snr().'opfunc'
+  let s:operator = a:operator
+  if s:operator is# 'toggle_modifier'
+    let s:toggle_modifier_dir = a:0 ? a:1 : {}
+  elseif s:operator is# 'change'
+    let [l:open, l:close] = vimtex#delim#get_surrounding('delim_math')
+    if empty(l:open) | return | endif
+    let l:name = get(l:open, 'name', l:open.is_open
+          \ ? l:open.match . ' ... ' . l:open.corr
+          \ : l:open.match . ' ... ' . l:open.corr)
+
+    let s:new_delim = vimtex#echo#input({
+          \ 'info' :
+          \   ['Change surrounding delimiter: ', ['VimtexWarning', l:name]],
+          \ 'complete' : 'customlist,vimtex#delim#change_input_complete',
+          \})
+  endif
+endfunction
+
+" }}}1
+function! s:opfunc(_) abort " {{{1
+  if s:operator is# 'toggle_modifier'
+    call call('vimtex#delim#toggle_modifier', [s:toggle_modifier_dir])
+  else
+  execute 'call vimtex#delim#'
+        \ .{'change': 'change(get(s:, "new_delim", ""))',
+        \   'delete': 'delete()',
+        \   'toggle_modifier': 'toggle_modifier()',
+        \ }[s:operator]
+  endif
+endfunction
+
+" }}}1
+function! s:snr() " {{{1
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+endfunction
+
+" }}}1
+
 function! vimtex#delim#change(...) " {{{1
   let [l:open, l:close] = vimtex#delim#get_surrounding('delim_math')
   if empty(l:open) | return | endif
@@ -267,13 +304,6 @@ function! vimtex#delim#change_with_args(open, close, new) " {{{1
   let l:line = getline(a:close.lnum)
   call setline(a:close.lnum,
         \ strpart(l:line, 0, l:c1-1) . l:end . strpart(l:line, l:c2))
-
-  if a:new ==# ''
-    silent! call repeat#set("\<plug>(vimtex-delim-delete)", v:count)
-  else
-    silent! call repeat#set(
-          \ "\<plug>(vimtex-delim-change-math)" . a:new . '', v:count)
-  endif
 endfunction
 
 " }}}1

--- a/autoload/vimtex/delim.vim
+++ b/autoload/vimtex/delim.vim
@@ -202,9 +202,9 @@ endfunction
 function! s:setup_operator(operator, ...) abort " {{{1
   let &opfunc = s:snr() . 'opfunc'
   let s:operator = a:operator
-  if s:operator is# 'toggle_modifier'
+  if s:operator ==# 'toggle_modifier'
     let s:toggle_modifier_dir = a:0 ? a:1 : {}
-  elseif s:operator is# 'change'
+  elseif s:operator ==# 'change'
     let [l:open, l:close] = vimtex#delim#get_surrounding('delim_math')
     if empty(l:open) | return | endif
     let l:name = get(l:open, 'name', l:open.is_open
@@ -221,7 +221,7 @@ endfunction
 
 " }}}1
 function! s:opfunc(_) abort " {{{1
-  if s:operator is# 'toggle_modifier'
+  if s:operator ==# 'toggle_modifier'
     call vimtex#delim#toggle_modifier[s:toggle_modifier_dir]
   else
     execute 'call vimtex#delim#'

--- a/autoload/vimtex/delim.vim
+++ b/autoload/vimtex/delim.vim
@@ -200,7 +200,7 @@ endfunction
 " }}}1
 
 function! s:setup_operator(operator, ...) abort " {{{1
-  let &opfunc = s:snr().'opfunc'
+  let &opfunc = s:snr() . 'opfunc'
   let s:operator = a:operator
   if s:operator is# 'toggle_modifier'
     let s:toggle_modifier_dir = a:0 ? a:1 : {}
@@ -222,13 +222,13 @@ endfunction
 " }}}1
 function! s:opfunc(_) abort " {{{1
   if s:operator is# 'toggle_modifier'
-    call call('vimtex#delim#toggle_modifier', [s:toggle_modifier_dir])
+    call vimtex#delim#toggle_modifier[s:toggle_modifier_dir]
   else
-  execute 'call vimtex#delim#'
-        \ .{'change': 'change(get(s:, "new_delim", ""))',
-        \   'delete': 'delete()',
-        \   'toggle_modifier': 'toggle_modifier()',
-        \ }[s:operator]
+    execute 'call vimtex#delim#'
+          \ . {'change': 'change(get(s:, "new_delim", ""))',
+          \   'delete': 'delete()',
+          \   'toggle_modifier': 'toggle_modifier()',
+          \ }[s:operator]
   endif
 endfunction
 

--- a/autoload/vimtex/env.vim
+++ b/autoload/vimtex/env.vim
@@ -132,7 +132,7 @@ function! s:setup_operator(operator, type) abort " {{{1
     if empty(l:new_env) | return | endif
     let s:new_env = l:new_env
   endif
-  let &opfunc = s:snr().'opfunc'
+  let &opfunc = s:snr() . 'opfunc'
 endfunction
 
 " }}}1

--- a/autoload/vimtex/env.vim
+++ b/autoload/vimtex/env.vim
@@ -127,7 +127,7 @@ endfunction
 
 function! s:setup_operator(operator, type) abort " {{{1
   let [s:operator, s:type] = [a:operator, a:type]
-  if s:operator is# 'change'
+  if s:operator ==# 'change'
     let l:new_env = vimtex#env#change_prompt(s:type)
     if empty(l:new_env) | return | endif
     let s:new_env = l:new_env
@@ -137,7 +137,7 @@ endfunction
 
 " }}}1
 function! s:opfunc(_) abort " {{{1
-  call call('vimtex#env#' . s:operator, s:operator is# 'delete' ? [s:type] : [])
+  call call('vimtex#env#' . s:operator, s:operator ==# 'delete' ? [s:type] : [])
 endfunction
 
 " }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -322,17 +322,16 @@ Manipulate surrounding commands/delimiters/environments~
   `""`, `()`, `[]`, `{}`, and `<>`.  As such, the mappings from vimtex
   should work well together with, and as an extension of, `surround.vim`.
   Consider also the customization described under |vimtex-faq-surround|.
-  The mappings may be repeated with the dot mapping |.| if one has
-  `vim-repeat` [1].
+  The mappings may be repeated with the dot command |.|.
 
-  A different possibility is to use `vim-sandwich` [2] (|sandwich.txt|) by
+  A different possibility is to use `vim-sandwich` [1] (|sandwich.txt|) by
   Machakann, which may be considered a generalisation of `surround.vim` in
   that it can handle much more complex sets of delimiters.  `vim-sandwich`
   is relatively easy to expand with custom surroundings and has built in
   support for LaTeX-specific surroundings such as quotations, ```text''`,
   and math delimiters, `$\left(a+b\right)$`.  For a list of supported
-  delimiters, see |sandwich-filetype-recipes|.  `vim-sandwich` also supports
-  `vim-repeat` in addition to `visualrepeat.vim` [3].
+  delimiters, see |sandwich-filetype-recipes|.  `vim-sandwich` supports
+  `vim-repeat` [2] in addition to `visualrepeat.vim` [3].
 
   Note: The default mappings of `vim-sandwich` differ from those of
     `surround.vim`, in that the use `s` as the prefix.  E.g., to add
@@ -347,8 +346,8 @@ Manipulate surrounding commands/delimiters/environments~
     |sandwich.txt|, |operator-sandwich.txt|, and |textobj-sandwich.txt|.
 
   [0]: https://github.com/tpope/vim-surround
-  [1]: https://github.com/tpope/vim-repeat
-  [2]: https://github.com/machakann/vim-sandwich
+  [1]: https://github.com/machakann/vim-sandwich
+  [2]: https://github.com/tpope/vim-repeat
   [3]: http://www.vim.org/scripts/script.php?script_id=3848
 
 Enhanced matching and higlighting of delimiters~

--- a/test/vader/cmd.vader
+++ b/test/vader/cmd.vader
@@ -11,8 +11,8 @@ Expect tex (Cmd: verify):
   foobar
   foo
 
-Do (Cmd: dsc):
-  dsc
+Execute (Cmd: dsc):
+  execute "normal dsc"
 
 Expect tex (Cmd: verify):
   foo

--- a/test/vader/delims.vader
+++ b/test/vader/delims.vader
@@ -4,8 +4,8 @@ Given tex (Delims: toggle in complicated math):
          & 1 \\
   \end{smallmatrix}\bigr)$
 
-Do (Toggle):
-  3jtsd
+Execute (Toggle):
+  execute 'normal 3jtsd'
 
 Expect tex (Verify):
   $(\begin{smallmatrix}

--- a/test/vader/env.vader
+++ b/test/vader/env.vader
@@ -15,8 +15,8 @@ Given tex (Environments: foo and bar):
     Bar
   \end{bar}
 
-Do (Change env: foo -> baz):
-  csebaz\<cr>
+Execute (Change env: foo -> baz):
+  execute "normal csebaz\<cr>"
 
 Expect tex (Verify):
   \begin{baz}
@@ -27,8 +27,8 @@ Expect tex (Verify):
     Bar
   \end{bar}
 
-Do (Change env: foo -> bar (with completion)):
-  cse\<c-z>\<c-z>\<c-z>\<cr>
+Execute (Change env: foo -> bar (with completion)):
+  execute "normal cse\<c-z>\<c-z>\<c-z>\<cr>"
 
 Expect tex (Verify):
   \begin{bar}
@@ -47,8 +47,8 @@ Given tex (Environments: test and center):
     \begin{center} a \end{center}
   \end{test}
 
-Do (Delete env: test and center):
-  dsedse
+Execute (Delete env: test and center):
+  execute 'normal dsedse'
 
 Expect tex (Verify):
      a 


### PR DESCRIPTION
## Introduction

This PR tries to eliminate `vim-repeat` as a dependency, in order to fix the [issue 1238](https://github.com/lervag/vimtex/issues/1238).  It affects these `<plug>` key sequences used as a lhs in some mappings:

| <plug> key sequence                            | mapped by default to | installed in file         |
| -----------------------------------------------|----------------------|---------------------------|
| `<plug>(vimtex-cmd-change)`                    | `csc`                | autoload/vimtex/cmd.vim   |
| `<plug>(vimtex-cmd-delete)`                    | `dsc`                | autoload/vimtex/cmd.vim   |
| `<plug>(vimtex-cmd-create)`                    | `F7`                 | autoload/vimtex/cmd.vim   |
| `<plug>(vimtex-cmd-toggle-star)`               | `tsc`                | autoload/vimtex/cmd.vim   |
| <br>                                           |                      |                           |
| `<plug>(vimtex-delim-toggle-modifier)`         |  `tsd`               | autoload/vimtex/delim.vim |
| `<plug>(vimtex-delim-toggle-modifier-reverse)` |  `tsD`               | autoload/vimtex/delim.vim |
| `<plug>(vimtex-delim-delete)`                  |  `dsd`               | autoload/vimtex/delim.vim |
| `<plug>(vimtex-delim-change-math)`             |  `csd`               | autoload/vimtex/delim.vim |
| <br>                                           |                      |                           |
| `<plug>(vimtex-env-delete)`                    | `dse`                | autoload/vimtex/env.vim   |
| `<plug>(vimtex-env-delete-math)`               | `ds$`                | autoload/vimtex/env.vim   |
| `<plug>(vimtex-env-toggle-star)`               | `tse`                | autoload/vimtex/env.vim   |
| `<plug>(vimtex-env-change)`                    | `cse`                | autoload/vimtex/env.vim   |
| `<plug>(vimtex-env-change-math)`               | `cs$`                | autoload/vimtex/env.vim   |

---

I've tried to respect the style of the original code (indentation level, explicit `l:` scope, full name of commands, folding markers ...), but I may have missed something.

There may be too much code, and even though I made some manual tests, I'm not sure it's completely reliable, so feel free to close the PR if it can't be merged.

Some questions/answers about how the changes work in the following.

## Why executing `:normal` to press `g@l`?

IOW, why this:

```vim
nnoremap <silent><buffer> <plug>(vimtex-cmd-delete)
    \ :<c-u>call <sid>setup_operator('delete')<bar>normal! g@l<cr>
                                                   ^^^^^^^^^^^
```

Instead of this:

```vim
nnoremap <silent><buffer> <plug>(vimtex-cmd-delete)
    \ :<c-u>call <sid>setup_operator('delete')<cr>g@l
                                                  ^^^
```

Here, both versions work, but the second one won't work if `s:normal_mode()` calls `input()`. A MWE:

```vim
nno  cd  :<c-u>call Func()<cr>bbb
fu! Func() abort
    call input('>')
endfu
```

Press `cd`, and you'll see that `bbb` has been consumed by `input()` and inserted on the command-line, instead of being pressed.  But if you rewrite the mapping like this, it works as expected:

```vim
nno  cd  :<c-u>call Func()<bar>norm! bbb<cr>
fu! Func() abort
    call input('> ')
endfu
```

To stay consistent, I've always used the first version, even when it was not necessary, so that if you change the code later and add an `input()` somewhere, it won't consume `g@l`.

## Why changing `vimtex#cmd#create_ask()`?

Before, this function was called by pressing `F7` or the dot command. In both cases, it asked the user for a command name.

However, when the user pressed `.`, they didn't have to type anything on the input prompt because `repeat#set()` wrote the last command name input by the user inside the typeahead buffer, followed by a CR, and so `input()` consumed the latter automatically. As a result, the same function `create_ask()` could behave differently depending on how it was called without inspecting any variable.

I could write the command name in the typeahead buffer, but I would need to do it only when the user pressed the dot command. I don't know how to do that without remapping `.` which would lead to re-write `vim-repeat` and defeat the purpose of this PR.

So, I had to change the signature of `create_ask()` to pass it a second flag, that it can inspect to decide whether it should prompt the user for a command name. Note that not only does it fix the issue `#1238` but it also removes the brief display of the input prompt which may be distracting to some users.

## Do the commands support a count?

No they don't.

I could have added support for a count, but:

 - It would have added a lot of code/complexity.
 - In the [latest commit](https://github.com/lervag/vimtex/commit/34e2423391daf614123f618910eaaedcc60a10cd), you have prefixed some of the `:call` used in mappings with `C-u`, which kills the repetition of the called functions, and the latters don't inspect `v:count[1]`; so I assume you didn't intend these commands to support a count.
 - I've searched for the pattern `count` in `:h vimtex`, and couldn't find a match where the documentation was saying that the commands are meant to support a count.
 - Even if it's not strictly equivalent, one can still press `.` to repeat a command a few times.

## Why removing `vimtex#echo#input()` from `vimtex#cmd#change()`?

`vimtex#cmd#change()` must be called by an operator function (`s:opfunc()`) to be made dot repeatable. And, inside an opfunc, I don't know how to print a message, then prompt the user for some input, without the message being erased. The only way I found to maintain the old behavior of the command, was to move `input()` outside the opfunc.

MWE:

```vim
nno cd :set opfunc=Func<cr>g@l
fu! Func(_)
    echo 'question'
    let answer = input('>')
endfu
" Press `cd`.
" You'll only see the prompt (`>`), not the message (`question`).
```

I think the issue comes from Vim which, inside an operator function, automatically redraws before any command which prints a message (like `:echo`, or `:call input()`). I don't know how to prevent it. `:h echo-redraw` doesn't help here. Adding a `:redraw` before the call to `input()` doesn't prevent Vim from erasing the previous message.

Just as an experiment, I also tried to print 2 messages with 2 `:echo` from a timer:

```vim
" ✔
:echo 'foo' | echo 'bar'
"    → foo
"      bar

" ✘
:call timer_start(0, {-> execute('echo "foo" | echo "bar"', '')})
"    → bar
```

And it suffers from the same issue. Same thing from an autocmd:

```vim
augroup test_echo
    au!
    au CursorHold * call Func() | au! test_echo
augroup END
fu! Func()
    echo 'foo'
    echo 'bar'
endfu
" ✘ wait a few seconds, only 'bar' is printed
```

## Why removing `vimtex#env#change()` from `vimtex#env#change_prompt()`?

For the same reason as before, I need `input()` to be called from outside an opfunc. So, I call `vimtex#env#change_prompt()` from `s:setup_operator()` which is called before the opfunc, then the latter can call `vimtex#env#change()` to make the change.

## Why checking `a:0` in `vimtex#env#change()`?

Originally, `vimtex#env#change()` could be called by `vimtex#env#toggle_star()` and be passed 3 arguments. It's still the case. However, it could also be called by `vimtex#env#change_prompt()`. It's not the case anymore, because again, `input()` must be called from outside an opfunc. So, `s:setup_operator()` calls `vimtex#env#change_prompt()` to get the user's input, then later `vimtex#env#change()` is called to make the change. However, I can't pass the 3 arguments that `vimtex#env#change()` expected originally. I could pass the user input (`a:new`), but not the other 2 arguments (`a:open`, `a:close`), because, contrary to the input which can be re-used when `.` is pressed, those must be recomputed for every repeat.

To summarize, when `vimtex#env#change()` is called by `vimtex#env#toggle_star()`, it can be passed its original 3 arguments, but not when it's called by `vimtex#env#change_prompt()`. That's why the function must check `a:0` to determine from where it was called and get its arguments accordingly.
