### PR TITLE
Prioritize local mappings over global ones

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -399,7 +399,7 @@ function! s:init_default_mappings() " {{{1
     if !hasmapto(a:rhs, a:mode)
           \ && index(get(g:vimtex_mappings_disable, a:mode, []), a:lhs) < 0
           \ && (empty(maparg(a:lhs, a:mode)) || a:0 > 0)
-      silent execute a:mode . 'map <silent><buffer>' a:lhs a:rhs
+      silent execute a:mode . 'map <silent><nowait><buffer>' a:lhs a:rhs
     endif
   endfunction
 

--- a/autoload/vimtex/compiler.vim
+++ b/autoload/vimtex/compiler.vim
@@ -203,9 +203,9 @@ function! vimtex#compiler#output() " {{{1
   augroup END
 
   " Set some mappings
-  nnoremap <silent><buffer> q :bwipeout<cr>
+  nnoremap <silent><nowait><buffer> q :bwipeout<cr>
   if has('nvim') || has('gui_running')
-    nnoremap <silent><buffer> <esc> :bwipeout<cr>
+    nnoremap <silent><nowait><buffer> <esc> :bwipeout<cr>
   endif
 
   " Set some buffer options

--- a/autoload/vimtex/fold.vim
+++ b/autoload/vimtex/fold.vim
@@ -15,8 +15,8 @@ function! vimtex#fold#init_buffer() abort " {{{1
 
   if g:vimtex_fold_manual
     " Remap zx to refresh fold levels
-    nnoremap <silent><buffer> zx :call vimtex#fold#refresh('zx')<cr>
-    nnoremap <silent><buffer> zX :call vimtex#fold#refresh('zX')<cr>
+    nnoremap <silent><nowait><buffer> zx :call vimtex#fold#refresh('zx')<cr>
+    nnoremap <silent><nowait><buffer> zX :call vimtex#fold#refresh('zX')<cr>
 
     " Define commands
     command! -buffer VimtexRefreshFolds call vimtex#fold#refresh('zx')

--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -47,8 +47,8 @@ function! vimtex#imaps#list() " {{{1
   endfor
   0delete _
 
-  nnoremap <silent><buffer> q     :bwipeout<cr>
-  nnoremap <silent><buffer> <esc> :bwipeout<cr>
+  nnoremap <silent><nowait><buffer> q     :bwipeout<cr>
+  nnoremap <silent><nowait><buffer> <esc> :bwipeout<cr>
 
   setlocal bufhidden=wipe
   setlocal buftype=nofile
@@ -78,7 +78,7 @@ endfunction
 function! s:create_map(map) " {{{1
   let l:leader = get(a:map, 'leader', get(g:, 'vimtex_imaps_leader', '`'))
   if l:leader !=# '' && !hasmapto(l:leader, 'i')
-    silent execute 'inoremap <silent><buffer>' l:leader . l:leader l:leader
+    silent execute 'inoremap <silent><nowait><buffer>' l:leader . l:leader l:leader
   endif
   let l:lhs = l:leader . a:map.lhs
 
@@ -100,7 +100,7 @@ function! s:create_map(map) " {{{1
     let b:vimtex_context[l:key] = a:map.context
   endif
 
-  silent execute 'inoremap <expr><silent><buffer>' l:lhs
+  silent execute 'inoremap <expr><silent><nowait><buffer>' l:lhs
         \ l:wrapper . '("' . escape(l:lhs, '\') . '", ' . string(a:map.rhs) . ')'
 
   let s:created_maps += [a:map]

--- a/autoload/vimtex/misc.vim
+++ b/autoload/vimtex/misc.vim
@@ -93,7 +93,7 @@ function! vimtex#misc#wordcount_display(opts) abort " {{{1
   0delete _
 
   " Set mappings
-  nnoremap <buffer> <silent> q :bwipeout<cr>
+  nnoremap <buffer><nowait><silent> q :bwipeout<cr>
 
   " Set buffer options
   setlocal bufhidden=wipe

--- a/autoload/vimtex/scratch.vim
+++ b/autoload/vimtex/scratch.vim
@@ -36,11 +36,11 @@ function! s:scratch.open() abort dict " {{{1
   setlocal nowrap
   setlocal tabstop=8
 
-  nnoremap <silent><buffer> q     :call b:scratch.close()<cr>
-  nnoremap <silent><buffer> <esc> :call b:scratch.close()<cr>
-  nnoremap <silent><buffer> <c-6> :call b:scratch.close()<cr>
-  nnoremap <silent><buffer> <c-^> :call b:scratch.close()<cr>
-  nnoremap <silent><buffer> <c-e> :call b:scratch.close()<cr>
+  nnoremap <silent><nowait><buffer> q     :call b:scratch.close()<cr>
+  nnoremap <silent><nowait><buffer> <esc> :call b:scratch.close()<cr>
+  nnoremap <silent><nowait><buffer> <c-6> :call b:scratch.close()<cr>
+  nnoremap <silent><nowait><buffer> <c-^> :call b:scratch.close()<cr>
+  nnoremap <silent><nowait><buffer> <c-e> :call b:scratch.close()<cr>
 
   if has_key(self, 'syntax')
     call self.syntax()


### PR DESCRIPTION
Some local mappings have been given the `<nowait>` argument, but not all.

This PR tries to give it to all local mappings, so that in case of a conflict with a global mapping, the local one wins immediately, and the user doesn't have to wait for the timeout to pass.

I found these mappings with this `:vimgrep` command which looks for the pattern `<buffer>`:

    :vim /<buffer>/gj ~/.vim/plugged/vimtex/**/*.vim | cw

Then I filtered the results and removed the lines which matched the patterns `<nowait>`, `autocmd`, or `<buffer>\s*\%(<plug>\|<sid>\)` (because the only mappings which really seem to matter are the ones whose lhs can be pressed by the user):

    :Cfilter! <nowait>\|autocmd\|<buffer>\s*\%(<plug>\|<sid>\)

The `:Cfilter` command is provided by the default `cfilter` package loaded with `:packadd cfilter`.

Feel free to close the PR if `<nowait>` causes an issue.