### PR TITLE
Make functions abort immediately when an error is raised

### DIFF
--- a/autoload/health/vimtex.vim
+++ b/autoload/health/vimtex.vim
@@ -63,7 +63,7 @@ endfunction
 
 " }}}1
 
-function! s:check_plugin_clash() " {{{1
+function! s:check_plugin_clash() abort " {{{1
   let l:scriptnames = split(execute('scriptnames'), "\n")
 
   let l:latexbox = !empty(filter(copy(l:scriptnames), "v:val =~# 'latex-box'"))

--- a/autoload/unite/sources/vimtex.vim
+++ b/autoload/unite/sources/vimtex.vim
@@ -17,7 +17,7 @@ let s:source = {
       \ 'hooks' : {},
       \}
 
-function! s:source.gather_candidates(args, context) " {{{1
+function! s:source.gather_candidates(args, context) abort " {{{1
   if exists('b:vimtex')
     let s:source.entries = vimtex#parser#toc(b:vimtex.tex)
     let s:source.maxlevel = max(map(copy(s:source.entries), 'v:val.level'))
@@ -27,7 +27,7 @@ function! s:source.gather_candidates(args, context) " {{{1
 endfunction
 
 " }}}1
-function! s:source.hooks.on_syntax(args, context) " {{{1
+function! s:source.hooks.on_syntax(args, context) abort " {{{1
   syntax match VimtexTocSecs /.* @\d$/
         \ contains=VimtexTocNum,VimtexTocTag,@Tex
         \ contained containedin=uniteSource__vimtex
@@ -61,7 +61,7 @@ endfunction
 
 " }}}1
 
-function! s:create_candidate(entry, maxlevel) " {{{1
+function! s:create_candidate(entry, maxlevel) abort " {{{1
   let level = a:maxlevel - a:entry.level
   let title = printf('%-65S%-10s',
         \ strpart(repeat(' ', 2*level) . a:entry.title, 0, 60),
@@ -76,7 +76,7 @@ endfunction
 
 " }}}1
 
-function! unite#sources#vimtex#define()
+function! unite#sources#vimtex#define() abort
   return s:source
 endfunction
 

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#init() " {{{1
+function! vimtex#init() abort " {{{1
   call vimtex#init_options()
 
   call s:init_highlights()
@@ -23,7 +23,7 @@ function! vimtex#init() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#init_options() " {{{1
+function! vimtex#init_options() abort " {{{1
   call s:init_option('vimtex_compiler_enabled', 1)
   call s:init_option('vimtex_compiler_method', 'latexmk')
   call s:init_option('vimtex_compiler_progname',
@@ -252,7 +252,7 @@ function! vimtex#init_options() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#check_plugin_clash() " {{{1
+function! vimtex#check_plugin_clash() abort " {{{1
   let l:scriptnames = vimtex#util#command('scriptnames')
 
   let l:latexbox = !empty(filter(copy(l:scriptnames), "v:val =~# 'latex-box'"))
@@ -274,7 +274,7 @@ endfunction
 
 " }}}1
 
-function! s:init_option(option, default) " {{{1
+function! s:init_option(option, default) abort " {{{1
   let l:option = 'g:' . a:option
   if !exists(l:option)
     let {l:option} = a:default
@@ -284,7 +284,7 @@ function! s:init_option(option, default) " {{{1
 endfunction
 
 " }}}1
-function! s:init_highlights() " {{{1
+function! s:init_highlights() abort " {{{1
   for [l:name, l:target] in [
         \ ['VimtexImapsArrow', 'Comment'],
         \ ['VimtexImapsLhs', 'ModeMsg'],
@@ -325,13 +325,13 @@ function! s:init_highlights() " {{{1
 endfunction
 
 " }}}1
-function! s:init_state() " {{{1
+function! s:init_state() abort " {{{1
   call vimtex#state#init()
   call vimtex#state#init_local()
 endfunction
 
 " }}}1
-function! s:init_buffer() " {{{1
+function! s:init_buffer() abort " {{{1
   " Set Vim options
   for l:suf in [
         \ '.sty',
@@ -392,10 +392,10 @@ function! s:init_buffer() " {{{1
 endfunction
 
 " }}}1
-function! s:init_default_mappings() " {{{1
+function! s:init_default_mappings() abort " {{{1
   if !g:vimtex_mappings_enabled | return | endif
 
-  function! s:map(mode, lhs, rhs, ...)
+  function! s:map(mode, lhs, rhs, ...) abort
     if !hasmapto(a:rhs, a:mode)
           \ && index(get(g:vimtex_mappings_disable, a:mode, []), a:lhs) < 0
           \ && (empty(maparg(a:lhs, a:mode)) || a:0 > 0)
@@ -537,12 +537,12 @@ endfunction
 
 " }}}1
 
-function! s:filename_changed_pre() " {{{1
+function! s:filename_changed_pre() abort " {{{1
   let s:filename_changed = expand('%:p') ==# b:vimtex.tex
 endfunction
 
 " }}}1
-function! s:filename_changed_post() " {{{1
+function! s:filename_changed_post() abort " {{{1
   if s:filename_changed
     let l:base_old = b:vimtex.base
     let b:vimtex.tex = fnamemodify(expand('%'), ':p')
@@ -565,7 +565,7 @@ function! s:filename_changed_post() " {{{1
 endfunction
 
 " }}}1
-function! s:buffer_deleted(reason) " {{{1
+function! s:buffer_deleted(reason) abort " {{{1
   "
   " We need a simple cache of buffer ids because a buffer unload might clear
   " buffer variables, so that a subsequent buffer wipe will not trigger a full
@@ -585,7 +585,7 @@ function! s:buffer_deleted(reason) " {{{1
 endfunction
 
 " }}}1
-function! s:quit() " {{{1
+function! s:quit() abort " {{{1
   for l:state in vimtex#state#list_all()
     call l:state.cleanup()
   endfor

--- a/autoload/vimtex/compiler.vim
+++ b/autoload/vimtex/compiler.vim
@@ -142,7 +142,7 @@ function! vimtex#compiler#compile_selected(type) abort range " {{{1
 endfunction
 
 " }}}1
-function! vimtex#compiler#output() " {{{1
+function! vimtex#compiler#output() abort " {{{1
   let l:file = get(b:vimtex.compiler, 'output', '')
   if empty(l:file)
     call vimtex#log#warning('No output exists!')
@@ -167,7 +167,7 @@ function! vimtex#compiler#output() " {{{1
   let s:output.name = l:file
   let s:output.bufnr = bufnr('%')
   let s:output.winnr = bufwinnr('%')
-  function! s:output.update() dict
+  function! s:output.update() dict abort
     if bufwinnr(self.name) != self.winnr
       return
     endif
@@ -184,7 +184,7 @@ function! vimtex#compiler#output() " {{{1
       execute 'keepalt' l:return . 'wincmd w'
     endif
   endfunction
-  function! s:output.destroy() dict
+  function! s:output.destroy() dict abort
     autocmd! vimtex_output_window
     augroup! vimtex_output_window
     unlet s:output
@@ -215,13 +215,13 @@ function! vimtex#compiler#output() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#compiler#stop() " {{{1
+function! vimtex#compiler#stop() abort " {{{1
   call b:vimtex.compiler.stop()
   silent! call timer_stop(b:vimtex.compiler.check_timer)
 endfunction
 
 " }}}1
-function! vimtex#compiler#stop_all() " {{{1
+function! vimtex#compiler#stop_all() abort " {{{1
   for l:state in vimtex#state#list_all()
     if exists('l:state.compiler.is_running')
           \ && l:state.compiler.is_running()
@@ -231,7 +231,7 @@ function! vimtex#compiler#stop_all() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#compiler#clean(full) " {{{1
+function! vimtex#compiler#clean(full) abort " {{{1
   call b:vimtex.compiler.clean(a:full)
 
   if empty(b:vimtex.compiler.build_dir) | return | endif
@@ -249,7 +249,7 @@ function! vimtex#compiler#clean(full) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#compiler#status(detailed) " {{{1
+function! vimtex#compiler#status(detailed) abort " {{{1
   if a:detailed
     let l:running = []
     for l:data in vimtex#state#list_all()

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -417,7 +417,7 @@ function! s:compiler_process.start_single() abort dict " {{{1
 
   if self.continuous
     let g:vimtex_compiler_callback_hooks += ['VimtexSSCallback']
-    function! VimtexSSCallback(status)
+    function! VimtexSSCallback(status) abort
       silent call vimtex#compiler#stop()
       call remove(g:vimtex_compiler_callback_hooks, 'VimtexSSCallback')
     endfunction

--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#complete#init_buffer() " {{{1
+function! vimtex#complete#init_buffer() abort " {{{1
   if !g:vimtex_complete_enabled | return | endif
 
   for l:completer in s:completers
@@ -18,7 +18,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#complete#omnifunc(findstart, base) " {{{1
+function! vimtex#complete#omnifunc(findstart, base) abort " {{{1
   if a:findstart
     if exists('s:completer') | unlet s:completer | endif
 
@@ -55,7 +55,7 @@ function! vimtex#complete#omnifunc(findstart, base) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#complete#complete(type, input, context) " {{{1
+function! vimtex#complete#complete(type, input, context) abort " {{{1
   try
     let s:completer = s:completer_{a:type}
     let s:completer.context = a:context
@@ -86,7 +86,7 @@ let s:completer_bib = {
       \ 'bstfile' :  expand('<sfile>:p:h') . '/vimcomplete',
       \}
 
-function! s:completer_bib.init() dict " {{{2
+function! s:completer_bib.init() dict abort " {{{2
   " Check if bibtex is executable
   if !executable('bibtex')
     let self.enabled = 0
@@ -113,7 +113,7 @@ function! s:completer_bib.init() dict " {{{2
   endif
 endfunction
 
-function! s:completer_bib.complete(regex) dict " {{{2
+function! s:completer_bib.complete(regex) dict abort " {{{2
   let self.candidates = []
 
   let self.type_length = 4
@@ -137,7 +137,7 @@ function! s:completer_bib.complete(regex) dict " {{{2
   return self.candidates
 endfunction
 
-function! s:completer_bib.search(regex) dict " {{{2
+function! s:completer_bib.search(regex) dict abort " {{{2
   let res = []
 
   " The bibtex completion seems to require that we are in the project root
@@ -218,7 +218,7 @@ function! s:completer_bib.search(regex) dict " {{{2
   return res
 endfunction
 
-function! s:completer_bib.find_bibs() dict " {{{2
+function! s:completer_bib.find_bibs() dict abort " {{{2
   "
   " Search for added bibliographies
   " * Parse commands such as \bibliography{file1,file2.bib,...}
@@ -259,7 +259,7 @@ let s:completer_ref = {
       \ 'labels' : [],
       \}
 
-function! s:completer_ref.complete(regex) dict " {{{2
+function! s:completer_ref.complete(regex) dict abort " {{{2
   let self.candidates = []
 
   for m in self.get_matches(a:regex)
@@ -280,7 +280,7 @@ function! s:completer_ref.complete(regex) dict " {{{2
   return self.candidates
 endfunction
 
-function! s:completer_ref.get_matches(regex) dict " {{{2
+function! s:completer_ref.get_matches(regex) dict abort " {{{2
   call self.parse_aux_files()
 
   " Match number
@@ -305,7 +305,7 @@ function! s:completer_ref.get_matches(regex) dict " {{{2
   return self.matches
 endfunction
 
-function! s:completer_ref.parse_aux_files() dict " {{{2
+function! s:completer_ref.parse_aux_files() dict abort " {{{2
   let l:files = [[b:vimtex.aux(), '']]
 
   " Handle local file editing (e.g. subfiles package)
@@ -333,7 +333,7 @@ function! s:completer_ref.parse_aux_files() dict " {{{2
   return self.labels
 endfunction
 
-function! s:completer_ref.parse_labels(file, prefix) dict " {{{2
+function! s:completer_ref.parse_labels(file, prefix) dict abort " {{{2
   "
   " Searches aux files recursively for commands of the form
   "
@@ -364,7 +364,7 @@ function! s:completer_ref.parse_labels(file, prefix) dict " {{{2
   return l:labels
 endfunction
 
-function! s:completer_ref.parse_number(num_tree) dict " {{{2
+function! s:completer_ref.parse_number(num_tree) dict abort " {{{2
   if type(a:num_tree) == type([])
     if len(a:num_tree) == 0
       return '-'
@@ -391,7 +391,7 @@ let s:completer_cmd = {
       \ 'inside_braces' : 0,
       \}
 
-function! s:completer_cmd.complete(regex) dict " {{{2
+function! s:completer_cmd.complete(regex) dict abort " {{{2
   let l:candidates = self.gather_candidates()
   let l:mode = vimtex#util#in_mathzone() ? 'm' : 'n'
 
@@ -401,7 +401,7 @@ function! s:completer_cmd.complete(regex) dict " {{{2
   return l:candidates
 endfunction
 
-function! s:completer_cmd.gather_candidates() dict " {{{2
+function! s:completer_cmd.gather_candidates() dict abort " {{{2
   call self.gather_candidates_from_packages()
   call self.gather_candidates_from_newcommands()
   call self.gather_candidates_from_lets()
@@ -412,7 +412,7 @@ function! s:completer_cmd.gather_candidates() dict " {{{2
         \ + copy(self.candidates_from_packages))
 endfunction
 
-function! s:completer_cmd.gather_candidates_from_packages() dict " {{{2
+function! s:completer_cmd.gather_candidates_from_packages() dict abort " {{{2
   let l:packages = [
         \ 'default',
         \ 'class-' . get(b:vimtex, 'documentclass', ''),
@@ -426,7 +426,7 @@ function! s:completer_cmd.gather_candidates_from_packages() dict " {{{2
   endfor
 endfunction
 
-function! s:completer_cmd.gather_candidates_from_newcommands() dict " {{{2
+function! s:completer_cmd.gather_candidates_from_newcommands() dict abort " {{{2
   " Simple caching
   if !empty(self.candidates_from_newcommands)
     let l:modified_time = max(map(
@@ -451,7 +451,7 @@ function! s:completer_cmd.gather_candidates_from_newcommands() dict " {{{2
   let self.candidates_from_newcommands = l:candidates
 endfunction
 
-function! s:completer_cmd.gather_candidates_from_lets() dict " {{{2
+function! s:completer_cmd.gather_candidates_from_lets() dict abort " {{{2
   let l:preamble = vimtex#parser#tex(b:vimtex.tex, {
         \ 're_stop': '\\begin{document}',
         \ 'detailed': 0,
@@ -483,13 +483,13 @@ let s:completer_img = {
       \   . ')$',
       \}
 
-function! s:completer_img.complete(regex) dict " {{{2
+function! s:completer_img.complete(regex) dict abort " {{{2
   call self.gather_candidates()
 
   return s:filter_with_options(self.candidates, a:regex)
 endfunction
 
-function! s:completer_img.gather_candidates() dict " {{{2
+function! s:completer_img.gather_candidates() dict abort " {{{2
   let l:added_files = []
   let l:generated_pdf = b:vimtex.out()
 
@@ -521,7 +521,7 @@ let s:completer_inc = {
       \ ],
       \}
 
-function! s:completer_inc.complete(regex) dict " {{{2
+function! s:completer_inc.complete(regex) dict abort " {{{2
   let self.candidates = split(globpath(b:vimtex.root, '**/*.tex'), '\n')
   let self.candidates = map(self.candidates,
         \ 'strpart(v:val, len(b:vimtex.root)+1)')
@@ -540,7 +540,7 @@ let s:completer_pdf = {
       \ 'patterns' : ['\v\\includepdf%(\s*\[[^]]*\])?\s*\{[^}]*$'],
       \}
 
-function! s:completer_pdf.complete(regex) dict " {{{2
+function! s:completer_pdf.complete(regex) dict abort " {{{2
   let self.candidates = split(globpath(b:vimtex.root, '**/*.pdf'), '\n')
   let self.candidates = map(self.candidates,
         \ 'strpart(v:val, len(b:vimtex.root)+1)')
@@ -559,7 +559,7 @@ let s:completer_sta = {
       \ 'patterns' : ['\v\\includestandalone%(\s*\[[^]]*\])?\s*\{[^}]*$'],
       \}
 
-function! s:completer_sta.complete(regex) dict " {{{2
+function! s:completer_sta.complete(regex) dict abort " {{{2
   let self.candidates = substitute(globpath(b:vimtex.root, '**/*.tex'), '\.tex', '', 'g')
   let self.candidates = split(self.candidates, '\n')
   let self.candidates = map(self.candidates,
@@ -587,13 +587,13 @@ let s:completer_gls = {
       \ },
       \}
 
-function! s:completer_gls.complete(regex) dict " {{{2
+function! s:completer_gls.complete(regex) dict abort " {{{2
   let l:candidates = self.parse_glossaries()
 
   return s:filter_with_options(l:candidates, a:regex)
 endfunction
 
-function! s:completer_gls.parse_glossaries() dict " {{{2
+function! s:completer_gls.parse_glossaries() dict abort " {{{2
   let self.candidates = []
 
   let l:re_input = g:vimtex#re#tex_input . '|^\s*\\loadglsentries'
@@ -626,12 +626,12 @@ let s:completer_pck = {
       \ 'candidates' : [],
       \}
 
-function! s:completer_pck.complete(regex) dict " {{{2
+function! s:completer_pck.complete(regex) dict abort " {{{2
   call self.gather_candidates()
   return s:filter_with_options(copy(self.candidates), a:regex)
 endfunction
 
-function! s:completer_pck.gather_candidates() dict " {{{2
+function! s:completer_pck.gather_candidates() dict abort " {{{2
   if empty(self.candidates)
     let self.candidates = map(s:get_texmf_candidates('sty'), '{
           \ ''word'' : v:val,
@@ -648,12 +648,12 @@ let s:completer_doc = {
       \ 'candidates' : [],
       \}
 
-function! s:completer_doc.complete(regex) dict " {{{2
+function! s:completer_doc.complete(regex) dict abort " {{{2
   return filter(copy(self.gather_candidates()),
         \ 'v:val.word =~# a:regex')
 endfunction
 
-function! s:completer_doc.gather_candidates() dict " {{{2
+function! s:completer_doc.gather_candidates() dict abort " {{{2
   if empty(self.candidates)
     let self.candidates = map(s:get_texmf_candidates('cls'), '{
           \ ''word'' : v:val,
@@ -673,7 +673,7 @@ let s:completer_env = {
       \ 'candidates_from_packages' : [],
       \}
 
-function! s:completer_env.complete(regex) dict " {{{2
+function! s:completer_env.complete(regex) dict abort " {{{2
   if self.context =~# '^\\end\>'
     " When completing \end{, search for an unmatched \begin{...}
     let l:matching_env = ''
@@ -716,7 +716,7 @@ function! s:completer_env.complete(regex) dict " {{{2
 endfunction
 
 " }}}2
-function! s:completer_env.gather_candidates() dict " {{{2
+function! s:completer_env.gather_candidates() dict abort " {{{2
   call self.gather_candidates_from_packages()
   call self.gather_candidates_from_newenvironments()
 
@@ -726,7 +726,7 @@ function! s:completer_env.gather_candidates() dict " {{{2
 endfunction
 
 " }}}2
-function! s:completer_env.gather_candidates_from_packages() dict " {{{2
+function! s:completer_env.gather_candidates_from_packages() dict abort " {{{2
   let l:packages = [
         \ 'default',
         \ 'class-' . get(b:vimtex, 'documentclass', ''),
@@ -741,7 +741,7 @@ function! s:completer_env.gather_candidates_from_packages() dict " {{{2
 endfunction
 
 " }}}2
-function! s:completer_env.gather_candidates_from_newenvironments() dict " {{{2
+function! s:completer_env.gather_candidates_from_newenvironments() dict abort " {{{2
   " Simple caching
   if !empty(self.candidates_from_newenvironments)
     let l:modified_time = max(map(
@@ -788,7 +788,7 @@ function! s:filter_with_options(input, regex) abort " {{{1
 endfunction
 
 " }}}1
-function! s:get_texmf_candidates(filetype) " {{{1
+function! s:get_texmf_candidates(filetype) abort " {{{1
   " First add the locally installed candidates
   let l:texmfhome = get(vimtex#kpsewhich#run('--var-value TEXMFHOME'), 0, 'XX')
   let l:candidates = glob(l:texmfhome . '/**/*.' . a:filetype, 0, 1)
@@ -805,7 +805,7 @@ function! s:get_texmf_candidates(filetype) " {{{1
 endfunction
 
 " }}}1
-function! s:load_candidates_from_packages(packages) " {{{1
+function! s:load_candidates_from_packages(packages) abort " {{{1
   let l:packages = filter(copy(a:packages),
         \ '!has_key(s:candidates_from_packages, v:val)')
   if empty(l:packages) | return | endif
@@ -866,7 +866,7 @@ endfunction
 let s:candidates_from_packages = {}
 
 " }}}1
-function! s:close_braces(candidates) " {{{1
+function! s:close_braces(candidates) abort " {{{1
   if strpart(getline('.'), col('.') - 1) !~# '^\s*[,}]'
     for l:cand in a:candidates
       if !has_key(l:cand, 'abbr')
@@ -880,7 +880,7 @@ function! s:close_braces(candidates) " {{{1
 endfunction
 
 " }}}1
-function! s:tex2tree(str) " {{{1
+function! s:tex2tree(str) abort " {{{1
   let tree = []
   let i1 = 0
   let i2 = -1
@@ -912,7 +912,7 @@ function! s:tex2tree(str) " {{{1
 endfunction
 
 " }}}1
-function! s:tex2unicode(line) " {{{1
+function! s:tex2unicode(line) abort " {{{1
   "
   " Substitute stuff like '\IeC{\"u}' to corresponding unicode symbols
   "

--- a/autoload/vimtex/debug.vim
+++ b/autoload/vimtex/debug.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#debug#stacktrace(...) " {{{1
+function! vimtex#debug#stacktrace(...) abort " {{{1
   "
   " This function builds on Luc Hermite's answer on Stack Exchange:
   " http://vi.stackexchange.com/a/6024/21

--- a/autoload/vimtex/delim.vim
+++ b/autoload/vimtex/delim.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#delim#init_buffer() " {{{1
+function! vimtex#delim#init_buffer() abort " {{{1
   nnoremap <silent><buffer> <plug>(vimtex-delim-toggle-modifier)
         \ :<c-u>call <sid>operator_setup('toggle_modifier_next')
         \ <bar> normal! <c-r>=v:count ? v:count : ''<cr>g@l<cr>
@@ -31,7 +31,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#delim#close() " {{{1
+function! vimtex#delim#close() abort " {{{1
   let l:save_pos = vimtex#pos#get_cursor()
   let l:pos_val_cursor = vimtex#pos#val(l:save_pos)
 
@@ -69,7 +69,7 @@ function! vimtex#delim#close() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#toggle_modifier(...) " {{{1
+function! vimtex#delim#toggle_modifier(...) abort " {{{1
   let l:args = a:0 > 0 ? a:1 : {}
   call extend(l:args, {
       \ 'count': v:count1,
@@ -124,7 +124,7 @@ function! vimtex#delim#toggle_modifier(...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#toggle_modifier_visual(...) " {{{1
+function! vimtex#delim#toggle_modifier_visual(...) abort " {{{1
   let l:args = a:0 > 0 ? a:1 : {}
   call extend(l:args, {
       \ 'count': v:count1,
@@ -199,7 +199,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#delim#change(...) " {{{1
+function! vimtex#delim#change(...) abort " {{{1
   let [l:open, l:close] = vimtex#delim#get_surrounding('delim_math')
   if empty(l:open) | return | endif
 
@@ -222,7 +222,7 @@ function! vimtex#delim#change(...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#change_with_args(open, close, new) " {{{1
+function! vimtex#delim#change_with_args(open, close, new) abort " {{{1
   "
   " Set target environment
   "
@@ -267,7 +267,7 @@ function! vimtex#delim#change_with_args(open, close, new) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#change_input_complete(lead, cmdline, pos) " {{{1
+function! vimtex#delim#change_input_complete(lead, cmdline, pos) abort " {{{1
   let l:all = deepcopy(g:vimtex#delim#lists.delim_all.name)
   let l:open = map(copy(l:all), 'v:val[0]')
   let l:close = map(copy(l:all), 'v:val[1]')
@@ -277,7 +277,7 @@ function! vimtex#delim#change_input_complete(lead, cmdline, pos) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#delete() " {{{1
+function! vimtex#delim#delete() abort " {{{1
   let [l:open, l:close] = vimtex#delim#get_surrounding('delim_modq_math')
   if empty(l:open) | return | endif
 
@@ -286,7 +286,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#delim#get_next(type, side, ...) " {{{1
+function! vimtex#delim#get_next(type, side, ...) abort " {{{1
   return s:get_delim(extend({
         \ 'direction' : 'next',
         \ 'type' : a:type,
@@ -295,7 +295,7 @@ function! vimtex#delim#get_next(type, side, ...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#get_prev(type, side, ...) " {{{1
+function! vimtex#delim#get_prev(type, side, ...) abort " {{{1
   return s:get_delim(extend({
         \ 'direction' : 'prev',
         \ 'type' : a:type,
@@ -304,7 +304,7 @@ function! vimtex#delim#get_prev(type, side, ...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#get_current(type, side, ...) " {{{1
+function! vimtex#delim#get_current(type, side, ...) abort " {{{1
   return s:get_delim(extend({
         \ 'direction' : 'current',
         \ 'type' : a:type,
@@ -313,7 +313,7 @@ function! vimtex#delim#get_current(type, side, ...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#get_matching(delim) " {{{1
+function! vimtex#delim#get_matching(delim) abort " {{{1
   if empty(a:delim) || !has_key(a:delim, 'lnum') | return {} | endif
 
   "
@@ -354,7 +354,7 @@ function! vimtex#delim#get_matching(delim) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#delim#get_surrounding(type) " {{{1
+function! vimtex#delim#get_surrounding(type) abort " {{{1
   let l:save_pos = vimtex#pos#get_cursor()
   let l:pos_val_cursor = vimtex#pos#val(l:save_pos)
   let l:pos_val_last = l:pos_val_cursor
@@ -417,14 +417,14 @@ function! s:operator_function(_) abort " {{{1
 endfunction
 
 " }}}1
-function! s:snr() " {{{1
+function! s:snr() abort " {{{1
   return matchstr(expand('<sfile>'), '<SNR>\d\+_')
 endfunction
 
 " }}}1
 "
 
-function! s:get_delim(opts) " {{{1
+function! s:get_delim(opts) abort " {{{1
   "
   " Arguments:
   "   opts = {
@@ -536,7 +536,7 @@ endfunction
 
 " }}}1
 
-function! s:parser_env(match, lnum, cnum, ...) " {{{1
+function! s:parser_env(match, lnum, cnum, ...) abort " {{{1
   let result = {}
 
   let result.type = 'env'
@@ -566,7 +566,7 @@ function! s:parser_env(match, lnum, cnum, ...) " {{{1
 endfunction
 
 " }}}1
-function! s:parser_tex(match, lnum, cnum, side, type, direction) " {{{1
+function! s:parser_tex(match, lnum, cnum, side, type, direction) abort " {{{1
   "
   " TeX shorthand are these
   "
@@ -622,7 +622,7 @@ function! s:parser_tex(match, lnum, cnum, side, type, direction) " {{{1
 endfunction
 
 " }}}1
-function! s:parser_latex(match, lnum, cnum, ...) " {{{1
+function! s:parser_latex(match, lnum, cnum, ...) abort " {{{1
   let result = {}
 
   let result.type = 'env'
@@ -646,7 +646,7 @@ function! s:parser_latex(match, lnum, cnum, ...) " {{{1
 endfunction
 
 " }}}1
-function! s:parser_delim(match, lnum, cnum, ...) " {{{1
+function! s:parser_delim(match, lnum, cnum, ...) abort " {{{1
   let result = {}
   let result.type = 'delim'
   let result.side =
@@ -697,7 +697,7 @@ function! s:parser_delim(match, lnum, cnum, ...) " {{{1
 endfunction
 
 " }}}1
-function! s:parser_delim_unmatched(match, lnum, cnum, ...) " {{{1
+function! s:parser_delim_unmatched(match, lnum, cnum, ...) abort " {{{1
   let result = {}
   let result.type = 'delim'
   let result.side =
@@ -737,7 +737,7 @@ function! s:parser_delim_unmatched(match, lnum, cnum, ...) " {{{1
 endfunction
 
 " }}}1
-function! s:parser_delim_get_regexp(delim, side, ...) " {{{1
+function! s:parser_delim_get_regexp(delim, side, ...) abort " {{{1
   let l:type = a:0 > 0 ? a:1 : 'delim_all'
 
   " First check for unmatched math delimiter
@@ -755,7 +755,7 @@ function! s:parser_delim_get_regexp(delim, side, ...) " {{{1
 endfunction
 
 " }}}1
-function! s:parser_delim_get_corr(delim, ...) " {{{1
+function! s:parser_delim_get_corr(delim, ...) abort " {{{1
   let l:type = a:0 > 0 ? a:1 : 'delim_all'
 
   for l:pair in g:vimtex#delim#lists[l:type].name
@@ -769,7 +769,7 @@ endfunction
 
 " }}}1
 
-function! s:get_matching_env() dict " {{{1
+function! s:get_matching_env() dict abort " {{{1
   let [re, flags, stopline] = self.is_open
         \ ? [self.re.close,  'nW', line('.') + s:stopline]
         \ : [self.re.open,  'bnW', max([line('.') - s:stopline, 1])]
@@ -782,7 +782,7 @@ function! s:get_matching_env() dict " {{{1
 endfunction
 
 " }}}1
-function! s:get_matching_tex() dict " {{{1
+function! s:get_matching_tex() dict abort " {{{1
   let [re, flags, stopline] = self.is_open
         \ ? [self.re.open,  'nW', line('.') + s:stopline]
         \ : [self.re.open, 'bnW', max([line('.') - s:stopline, 1])]
@@ -794,7 +794,7 @@ function! s:get_matching_tex() dict " {{{1
 endfunction
 
 " }}}1
-function! s:get_matching_latex() dict " {{{1
+function! s:get_matching_latex() dict abort " {{{1
   let [re, flags, stopline] = self.is_open
         \ ? [self.re.close, 'nW', line('.') + s:stopline]
         \ : [self.re.open, 'bnW', max([line('.') - s:stopline, 1])]
@@ -806,7 +806,7 @@ function! s:get_matching_latex() dict " {{{1
 endfunction
 
 " }}}1
-function! s:get_matching_delim() dict " {{{1
+function! s:get_matching_delim() dict abort " {{{1
   let [re, flags, stopline] = self.is_open
         \ ? [self.re.close,  'nW', line('.') + s:stopline]
         \ : [self.re.open,  'bnW', max([line('.') - s:stopline, 1])]
@@ -819,7 +819,7 @@ function! s:get_matching_delim() dict " {{{1
 endfunction
 
 " }}}1
-function! s:get_matching_delim_unmatched() dict " {{{1
+function! s:get_matching_delim_unmatched() dict abort " {{{1
   let [re, flags, stopline] = self.is_open
         \ ? [self.re.close,  'nW', line('.') + s:stopline]
         \ : [self.re.open,  'bnW', max([line('.') - s:stopline, 1])]
@@ -854,7 +854,7 @@ endfunction
 " }}}1
 
 
-function! s:init_delim_lists() " {{{1
+function! s:init_delim_lists() abort " {{{1
   " Define the default value
   let l:lists = {
         \ 'env_tex' : {
@@ -945,7 +945,7 @@ function! s:init_delim_lists() " {{{1
 endfunction
 
 " }}}1
-function! s:init_delim_regexes() " {{{1
+function! s:init_delim_regexes() abort " {{{1
   let l:re = {}
   let l:re.env_all = {}
   let l:re.delim_all = {}
@@ -1003,7 +1003,7 @@ function! s:init_delim_regexes() " {{{1
 endfunction
 
 " }}}1
-function! s:init_delim_regexes_generator(list_name) " {{{1
+function! s:init_delim_regexes_generator(list_name) abort " {{{1
   let l:list = g:vimtex#delim#lists[a:list_name]
   let l:open = join(map(copy(l:list.re), 'v:val[0]'), '\|')
   let l:close = join(map(copy(l:list.re), 'v:val[1]'), '\|')

--- a/autoload/vimtex/doc.vim
+++ b/autoload/vimtex/doc.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#doc#init_buffer() " {{{1
+function! vimtex#doc#init_buffer() abort " {{{1
   command! -buffer -nargs=? VimtexDocPackage call vimtex#doc#package(<q-args>)
 
   nnoremap <buffer> <plug>(vimtex-doc-package) :VimtexDocPackage<cr>
@@ -12,7 +12,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#doc#package(word) " {{{1
+function! vimtex#doc#package(word) abort " {{{1
   let l:context = empty(a:word)
         \ ? s:packages_get_from_cursor()
         \ : {
@@ -33,7 +33,7 @@ function! vimtex#doc#package(word) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#doc#make_selection(context) " {{{1
+function! vimtex#doc#make_selection(context) abort " {{{1
   if has_key(a:context, 'selected') | return | endif
 
   if len(a:context.candidates) == 0
@@ -79,7 +79,7 @@ endfunction
 
 " }}}1
 
-function! s:packages_get_from_cursor() " {{{1
+function! s:packages_get_from_cursor() abort " {{{1
   let l:cmd = vimtex#cmd#get_current()
   if empty(l:cmd) | return {} | endif
 
@@ -93,7 +93,7 @@ function! s:packages_get_from_cursor() " {{{1
 endfunction
 
 " }}}1
-function! s:packages_from_usepackage(cmd) " {{{1
+function! s:packages_from_usepackage(cmd) abort " {{{1
   try
     " Gather and clean up candidate list
     let l:candidates = substitute(a:cmd.args[0].text, '%.\{-}\n', '', 'g')
@@ -118,7 +118,7 @@ function! s:packages_from_usepackage(cmd) " {{{1
 endfunction
 
 " }}}1
-function! s:packages_from_documentclass(cmd) " {{{1
+function! s:packages_from_documentclass(cmd) abort " {{{1
   try
     return {
           \ 'type': 'documentclass',
@@ -131,7 +131,7 @@ function! s:packages_from_documentclass(cmd) " {{{1
 endfunction
 
 " }}}1
-function! s:packages_from_command(cmd) " {{{1
+function! s:packages_from_command(cmd) abort " {{{1
   let l:packages = [
         \ 'default',
         \ 'class-' . get(b:vimtex, 'documentclass', ''),
@@ -173,7 +173,7 @@ function! s:packages_from_command(cmd) " {{{1
 endfunction
 
 " }}}1
-function! s:packages_remove_invalid(context) " {{{1
+function! s:packages_remove_invalid(context) abort " {{{1
   let l:invalid_packages = filter(copy(a:context.candidates),
         \   'empty(vimtex#kpsewhich#find(v:val . ''.sty'')) && '
         \ . 'empty(vimtex#kpsewhich#find(v:val . ''.cls''))')
@@ -204,7 +204,7 @@ function! s:packages_remove_invalid(context) " {{{1
 endfunction
 
 " }}}1
-function! s:packages_open(context) " {{{1
+function! s:packages_open(context) abort " {{{1
   if !has_key(a:context, 'selected')
     call vimtex#doc#make_selection(a:context)
   endif

--- a/autoload/vimtex/echo.vim
+++ b/autoload/vimtex/echo.vim
@@ -4,14 +4,14 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#echo#echo(message) " {{{1
+function! vimtex#echo#echo(message) abort " {{{1
   echohl VimtexMsg
   echo a:message
   echohl None
 endfunction
 
 " }}}1
-function! vimtex#echo#input(opts) " {{{1
+function! vimtex#echo#input(opts) abort " {{{1
   if has_key(a:opts, 'info')
     call vimtex#echo#formatted(a:opts.info)
   endif
@@ -29,7 +29,7 @@ function! vimtex#echo#input(opts) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#echo#formatted(parts) " {{{1
+function! vimtex#echo#formatted(parts) abort " {{{1
   echo ''
   try
     for part in a:parts

--- a/autoload/vimtex/env.vim
+++ b/autoload/vimtex/env.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#env#init_buffer() " {{{1
+function! vimtex#env#init_buffer() abort " {{{1
   nnoremap <silent><buffer> <plug>(vimtex-env-delete)
         \ :<c-u>call <sid>operator_setup('delete', 'env_tex')<bar>normal! g@l<cr>
 
@@ -23,7 +23,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#env#change(open, close, new) " {{{1
+function! vimtex#env#change(open, close, new) abort " {{{1
   "
   " Set target environment
   "
@@ -66,14 +66,14 @@ function! vimtex#env#change(open, close, new) " {{{1
         \ strpart(l:line, 0, l:c1-1) . l:end . strpart(l:line, l:c2))
 endfunction
 
-function! vimtex#env#change_surrounding_to(type, new) " {{{1
+function! vimtex#env#change_surrounding_to(type, new) abort " {{{1
   let [l:open, l:close] = vimtex#delim#get_surrounding(a:type)
   if empty(l:open) | return | endif
 
   return vimtex#env#change(l:open, l:close, a:new)
 endfunction
 
-function! vimtex#env#delete(type) " {{{1
+function! vimtex#env#delete(type) abort " {{{1
   let [l:open, l:close] = vimtex#delim#get_surrounding(a:type)
   if empty(l:open) | return | endif
 
@@ -94,7 +94,7 @@ function! vimtex#env#delete(type) " {{{1
   endif
 endfunction
 
-function! vimtex#env#toggle_star() " {{{1
+function! vimtex#env#toggle_star() abort " {{{1
   let [l:open, l:close] = vimtex#delim#get_surrounding('env_tex')
   if empty(l:open) | return | endif
 
@@ -104,14 +104,14 @@ endfunction
 
 " }}}1
 
-function! vimtex#env#is_inside(env) " {{{1
+function! vimtex#env#is_inside(env) abort " {{{1
   let l:stopline = max([line('.') - 50, 1])
   return searchpairpos('\\begin\s*{' . a:env . '\*\?}', '',
         \ '\\end\s*{' . a:env . '\*\?}', 'bnW', '', l:stopline)
 endfunction
 
 " }}}1
-function! vimtex#env#input_complete(lead, cmdline, pos) " {{{1
+function! vimtex#env#input_complete(lead, cmdline, pos) abort " {{{1
   let l:cands = map(vimtex#complete#complete('env', '', '\begin'), 'v:val.word')
 
   " Never include document and remove current env (place it first)
@@ -125,7 +125,7 @@ endfunction
 
 " }}}1
 
-function! s:change_prompt(type) " {{{1
+function! s:change_prompt(type) abort " {{{1
   let [l:open, l:close] = vimtex#delim#get_surrounding(a:type)
   if empty(l:open) | return | endif
 

--- a/autoload/vimtex/fold.vim
+++ b/autoload/vimtex/fold.vim
@@ -31,7 +31,7 @@ function! vimtex#fold#init_buffer() abort " {{{1
       " vint: +ProhibitAutocmdWithNoGroup
     augroup END
 
-    function! s:fold_manual_refresh()
+    function! s:fold_manual_refresh() abort
       call vimtex#fold#refresh('zx')
       if exists('b:fold_manual_augroup')
         execute 'autocmd!' b:fold_manual_augroup

--- a/autoload/vimtex/format.vim
+++ b/autoload/vimtex/format.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#format#init_buffer() " {{{1
+function! vimtex#format#init_buffer() abort " {{{1
   if !g:vimtex_format_enabled | return | endif
 
   setlocal formatexpr=vimtex#format#formatexpr()
@@ -12,7 +12,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#format#formatexpr() " {{{1
+function! vimtex#format#formatexpr() abort " {{{1
   if mode() =~# '[iR]' | return -1 | endif
 
   " Temporary disable folds and save view
@@ -67,7 +67,7 @@ endfunction
 
 " }}}1
 
-function! s:format(top, bottom) " {{{1
+function! s:format(top, bottom) abort " {{{1
   let l:bottom = a:bottom
   let l:mark = a:bottom
   for l:current in range(a:bottom, a:top, -1)
@@ -122,7 +122,7 @@ function! s:format(top, bottom) " {{{1
 endfunction
 
 " }}}1
-function! s:format_build_lines(start, end) " {{{1
+function! s:format_build_lines(start, end) abort " {{{1
   "
   " Get the desired text to format as a list of words, but preserve the ending
   " line spaces
@@ -171,7 +171,7 @@ endfunction
 
 " }}}1
 
-function! s:compare_lines(new, old) " {{{1
+function! s:compare_lines(new, old) abort " {{{1
   let l:min_length = min([len(a:new), len(a:old)])
   for l:i in range(l:min_length)
     if a:new[l:i] !=# a:old[l:i]
@@ -182,7 +182,7 @@ function! s:compare_lines(new, old) " {{{1
 endfunction
 
 " }}}1
-function! s:get_indents(number) " {{{1
+function! s:get_indents(number) abort " {{{1
   return !&l:expandtab && &l:shiftwidth == &l:tabstop
         \ ? repeat("\t", a:number/&l:tabstop)
         \ : repeat(' ', a:number)

--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#imaps#init_buffer() " {{{1
+function! vimtex#imaps#init_buffer() abort " {{{1
   if !g:vimtex_imaps_enabled | return | endif
 
   "
@@ -27,7 +27,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#imaps#add_map(map) " {{{1
+function! vimtex#imaps#add_map(map) abort " {{{1
   let s:custom_maps = get(s:, 'custom_maps', []) + [a:map]
 
   if exists('s:created_maps')
@@ -36,7 +36,7 @@ function! vimtex#imaps#add_map(map) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#imaps#list() " {{{1
+function! vimtex#imaps#list() abort " {{{1
   silent new vimtex\ imaps
 
   for l:map in s:created_maps
@@ -75,7 +75,7 @@ endfunction
 "
 " The imap generator
 "
-function! s:create_map(map) " {{{1
+function! s:create_map(map) abort " {{{1
   let l:leader = get(a:map, 'leader', get(g:, 'vimtex_imaps_leader', '`'))
   if l:leader !=# '' && !hasmapto(l:leader, 'i')
     silent execute 'inoremap <silent><buffer>' l:leader . l:leader l:leader
@@ -111,17 +111,17 @@ endfunction
 "
 " Wrappers
 "
-function! vimtex#imaps#wrap_trivial(lhs, rhs) " {{{1
+function! vimtex#imaps#wrap_trivial(lhs, rhs) abort " {{{1
   return a:rhs
 endfunction
 
 " }}}1
-function! vimtex#imaps#wrap_math(lhs, rhs) " {{{1
+function! vimtex#imaps#wrap_math(lhs, rhs) abort " {{{1
   return s:is_math() ? a:rhs : a:lhs
 endfunction
 
 " }}}1
-function! vimtex#imaps#wrap_environment(lhs, rhs) " {{{1
+function! vimtex#imaps#wrap_environment(lhs, rhs) abort " {{{1
   let l:return = a:lhs
   let l:cursor = vimtex#pos#val(vimtex#pos#get_cursor())
   let l:value = 0
@@ -154,7 +154,7 @@ endfunction
 "
 " Helpers
 "
-function! s:is_math() " {{{1
+function! s:is_math() abort " {{{1
   return match(map(synstack(line('.'), max([col('.') - 1, 1])),
         \ 'synIDattr(v:val, ''name'')'), '^texMathZone[A-Z]S\?$') >= 0
 endfunction

--- a/autoload/vimtex/include.vim
+++ b/autoload/vimtex/include.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#include#expr() " {{{1
+function! vimtex#include#expr() abort " {{{1
   call s:visited.timeout()
   let l:fname = substitute(v:fname, '^\s*\|\s*$', '', 'g')
 
@@ -43,7 +43,7 @@ endfunction
 
 " }}}1
 
-function! s:input(fname) " {{{1
+function! s:input(fname) abort " {{{1
   let [l:lnum, l:cnum] = searchpos(g:vimtex#re#tex_input, 'bcn', line('.'))
   if l:lnum == 0 | return a:fname | endif
 
@@ -59,7 +59,7 @@ function! s:input(fname) " {{{1
 endfunction
 
 " }}}1
-function! s:split(fname) " {{{1
+function! s:split(fname) abort " {{{1
   let l:files = []
 
   let l:current = expand('<cword>')

--- a/autoload/vimtex/info.vim
+++ b/autoload/vimtex/info.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#info#init_buffer() " {{{1
+function! vimtex#info#init_buffer() abort " {{{1
   command! -buffer -bang VimtexInfo call vimtex#info#open(<q-bang> == '!')
 
   nnoremap <buffer> <plug>(vimtex-info)      :VimtexInfo<cr>

--- a/autoload/vimtex/kpsewhich.vim
+++ b/autoload/vimtex/kpsewhich.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#kpsewhich#find(file) " {{{1
+function! vimtex#kpsewhich#find(file) abort " {{{1
   execute 'lcd' fnameescape(b:vimtex.root)
   let l:output = split(system('kpsewhich "' . a:file . '"'), '\n')
   lcd -
@@ -19,7 +19,7 @@ function! vimtex#kpsewhich#find(file) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#kpsewhich#run(args) " {{{1
+function! vimtex#kpsewhich#run(args) abort " {{{1
   execute 'lcd' fnameescape(b:vimtex.root)
   let l:output = split(system('kpsewhich ' . a:args), '\n')
   lcd -

--- a/autoload/vimtex/log.vim
+++ b/autoload/vimtex/log.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#log#init_buffer() " {{{1
+function! vimtex#log#init_buffer() abort " {{{1
   command! -buffer -bang VimtexLog call vimtex#log#open()
 
   nnoremap <buffer> <plug>(vimtex-log) :VimtexLog<cr>

--- a/autoload/vimtex/matchparen.vim
+++ b/autoload/vimtex/matchparen.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#matchparen#init_buffer() " {{{1
+function! vimtex#matchparen#init_buffer() abort " {{{1
   if !g:vimtex_matchparen_enabled | return | endif
 
   call vimtex#matchparen#enable()
@@ -12,17 +12,17 @@ endfunction
 
 " }}}1
 
-function! vimtex#matchparen#enable() " {{{1
+function! vimtex#matchparen#enable() abort " {{{1
   call s:matchparen.enable()
 endfunction
 
 " }}}1
-function! vimtex#matchparen#disable() " {{{1
+function! vimtex#matchparen#disable() abort " {{{1
   call s:matchparen.disable()
 endfunction
 
 " }}}1
-function! vimtex#matchparen#popup_check(...) " {{{1
+function! vimtex#matchparen#popup_check(...) abort " {{{1
   if pumvisible()
     call s:matchparen.highlight()
   endif

--- a/autoload/vimtex/misc.vim
+++ b/autoload/vimtex/misc.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#misc#init_buffer() " {{{1
+function! vimtex#misc#init_buffer() abort " {{{1
   command! -buffer                VimtexReload call vimtex#misc#reload()
   command! -buffer -bang -range=% VimtexCountWords
         \ call vimtex#misc#wordcount_display({

--- a/autoload/vimtex/motion.vim
+++ b/autoload/vimtex/motion.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#motion#init_buffer() " {{{1
+function! vimtex#motion#init_buffer() abort " {{{1
   if !g:vimtex_motion_enabled | return | endif
 
   " Utility map to avoid conflict with "normal" command
@@ -86,7 +86,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#motion#find_matching_pair(...) " {{{1
+function! vimtex#motion#find_matching_pair(...) abort " {{{1
   if a:0 > 0
     normal! gv
   endif
@@ -109,7 +109,7 @@ function! vimtex#motion#find_matching_pair(...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#motion#paragraph(backwards, visual) " {{{1
+function! vimtex#motion#paragraph(backwards, visual) abort " {{{1
   if a:visual
     normal! gv
   endif
@@ -144,7 +144,7 @@ function! vimtex#motion#paragraph(backwards, visual) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#motion#section(type, backwards, visual) " {{{1
+function! vimtex#motion#section(type, backwards, visual) abort " {{{1
   let l:count = v:count1
   if a:visual
     normal! gv
@@ -197,7 +197,7 @@ function! vimtex#motion#section(type, backwards, visual) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#motion#environment(begin, backwards, visual) " {{{1
+function! vimtex#motion#environment(begin, backwards, visual) abort " {{{1
   let l:count = v:count1
   if a:visual
     normal! gv
@@ -212,7 +212,7 @@ function! vimtex#motion#environment(begin, backwards, visual) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#motion#comment(begin, backwards, visual) " {{{1
+function! vimtex#motion#comment(begin, backwards, visual) abort " {{{1
   let l:count = v:count1
   if a:visual
     normal! gv

--- a/autoload/vimtex/parser.vim
+++ b/autoload/vimtex/parser.vim
@@ -4,12 +4,12 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#parser#tex(file, ...) " {{{1
+function! vimtex#parser#tex(file, ...) abort " {{{1
   return vimtex#parser#general#parse(a:file, a:0 > 0 ? a:1 : {})
 endfunction
 
 " }}}1
-function! vimtex#parser#aux(file, ...) " {{{1
+function! vimtex#parser#aux(file, ...) abort " {{{1
   let l:options = extend(a:0 > 0 ? a:1 : {}, {
         \ 'detailed' : 0,
         \ 'type' : 'aux',
@@ -18,7 +18,7 @@ function! vimtex#parser#aux(file, ...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#parser#fls(file, ...) " {{{1
+function! vimtex#parser#fls(file, ...) abort " {{{1
   let l:options = extend(a:0 > 0 ? a:1 : {}, {
         \ 'detailed' : 0,
         \ 'type' : 'fls',
@@ -29,13 +29,13 @@ endfunction
 
 " }}}1
 
-function! vimtex#parser#toc(file) " {{{1
+function! vimtex#parser#toc(file) abort " {{{1
   return vimtex#parser#toc#parse(a:file)
 endfunction
 
 " }}}1
 
-function! vimtex#parser#get_externalfiles() " {{{1
+function! vimtex#parser#get_externalfiles() abort " {{{1
   let l:preamble = vimtex#parser#tex(b:vimtex.tex, {
         \ 're_stop' : '\\begin{document}',
         \ 'detailed' : 0,
@@ -55,7 +55,7 @@ function! vimtex#parser#get_externalfiles() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#parser#selection_to_texfile(type, ...) range " {{{1
+function! vimtex#parser#selection_to_texfile(type, ...) range abort " {{{1
   "
   " Get selected lines. Method depends on type of selection, which may be
   " either of

--- a/autoload/vimtex/parser/toc.vim
+++ b/autoload/vimtex/parser/toc.vim
@@ -309,7 +309,7 @@ let s:matcher_preamble = {
       \ 'in_content' : 0,
       \ 'priority' : 1,
       \}
-function! s:matcher_preamble.get_entry(context) " {{{1
+function! s:matcher_preamble.get_entry(context) abort " {{{1
   return g:vimtex_toc_show_preamble
         \ ? {
         \   'title'  : 'Preamble',

--- a/autoload/vimtex/paths.vim
+++ b/autoload/vimtex/paths.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#paths#shorten_relative(path) " {{{1
+function! vimtex#paths#shorten_relative(path) abort " {{{1
   " Input: An absolute path
   " Output: Relative path with respect to the vimtex root, path relative to
   "         vimtex root (unless absolute path is shorter)
@@ -15,7 +15,7 @@ function! vimtex#paths#shorten_relative(path) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#paths#relative(path, current) " {{{1
+function! vimtex#paths#relative(path, current) abort " {{{1
   " Note: This algorithm is based on the one presented by @Offirmo at SO,
   "       http://stackoverflow.com/a/12498485/51634
   let l:target = substitute(a:path, '\\', '/', 'g')

--- a/autoload/vimtex/pos.vim
+++ b/autoload/vimtex/pos.vim
@@ -4,31 +4,31 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#pos#set_cursor(...) " {{{1
+function! vimtex#pos#set_cursor(...) abort " {{{1
   call cursor(s:parse_args(a:000))
 endfunction
 
 " }}}1
-function! vimtex#pos#get_cursor() " {{{1
+function! vimtex#pos#get_cursor() abort " {{{1
   return exists('*getcurpos') ? getcurpos() : getpos('.')
 endfunction
 
 " }}}1
-function! vimtex#pos#get_cursor_line() " {{{1
+function! vimtex#pos#get_cursor_line() abort " {{{1
   let l:pos = vimtex#pos#get_cursor()
   return l:pos[1]
 endfunction
 
 " }}}1
 
-function! vimtex#pos#val(...) " {{{1
+function! vimtex#pos#val(...) abort " {{{1
   let [l:lnum, l:cnum; l:rest] = s:parse_args(a:000)
 
   return 100000*l:lnum + min([l:cnum, 90000])
 endfunction
 
 " }}}1
-function! vimtex#pos#next(...) " {{{1
+function! vimtex#pos#next(...) abort " {{{1
   let [l:lnum, l:cnum; l:rest] = s:parse_args(a:000)
 
   return l:cnum < strlen(getline(l:lnum))
@@ -37,7 +37,7 @@ function! vimtex#pos#next(...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#pos#prev(...) " {{{1
+function! vimtex#pos#prev(...) abort " {{{1
   let [l:lnum, l:cnum; l:rest] = s:parse_args(a:000)
 
   return l:cnum > 1
@@ -46,25 +46,25 @@ function! vimtex#pos#prev(...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#pos#larger(pos1, pos2) " {{{1
+function! vimtex#pos#larger(pos1, pos2) abort " {{{1
   return vimtex#pos#val(a:pos1) > vimtex#pos#val(a:pos2)
 endfunction
 
 " }}}1
-function! vimtex#pos#equal(p1, p2) " {{{1
+function! vimtex#pos#equal(p1, p2) abort " {{{1
   let l:pos1 = s:parse_args(a:p1)
   let l:pos2 = s:parse_args(a:p2)
   return l:pos1[:1] == l:pos2[:1]
 endfunction
 
 " }}}1
-function! vimtex#pos#smaller(pos1, pos2) " {{{1
+function! vimtex#pos#smaller(pos1, pos2) abort " {{{1
   return vimtex#pos#val(a:pos1) < vimtex#pos#val(a:pos2)
 endfunction
 
 " }}}1
 
-function! s:parse_args(args) " {{{1
+function! s:parse_args(args) abort " {{{1
   "
   " The arguments should be in one of the following forms (when unpacked):
   "

--- a/autoload/vimtex/profile.vim
+++ b/autoload/vimtex/profile.vim
@@ -4,13 +4,13 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#profile#open() " {{{1
+function! vimtex#profile#open() abort " {{{1
   source ~/.vim/vimrc
   silent edit prof.log
 endfunction
 
 " }}}1
-function! vimtex#profile#print() " {{{1
+function! vimtex#profile#print() abort " {{{1
   for l:line in readfile('prof.log')
     echo l:line
   endfor
@@ -20,7 +20,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#profile#file(filename) " {{{1
+function! vimtex#profile#file(filename) abort " {{{1
   profile start prof.log
   profile func *
 
@@ -31,7 +31,7 @@ function! vimtex#profile#file(filename) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#profile#command(cmd) " {{{1
+function! vimtex#profile#command(cmd) abort " {{{1
   profile start prof.log
   profile func *
 
@@ -43,7 +43,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#profile#filter(sections) " {{{1
+function! vimtex#profile#filter(sections) abort " {{{1
   let l:lines = readfile('prof.log')
   call filter(l:lines, 'v:val !~# ''FTtex''')
   call filter(l:lines, 'v:val !~# ''LoadFTPlugin''')
@@ -58,7 +58,7 @@ endfunction
 
 " }}}1
 
-function! s:fix_sids() " {{{1
+function! s:fix_sids() abort " {{{1
   let l:lines = readfile('prof.log')
   let l:new = []
   for l:line in l:lines
@@ -83,7 +83,7 @@ function! s:fix_sids() " {{{1
 endfunction
 
 " }}}1
-function! s:get_section(name, lines) " {{{1
+function! s:get_section(name, lines) abort " {{{1
   let l:active = 0
   let l:section = []
   for l:line in a:lines

--- a/autoload/vimtex/qf/latexlog.vim
+++ b/autoload/vimtex/qf/latexlog.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#qf#latexlog#new() " {{{1
+function! vimtex#qf#latexlog#new() abort " {{{1
   return deepcopy(s:qf)
 endfunction
 
@@ -201,7 +201,7 @@ endfunction
 
 " }}}1
 
-function! s:log_contains_error(logfile) " {{{1
+function! s:log_contains_error(logfile) abort " {{{1
   let lines = readfile(a:logfile)
   let lines = filter(lines, 'v:val =~# ''^.*:\d\+: ''')
   let lines = vimtex#util#uniq(map(lines, 'matchstr(v:val, ''^.*\ze:\d\+:'')'))

--- a/autoload/vimtex/qf/pplatex.vim
+++ b/autoload/vimtex/qf/pplatex.vim
@@ -5,7 +5,7 @@
 " Email:        karl.yngve@gmail.com
 "
 
-function! vimtex#qf#pplatex#new() " {{{1
+function! vimtex#qf#pplatex#new() abort " {{{1
   return deepcopy(s:qf)
 endfunction
 

--- a/autoload/vimtex/qf/pulp.vim
+++ b/autoload/vimtex/qf/pulp.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#qf#pulp#new() " {{{1
+function! vimtex#qf#pulp#new() abort " {{{1
   return deepcopy(s:qf)
 endfunction
 

--- a/autoload/vimtex/state.vim
+++ b/autoload/vimtex/state.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#state#init_buffer() " {{{1
+function! vimtex#state#init_buffer() abort " {{{1
   command! -buffer VimtexToggleMain  call vimtex#state#toggle_main()
   command! -buffer VimtexReloadState call vimtex#state#reload()
 
@@ -13,7 +13,7 @@ function! vimtex#state#init_buffer() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#state#init() " {{{1
+function! vimtex#state#init() abort " {{{1
   let l:main = s:get_main()
   let l:id   = s:get_main_id(l:main)
 
@@ -29,7 +29,7 @@ function! vimtex#state#init() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#state#init_local() " {{{1
+function! vimtex#state#init_local() abort " {{{1
   let l:filename = expand('%:p')
   let l:preserve_root = get(s:, 'subfile_preserve_root')
   unlet! s:subfile_preserve_root
@@ -59,7 +59,7 @@ function! vimtex#state#init_local() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#state#reload() " {{{1
+function! vimtex#state#reload() abort " {{{1
   let l:id = s:get_main_id(expand('%:p'))
   if has_key(s:vimtex_states, l:id)
     let l:vimtex = remove(s:vimtex_states, l:id)
@@ -77,7 +77,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#state#toggle_main() " {{{1
+function! vimtex#state#toggle_main() abort " {{{1
   if exists('b:vimtex_local')
     let b:vimtex_local.active = !b:vimtex_local.active
 
@@ -92,22 +92,22 @@ function! vimtex#state#toggle_main() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#state#list_all() " {{{1
+function! vimtex#state#list_all() abort " {{{1
   return values(s:vimtex_states)
 endfunction
 
 " }}}1
-function! vimtex#state#exists(id) " {{{1
+function! vimtex#state#exists(id) abort " {{{1
   return has_key(s:vimtex_states, a:id)
 endfunction
 
 " }}}1
-function! vimtex#state#get(id) " {{{1
+function! vimtex#state#get(id) abort " {{{1
   return s:vimtex_states[a:id]
 endfunction
 
 " }}}1
-function! vimtex#state#cleanup(id) " {{{1
+function! vimtex#state#cleanup(id) abort " {{{1
   if !vimtex#state#exists(a:id) | return | endif
 
   "
@@ -159,7 +159,7 @@ endfunction
 
 " }}}1
 
-function! s:get_main_id(main) " {{{1
+function! s:get_main_id(main) abort " {{{1
   for [l:id, l:state] in items(s:vimtex_states)
     if l:state.tex == a:main
       return str2nr(l:id)
@@ -169,7 +169,7 @@ function! s:get_main_id(main) " {{{1
   return -1
 endfunction
 
-function! s:get_main() " {{{1
+function! s:get_main() abort " {{{1
   if exists('s:disabled_modules')
     unlet s:disabled_modules
   endif
@@ -247,7 +247,7 @@ function! s:get_main() " {{{1
 endfunction
 
 " }}}1
-function! s:get_main_from_texroot() " {{{1
+function! s:get_main_from_texroot() abort " {{{1
   for l:line in getline(1, 5)
     let l:filename = matchstr(l:line, g:vimtex#re#tex_input_root)
     if len(l:filename) > 0
@@ -264,7 +264,7 @@ function! s:get_main_from_texroot() " {{{1
 endfunction
 
 " }}}1
-function! s:get_main_from_subfile() " {{{1
+function! s:get_main_from_subfile() abort " {{{1
   for l:line in getline(1, 5)
     let l:filename = matchstr(l:line,
           \ '^\C\s*\\documentclass\[\zs.*\ze\]{subfiles}')
@@ -304,7 +304,7 @@ function! s:get_main_from_subfile() " {{{1
 endfunction
 
 " }}}1
-function! s:get_main_latexmain(file) " {{{1
+function! s:get_main_latexmain(file) abort " {{{1
   for l:cand in s:findfiles_recursive('*.latexmain', expand('%:p:h'))
     let l:cand = fnamemodify(l:cand, ':p:r')
     if s:file_reaches_current(l:cand)
@@ -317,7 +317,7 @@ function! s:get_main_latexmain(file) " {{{1
   return ''
 endfunction
 
-function! s:get_main_recurse(...) " {{{1
+function! s:get_main_recurse(...) abort " {{{1
   " Either start the search from the original file, or check if the supplied
   " file is a main file (or invalid)
   if a:0 == 0
@@ -357,7 +357,7 @@ function! s:get_main_recurse(...) " {{{1
 endfunction
 
 " }}}1
-function! s:file_is_main(file) " {{{1
+function! s:file_is_main(file) abort " {{{1
   if !filereadable(a:file) | return 0 | endif
 
   "
@@ -375,7 +375,7 @@ function! s:file_is_main(file) " {{{1
 endfunction
 
 " }}}1
-function! s:file_reaches_current(file) " {{{1
+function! s:file_reaches_current(file) abort " {{{1
   if !filereadable(a:file) | return 0 | endif
 
   for l:line in filter(readfile(a:file), 'v:val =~# g:vimtex#re#tex_input')
@@ -400,7 +400,7 @@ function! s:file_reaches_current(file) " {{{1
 endfunction
 
 " }}}1
-function! s:findfiles_recursive(expr, path) " {{{1
+function! s:findfiles_recursive(expr, path) abort " {{{1
   let l:path = a:path
   let l:dirs = l:path
   while l:path != fnamemodify(l:path, ':h')

--- a/autoload/vimtex/text_obj.vim
+++ b/autoload/vimtex/text_obj.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#text_obj#init_buffer() " {{{1
+function! vimtex#text_obj#init_buffer() abort " {{{1
   if !g:vimtex_text_obj_enabled | return | endif
 
   for [l:map, l:name, l:opt] in [
@@ -26,7 +26,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#text_obj#commands(is_inner, mode) " {{{1
+function! vimtex#text_obj#commands(is_inner, mode) abort " {{{1
   if a:mode
     call vimtex#pos#set_cursor(getpos("'>"))
   endif
@@ -62,7 +62,7 @@ function! vimtex#text_obj#commands(is_inner, mode) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#text_obj#delimited(is_inner, mode, type) " {{{1
+function! vimtex#text_obj#delimited(is_inner, mode, type) abort " {{{1
   if a:mode
     let l:object = s:get_sel_delimited_visual(a:is_inner, a:type)
     if empty(l:object)
@@ -83,7 +83,7 @@ function! vimtex#text_obj#delimited(is_inner, mode, type) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#text_obj#sections(is_inner, mode) " {{{1
+function! vimtex#text_obj#sections(is_inner, mode) abort " {{{1
   let l:pos_save = vimtex#pos#get_cursor()
   call vimtex#pos#set_cursor(vimtex#pos#next(l:pos_save))
 
@@ -116,7 +116,7 @@ endfunction
 
 " }}}1
 
-function! s:get_sel_delimited_visual(is_inner, type) " {{{1
+function! s:get_sel_delimited_visual(is_inner, type) abort " {{{1
   if a:is_inner
     call vimtex#pos#set_cursor(vimtex#pos#next(getpos("'>")))
     let [l:open, l:close] = vimtex#delim#get_surrounding(a:type)
@@ -161,7 +161,7 @@ function! s:get_sel_delimited_visual(is_inner, type) " {{{1
 endfunction
 
 " }}}1
-function! s:get_sel_delimited(open, close, is_inner) " {{{1
+function! s:get_sel_delimited(open, close, is_inner) abort " {{{1
   " Determine if operator is linewise
   let l:linewise = index(g:vimtex_text_obj_linewise_operators, v:operator) >= 0
 
@@ -212,7 +212,7 @@ function! s:get_sel_delimited(open, close, is_inner) " {{{1
 endfunction
 
 " }}}1
-function! s:get_sel_sections(is_inner, type) " {{{1
+function! s:get_sel_sections(is_inner, type) abort " {{{1
   let l:pos_save = vimtex#pos#get_cursor()
   let l:min_val = get(s:section_to_val, a:type)
 

--- a/autoload/vimtex/toc.vim
+++ b/autoload/vimtex/toc.vim
@@ -630,7 +630,7 @@ function! s:toc.increase_depth() abort dict "{{{1
 endfunction
 
 " }}}1
-function! s:toc.filter() dict "{{{1
+function! s:toc.filter() dict abort "{{{1
   let re_filter = input('filter entry title by: ')
   for entry in self.entries
     let entry.hidden = get(entry, 'hidden') || entry.title !~# re_filter
@@ -639,7 +639,7 @@ function! s:toc.filter() dict "{{{1
 endfunction
 
 " }}}1
-function! s:toc.clear_filter() dict "{{{1
+function! s:toc.clear_filter() dict abort "{{{1
   for entry in self.entries
     let entry.hidden = 0
   endfor
@@ -736,7 +736,7 @@ endfunction
 
 " }}}1
 
-function! s:int_to_roman(number) " {{{1
+function! s:int_to_roman(number) abort " {{{1
   let l:number = a:number
   let l:result = ''
   for [l:val, l:romn] in [
@@ -764,7 +764,7 @@ function! s:int_to_roman(number) " {{{1
 endfunction
 
 " }}}1
-function! s:base(n, k) " {{{1
+function! s:base(n, k) abort " {{{1
   if a:n < a:k
     return [a:n]
   else

--- a/autoload/vimtex/util.vim
+++ b/autoload/vimtex/util.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#util#command(cmd) " {{{1
+function! vimtex#util#command(cmd) abort " {{{1
   let l:a = @a
   try
     silent! redir @a
@@ -18,7 +18,7 @@ function! vimtex#util#command(cmd) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#util#get_os() " {{{1
+function! vimtex#util#get_os() abort " {{{1
   if has('win32') || has('win32unix')
     return 'win'
   elseif has('unix')
@@ -31,17 +31,17 @@ function! vimtex#util#get_os() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#util#in_comment(...) " {{{1
+function! vimtex#util#in_comment(...) abort " {{{1
   return call('vimtex#util#in_syntax', ['texComment'] + a:000)
 endfunction
 
 " }}}1
-function! vimtex#util#in_mathzone(...) " {{{1
+function! vimtex#util#in_mathzone(...) abort " {{{1
   return call('vimtex#util#in_syntax', ['texMathZone'] + a:000)
 endfunction
 
 " }}}1
-function! vimtex#util#in_syntax(name, ...) " {{{1
+function! vimtex#util#in_syntax(name, ...) abort " {{{1
 
   " Usage: vimtex#util#in_syntax(name, [line, col])
 
@@ -59,7 +59,7 @@ function! vimtex#util#in_syntax(name, ...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#util#extend_recursive(dict1, dict2, ...) " {{{1
+function! vimtex#util#extend_recursive(dict1, dict2, ...) abort " {{{1
   let l:option = a:0 > 0 ? a:1 : 'force'
   if index(['force', 'keep', 'error'], l:option) < 0
     throw 'E475: Invalid argument: ' . l:option
@@ -82,7 +82,7 @@ function! vimtex#util#extend_recursive(dict1, dict2, ...) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#util#shellescape(cmd) " {{{1
+function! vimtex#util#shellescape(cmd) abort " {{{1
   "
   " Path used in "cmd" only needs to be enclosed by double quotes.
   " shellescape() on Windows with "shellslash" set will produce a path
@@ -101,7 +101,7 @@ function! vimtex#util#shellescape(cmd) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#util#uniq(list) " {{{1
+function! vimtex#util#uniq(list) abort " {{{1
   if exists('*uniq') | return uniq(a:list) | endif
   if len(a:list) <= 1 | return a:list | endif
 
@@ -115,7 +115,7 @@ function! vimtex#util#uniq(list) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#util#uniq_unsorted(list) " {{{1
+function! vimtex#util#uniq_unsorted(list) abort " {{{1
   if len(a:list) <= 1 | return a:list | endif
 
   let l:visited = [a:list[0]]

--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#view#init_buffer() " {{{1
+function! vimtex#view#init_buffer() abort " {{{1
   if !g:vimtex_view_enabled | return | endif
 
   command! -buffer -nargs=? -complete=file VimtexView
@@ -23,7 +23,7 @@ function! vimtex#view#init_buffer() " {{{1
 endfunction
 
 " }}}1
-function! vimtex#view#init_state(state) " {{{1
+function! vimtex#view#init_state(state) abort " {{{1
   if !g:vimtex_view_enabled | return | endif
   if has_key(a:state, 'viewer') | return | endif
 
@@ -64,7 +64,7 @@ endfunction
 
 " }}}1
 
-function! vimtex#view#reverse_goto(line, filename) " {{{1
+function! vimtex#view#reverse_goto(line, filename) abort " {{{1
   let l:file = resolve(a:filename)
 
   if !bufexists(l:file)

--- a/autoload/vimtex/view/common.vim
+++ b/autoload/vimtex/view/common.vim
@@ -4,12 +4,12 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#view#common#apply_common_template(viewer) " {{{1
+function! vimtex#view#common#apply_common_template(viewer) abort " {{{1
   return extend(a:viewer, deepcopy(s:common_template))
 endfunction
 
 " }}}1
-function! vimtex#view#common#apply_xwin_template(class, viewer) " {{{1
+function! vimtex#view#common#apply_xwin_template(class, viewer) abort " {{{1
   let a:viewer.class = a:class
   let a:viewer.xwin_id = 0
   call extend(a:viewer, deepcopy(s:xwin_template))
@@ -17,7 +17,7 @@ function! vimtex#view#common#apply_xwin_template(class, viewer) " {{{1
 endfunction
 
 " }}}1
-function! vimtex#view#common#not_readable(output) " {{{1
+function! vimtex#view#common#not_readable(output) abort " {{{1
   if !filereadable(a:output)
     call vimtex#log#warning('Viewer cannot read PDF file!', a:output)
     return 1
@@ -30,19 +30,19 @@ endfunction
 
 let s:common_template = {}
 
-function! s:common_template.out() dict " {{{1
+function! s:common_template.out() dict abort " {{{1
   return g:vimtex_view_use_temp_files
         \ ? b:vimtex.root . '/' . b:vimtex.name . '_vimtex.pdf'
         \ : b:vimtex.out(1)
 endfunction
 
 " }}}1
-function! s:common_template.synctex() dict " {{{1
+function! s:common_template.synctex() dict abort " {{{1
   return fnamemodify(self.out(), ':r') . '.synctex.gz'
 endfunction
 
 " }}}1
-function! s:common_template.copy_files() dict " {{{1
+function! s:common_template.copy_files() dict abort " {{{1
   if !g:vimtex_view_use_temp_files | return | endif
 
   "
@@ -86,7 +86,7 @@ endfunction
 
 let s:xwin_template = {}
 
-function! s:xwin_template.view(file) dict " {{{1
+function! s:xwin_template.view(file) dict abort " {{{1
   if empty(a:file)
     let outfile = self.out()
   else
@@ -111,7 +111,7 @@ function! s:xwin_template.view(file) dict " {{{1
 endfunction
 
 " }}}1
-function! s:xwin_template.xwin_get_id() dict " {{{1
+function! s:xwin_template.xwin_get_id() dict abort " {{{1
   if !executable('xdotool') | return 0 | endif
   if self.xwin_id > 0 | return self.xwin_id | endif
 
@@ -134,7 +134,7 @@ function! s:xwin_template.xwin_get_id() dict " {{{1
 endfunction
 
 " }}}1
-function! s:xwin_template.xwin_exists() dict " {{{1
+function! s:xwin_template.xwin_exists() dict abort " {{{1
   if !executable('xdotool') | return 0 | endif
 
   "
@@ -174,7 +174,7 @@ function! s:xwin_template.xwin_exists() dict " {{{1
 endfunction
 
 " }}}1
-function! s:xwin_template.xwin_send_keys(keys) dict " {{{1
+function! s:xwin_template.xwin_send_keys(keys) dict abort " {{{1
   if !executable('xdotool') | return | endif
 
   if a:keys !=# ''

--- a/autoload/vimtex/view/general.vim
+++ b/autoload/vimtex/view/general.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#view#general#new() " {{{1
+function! vimtex#view#general#new() abort " {{{1
   " Check if the viewer is executable
   if !executable(g:vimtex_view_general_viewer)
     call vimtex#log#warning(
@@ -31,7 +31,7 @@ let s:general = {
       \ 'name' : 'General'
       \}
 
-function! s:general.view(file) dict " {{{1
+function! s:general.view(file) dict abort " {{{1
   if empty(a:file)
     let outfile = self.out()
 
@@ -65,7 +65,7 @@ function! s:general.view(file) dict " {{{1
 endfunction
 
 " }}}1
-function! s:general.latexmk_append_argument() dict " {{{1
+function! s:general.latexmk_append_argument() dict abort " {{{1
   if g:vimtex_view_use_temp_files
     return ' -view=none'
   else

--- a/autoload/vimtex/view/mupdf.vim
+++ b/autoload/vimtex/view/mupdf.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#view#mupdf#new() " {{{1
+function! vimtex#view#mupdf#new() abort " {{{1
   " Check if the viewer is executable
   if !executable('mupdf')
     call vimtex#log#error(
@@ -24,7 +24,7 @@ let s:mupdf = {
       \ 'name': 'MuPDF',
       \}
 
-function! s:mupdf.start(outfile) dict " {{{1
+function! s:mupdf.start(outfile) dict abort " {{{1
   let l:cmd = 'mupdf ' .  g:vimtex_view_mupdf_options
         \ . ' ' . vimtex#util#shellescape(a:outfile)
   let self.process = vimtex#process#start(l:cmd)
@@ -38,7 +38,7 @@ function! s:mupdf.start(outfile) dict " {{{1
 endfunction
 
 " }}}1
-function! s:mupdf.forward_search(outfile) dict " {{{1
+function! s:mupdf.forward_search(outfile) dict abort " {{{1
   if !executable('xdotool') | return | endif
   if !executable('synctex') | return | endif
 
@@ -62,7 +62,7 @@ function! s:mupdf.forward_search(outfile) dict " {{{1
 endfunction
 
 " }}}1
-function! s:mupdf.reverse_search() dict " {{{1
+function! s:mupdf.reverse_search() dict abort " {{{1
   if !executable('xdotool') | return | endif
   if !executable('synctex') | return | endif
 
@@ -106,7 +106,7 @@ function! s:mupdf.reverse_search() dict " {{{1
 endfunction
 
 " }}}1
-function! s:mupdf.compiler_callback(status) dict " {{{1
+function! s:mupdf.compiler_callback(status) dict abort " {{{1
   if !a:status && g:vimtex_view_use_temp_files < 2
     return
   endif
@@ -147,7 +147,7 @@ function! s:mupdf.compiler_callback(status) dict " {{{1
 endfunction
 
 " }}}1
-function! s:mupdf.latexmk_append_argument() dict " {{{1
+function! s:mupdf.latexmk_append_argument() dict abort " {{{1
   if g:vimtex_view_use_temp_files
     let cmd = ' -view=none'
   else
@@ -162,7 +162,7 @@ function! s:mupdf.latexmk_append_argument() dict " {{{1
 endfunction
 
 " }}}1
-function! s:mupdf.focus_viewer() dict " {{{1
+function! s:mupdf.focus_viewer() dict abort " {{{1
   if !executable('xdotool') | return | endif
 
   if self.xwin_id > 0
@@ -172,7 +172,7 @@ function! s:mupdf.focus_viewer() dict " {{{1
 endfunction
 
 " }}}1
-function! s:mupdf.focus_vim() dict " {{{1
+function! s:mupdf.focus_vim() dict abort " {{{1
   if !executable('xdotool') | return | endif
 
   silent call system('xdotool windowactivate ' . v:windowid . ' --sync')

--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#view#skim#new() " {{{1
+function! vimtex#view#skim#new() abort " {{{1
   " Check if Skim is installed
   let l:cmd = join([
         \ 'osascript -e ',
@@ -27,7 +27,7 @@ let s:skim = {
       \ 'startskim' : 'open -a Skim',
       \}
 
-function! s:skim.view(file) dict " {{{1
+function! s:skim.view(file) dict abort " {{{1
   if empty(a:file)
     let outfile = self.out()
 
@@ -67,7 +67,7 @@ function! s:skim.view(file) dict " {{{1
 endfunction
 
 " }}}1
-function! s:skim.compiler_callback(status) dict " {{{1
+function! s:skim.compiler_callback(status) dict abort " {{{1
   if !a:status && g:vimtex_view_use_temp_files < 2
     return
   endif
@@ -99,7 +99,7 @@ function! s:skim.compiler_callback(status) dict " {{{1
 endfunction
 
 " }}}1
-function! s:skim.latexmk_append_argument() dict " {{{1
+function! s:skim.latexmk_append_argument() dict abort " {{{1
   if g:vimtex_view_use_temp_files || g:vimtex_view_automatic
     return ' -view=none'
   else

--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#view#zathura#new() " {{{1
+function! vimtex#view#zathura#new() abort " {{{1
   " Check if the viewer is executable
   if !executable('zathura')
     call vimtex#log#error('Zathura is not executable!')
@@ -39,7 +39,7 @@ let s:zathura = {
       \ 'has_synctex' : 1,
       \}
 
-function! s:zathura.start(outfile) dict " {{{1
+function! s:zathura.start(outfile) dict abort " {{{1
   let l:cmd  = 'zathura'
   if self.has_synctex
     let l:cmd .= ' -x "' . g:vimtex_compiler_progname
@@ -62,7 +62,7 @@ function! s:zathura.start(outfile) dict " {{{1
 endfunction
 
 " }}}1
-function! s:zathura.forward_search(outfile) dict " {{{1
+function! s:zathura.forward_search(outfile) dict abort " {{{1
   if !self.has_synctex | return | endif
   if !filereadable(self.synctex()) | return | endif
 
@@ -77,7 +77,7 @@ function! s:zathura.forward_search(outfile) dict " {{{1
 endfunction
 
 " }}}1
-function! s:zathura.compiler_callback(status) dict " {{{1
+function! s:zathura.compiler_callback(status) dict abort " {{{1
   if !a:status && g:vimtex_view_use_temp_files < 2
     return
   endif
@@ -114,7 +114,7 @@ function! s:zathura.compiler_callback(status) dict " {{{1
 endfunction
 
 " }}}1
-function! s:zathura.latexmk_append_argument() dict " {{{1
+function! s:zathura.latexmk_append_argument() dict abort " {{{1
   if g:vimtex_view_use_temp_files
     let cmd = ' -view=none'
   else
@@ -133,7 +133,7 @@ function! s:zathura.latexmk_append_argument() dict " {{{1
 endfunction
 
 " }}}1
-function! s:zathura.get_pid() dict " {{{1
+function! s:zathura.get_pid() dict abort " {{{1
   " First try to match full output file name
   let cmd = 'pgrep -nf "zathura.*'
         \ . escape(get(self, 'outfile', self.out()), '~\%.') . '"'

--- a/indent/bib.vim
+++ b/indent/bib.vim
@@ -18,7 +18,7 @@ set cpo&vim
 setlocal autoindent
 setlocal indentexpr=VimtexIndentBib()
 
-function! VimtexIndentBib() " {{{1
+function! VimtexIndentBib() abort " {{{1
   " Find first non-blank line above the current line
   let lnum = prevnonblank(v:lnum - 1)
   if lnum == 0
@@ -64,7 +64,7 @@ function! VimtexIndentBib() " {{{1
   return ind
 endfunction
 
-function! s:count(pattern, line) " {{{1
+function! s:count(pattern, line) abort " {{{1
   let sum = 0
   let indx = match(a:line, a:pattern)
   while indx >= 0


### PR DESCRIPTION
Some functions have been given the `abort` argument, but not all.

This PR tries to give it to all functions, so that if an error is raised, the function aborts immediately.

I found these functions with this `:vimgrep` command:

    :noa vim /^\s*fu\%[nction]!\=\%(.*abort\)\@!.*\zs\s*"\s*{{{\|^\s*fu\%[nction]!\=\%(.*abort\)\@!.*\zs/gj ~/.vim/plugged/vimtex/**/*.vim | cw

Feel free to close the PR if adding `abort` causes an issue.

---

I was tempted to submit another PR to add the keycode `<c-u>` in front of all the `:call` commands in mappings, so that if the user presses a count by accident before the lhs, Vim won't translate it into a range which would cause the subsequent function to be called several times, and may have undesired effects.

MWE:

    nno  cd  :call Func()<cr>
    fu! Func()
        echo 'hello'
    endfu
    " press `3cd`, and you'll see 'hello' printed 3 times

I found 35 matches with this `:vimgrep` command:

    :noa vim /\m\cmap.*\%(<c-u>\s*\)\@<!\zs\<call\>/gj ~/.vim/plugged/vimtex/**/*.vim | cw

But I don't know the codebase well enough, and it's possible that some of them expect a range because the functionality they help to implement supports a count, so I didn't submit another PR.

