### PR TITLE
enable continuous and callback of latexmk without clientserver

### DIFF
--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -126,7 +126,7 @@ function! s:compiler.init_check_requirements() abort dict " {{{1
     if !(has('clientserver') || has('nvim') || has('job'))
       let self.callback = 0
       call vimtex#log#warning(
-            \ 'Can''t use callbacks without +job or +clientserver',
+            \ 'Can''t use callbacks without +job, +nvim or +clientserver',
             \ 'Callback option has been disabled.')
     endif
   endif
@@ -184,7 +184,7 @@ function! s:compiler.build_cmd() abort dict " {{{1
     endif
 
     if self.callback
-      if has('job')
+      if has('job') || has('nvim')
         for [l:opt, l:val] in items({
               \ 'success_cmd' : 'vimtex_compiler_callback_success',
               \ 'failure_cmd' : 'vimtex_compiler_callback_failure',
@@ -588,6 +588,11 @@ endfunction
 function! s:callback_nvim_output(id, data, event) abort dict " {{{1
   if !empty(a:data) && filewritable(self.output)
     call writefile(filter(a:data, '!empty(v:val)'), self.output, 'a')
+  endif
+  if match(a:data, 'vimtex_compiler_callback_success') != -1
+    call vimtex#compiler#callback(1)
+  elseif match(a:data, 'vimtex_compiler_callback_failure') != -1
+    call vimtex#compiler#callback(0)
   endif
 endfunction
 

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -126,7 +126,7 @@ function! s:compiler.init_check_requirements() abort dict " {{{1
     if !(has('clientserver') || has('nvim') || has('job'))
       let self.callback = 0
       call vimtex#log#warning(
-            \ 'Can''t use callbacks without +clientserver',
+            \ 'Can''t use callbacks without +job or +clientserver',
             \ 'Callback option has been disabled.')
     endif
   endif
@@ -192,25 +192,23 @@ function! s:compiler.build_cmd() abort dict " {{{1
           let l:func = 'echo ' . l:val
           let l:cmd .= vimtex#compiler#latexmk#wrap_option(l:opt, l:func)
         endfor
+      elseif empty(v:servername)
+        call vimtex#log#warning('Can''t use callbacks with empty v:servername')
       else
-        if empty(v:servername)
-          call vimtex#log#warning('Can''t use callbacks with empty v:servername')
-        else
-          " Some notes:
-          " - We excape the v:servername because this seems necessary on Windows
-          "   for neovim, see e.g. Github Issue #877
-          for [l:opt, l:val] in items({'success_cmd' : 1, 'failure_cmd' : 0})
-            let l:callback = has('win32')
-                  \   ? '"vimtex#compiler#callback(' . l:val . ')"'
-                  \   : '\"vimtex\#compiler\#callback(' . l:val . ')\"'
-            let l:func = vimtex#util#shellescape('""')
-                  \ . g:vimtex_compiler_progname
-                  \ . vimtex#util#shellescape('""')
-                  \ . ' --servername ' . vimtex#util#shellescape(v:servername)
-                  \ . ' --remote-expr ' . l:callback
-            let l:cmd .= vimtex#compiler#latexmk#wrap_option(l:opt, l:func)
-          endfor
-        endif
+        " Some notes:
+        " - We excape the v:servername because this seems necessary on Windows
+        "   for neovim, see e.g. Github Issue #877
+        for [l:opt, l:val] in items({'success_cmd' : 1, 'failure_cmd' : 0})
+          let l:callback = has('win32')
+                \   ? '"vimtex#compiler#callback(' . l:val . ')"'
+                \   : '\"vimtex\#compiler\#callback(' . l:val . ')\"'
+          let l:func = vimtex#util#shellescape('""')
+                \ . g:vimtex_compiler_progname
+                \ . vimtex#util#shellescape('""')
+                \ . ' --servername ' . vimtex#util#shellescape(v:servername)
+                \ . ' --remote-expr ' . l:callback
+          let l:cmd .= vimtex#compiler#latexmk#wrap_option(l:opt, l:func)
+        endfor
       endif
     endif
   endif

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -185,11 +185,11 @@ function! s:compiler.build_cmd() abort dict " {{{1
 
     if self.callback
       if has('job')
-        for [l:opt, l:val] in items({'success_cmd' : 'vimtex_compiler_callback_success', 'failure_cmd' : 'vimtex_compiler_callback_failure'})
-          let l:func = vimtex#util#shellescape('""')
-                \ . 'echo '
-                \ . vimtex#util#shellescape('""')
-                \ . l:val
+        for [l:opt, l:val] in items({
+              \ 'success_cmd' : 'vimtex_compiler_callback_success',
+              \ 'failure_cmd' : 'vimtex_compiler_callback_failure',
+              \})
+          let l:func = 'echo ' . l:val
           let l:cmd .= vimtex#compiler#latexmk#wrap_option(l:opt, l:func)
         endfor
       else
@@ -468,7 +468,7 @@ function! s:compiler_jobs.exec() abort dict " {{{1
         \}
 
   if self.continuous
-    let l:options.out_cb = function('s:continuous_callback')
+    let l:options.out_cb = function('s:callback_continuous_output')
     let l:options.out_io = 'pipe'
   else
     let s:cb_target = self.target_path !=# b:vimtex.tex
@@ -516,14 +516,14 @@ function! s:callback(ch, msg) abort " {{{1
 endfunction
 
 " }}}1
-func! s:continuous_callback(channel, msg) abort " {{{1
-    call writefile([a:msg], b:vimtex.compiler.output, 'a')
-    if a:msg == 'vimtex_compiler_callback_success'
-        call vimtex#compiler#callback(1)
-    elseif a:msg == 'vimtex_compiler_callback_failure'
-        call vimtex#compiler#callback(0)
-    endif
-endfunc
+function! s:callback_continuous_output(channel, msg) abort " {{{1
+  call writefile([a:msg], b:vimtex.compiler.output, 'a')
+  if a:msg ==# 'vimtex_compiler_callback_success'
+    call vimtex#compiler#callback(1)
+  elseif a:msg ==# 'vimtex_compiler_callback_failure'
+    call vimtex#compiler#callback(0)
+  endif
+endfunction
 
 " }}}1
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -229,12 +229,17 @@ Compiler backend~
   but where the compilation behaviour is typically defined in the preamble
   of the document. (|vimtex-arara|)
 
+Job~
+                                                          *vimtex-job*
+  |vimtex| requires the |job| for the callback functionality to work.
+  The callbacks are used to provide feedback when compilation is finished,
+  as well as to parse the log for errors and warnings and to open the
+  |quickfix| window when necessary.
+
 Clientserver~
                                                           *vimtex-clientserver*
-  |vimtex| requires the |clientserver| for the callback functionality to work.
-  The callbacks are used to provide feedback when compilation is finished, as
-  well as to parse the log for errors and warnings and to open the |quickfix|
-  window when necessary.
+  When the |job| is not available, |vimtex| requires the |clientserver| for the
+  callback functionality to work.
 
   A server will be started automatically if Vim is running on Windows, or if
   running in a GUI.  If you use Vim under a terminal in Linux or OSX, a server
@@ -807,9 +812,9 @@ OPTIONS                                                        *vimtex-options*
     If enabled, this option tells `latexmk` to run |vimtex#compiler#callback|
     after compilation is finished.
 
-    Note 1: This feature requires |clientserver|.
-    Note 2: The callback is run with the vim executable defined by
-            |g:vimtex_compiler_progname|.
+    Note 1: This feature requires |job| or |clientserver|.
+    Note 2: When using |clientserver| the callback is run with the vim
+            executable defined by |g:vimtex_compiler_progname|.
     Note 3: Callbacks are only possible when the `backend` is one of `nvim` or
             `jobs`, or when `continuous` is also activated.
 
@@ -3260,10 +3265,10 @@ when source files have been changed.  |vimtex| uses the continuous mode by
 default, but `latexmk` also allows single shot compilations.  The compiler may
 be configured through the |g:vimtex_compiler_latexmk| option.
 
-If vim is compiled with the |+clientserver| option and if the `callback` key
-is enabled (which it is by default), then compilation errors will be parsed
-automatically.  This is done by utilizing the tricks explained below.  Note
-that this only works for continuous compilation mode.
+If vim is compiled with the |+job| or the |+clientserver| option and if the
+`callback` key is enabled (which it is by default), then compilation errors
+will be parsed automatically.  This is done by utilizing the tricks explained
+below. Note that this only works for continuous compilation mode.
 
 As stated, one may customize the `latexmk` options through
 |g:vimtex_compiler_latexmk|.  However, one may also configure `latexmk`

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -231,15 +231,15 @@ Compiler backend~
 
 Job~
                                                           *vimtex-job*
-  |vimtex| requires the |job| for the callback functionality to work.
+  |vimtex| requires the |job| or |nvim| for the callback functionality to work.
   The callbacks are used to provide feedback when compilation is finished,
   as well as to parse the log for errors and warnings and to open the
   |quickfix| window when necessary.
 
 Clientserver~
                                                           *vimtex-clientserver*
-  When the |job| is not available, |vimtex| requires the |clientserver| for the
-  callback functionality to work.
+  When the |job| or |nvim| is not available, |vimtex| requires the
+  |clientserver| for the callback functionality to work.
 
   A server will be started automatically if Vim is running on Windows, or if
   running in a GUI.  If you use Vim under a terminal in Linux or OSX, a server
@@ -812,7 +812,7 @@ OPTIONS                                                        *vimtex-options*
     If enabled, this option tells `latexmk` to run |vimtex#compiler#callback|
     after compilation is finished.
 
-    Note 1: This feature requires |job| or |clientserver|.
+    Note 1: This feature requires |nvim|, |job| or |clientserver|.
     Note 2: When using |clientserver| the callback is run with the vim
             executable defined by |g:vimtex_compiler_progname|.
     Note 3: Callbacks are only possible when the `backend` is one of `nvim` or
@@ -3265,7 +3265,7 @@ when source files have been changed.  |vimtex| uses the continuous mode by
 default, but `latexmk` also allows single shot compilations.  The compiler may
 be configured through the |g:vimtex_compiler_latexmk| option.
 
-If vim is compiled with the |+job| or the |+clientserver| option and if the
+If you use neovim or use Vim with |+job| or |+clientserver| option and if the
 `callback` key is enabled (which it is by default), then compilation errors
 will be parsed automatically.  This is done by utilizing the tricks explained
 below. Note that this only works for continuous compilation mode.


### PR DESCRIPTION
This PR is for #1207.
This is helpful when I use macvim in ternimal (https://github.com/macvim-dev/macvim/issues/657)

TODO:

- documentation
- anything else?