### PR TITLE
Add viewer support for cygwin environments

### DIFF
--- a/autoload/vimtex/view/general.vim
+++ b/autoload/vimtex/view/general.vim
@@ -54,6 +54,10 @@ function! s:general.view(file) dict abort " {{{1
   let l:cmd = substitute(l:cmd, '@col', col('.'), 'g')
   let l:cmd = substitute(l:cmd, '@tex',
         \ vimtex#util#shellescape(expand('%:p')), 'g')
+  " Check if we are inside Cygwin and call the viewer with a Windows path
+  if executable('cygpath')
+    let outfile = substitute(system('cygpath -aw '.outfile), '\n', '', 'g')
+  endif
   let l:cmd = substitute(l:cmd, '@pdf', vimtex#util#shellescape(outfile), 'g')
 
   " Start the view process


### PR DESCRIPTION
When running Vim inside Cygwin the paths are relative to the Cygwin environment, they are not real Windows paths. Example: `/home/pirofti/foo.pdf` versus `C:\cygwin\home\pirofti\foo.pdf`. 

PDF viewers are usually installed in Windows not in Cygwin. So when the viewer is invoked with the PDF path, Vimtex sends a Cygwin path instead of a Windows path and the viewer does not know how to parse that.

This patch checks if we are running inside Cygwin by checking for the specific `cygpath` utility that is also used to generate a Windows path from a Cygwin path.