### PR TITLE
Improve syntax highlighting of tabular specifications

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -108,10 +108,12 @@ if exists('b:vimtex.packages.tabularx') || exists('b:vimtex.packages.array')
   syntax match texTabularCol /\*/
         \ containedin=texTabularArg
         \ nextgroup=texTabularMulti
+        \ contained
   syntax region texTabularMulti matchgroup=Delimiter
         \ start='{' end='}'
         \ containedin=texTabularArg
         \ nextgroup=texTabularArg
+        \ contained
 
   syntax match texTabularAtSep /@/
         \ containedin=texTabularArg
@@ -126,11 +128,13 @@ if exists('b:vimtex.packages.tabularx') || exists('b:vimtex.packages.array')
         \ start='{' end='}'
         \ containedin=texTabularArg
         \ contains=texLength,texStatement,texMathDelimSingle
+        \ contained
 
   syntax region texTabularLength matchgroup=Delimiter
         \ start='{' end='}'
         \ containedin=texTabularArg
         \ contains=texLength,texStatement
+        \ contained
 
   syntax match texMathDelimSingle /\$\$\?/
         \ containedin=texTabularPostPreArg

--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -96,15 +96,18 @@ if exists('b:vimtex.packages.tabularx') || exists('b:vimtex.packages.array')
   syntax match texTabular '\\begin{tabular}\_[^{]\{-}\ze{'
         \ contains=texBeginEnd
         \ nextgroup=texTabularArg
+        \ contained
   syntax region texTabularArg matchgroup=Delimiter
         \ start='{' end='}'
         \ contained
 
   syntax match texTabularCol /[lcr]/
         \ containedin=texTabularArg
+        \ contained
   syntax match texTabularCol /[pmb]/
         \ containedin=texTabularArg
         \ nextgroup=texTabularLength
+        \ contained
   syntax match texTabularCol /\*/
         \ containedin=texTabularArg
         \ nextgroup=texTabularMulti
@@ -118,11 +121,14 @@ if exists('b:vimtex.packages.tabularx') || exists('b:vimtex.packages.array')
   syntax match texTabularAtSep /@/
         \ containedin=texTabularArg
         \ nextgroup=texTabularLength
+        \ contained
   syntax match texTabularVertline /||\?/
         \ containedin=texTabularArg
+        \ contained
   syntax match texTabularPostPre /[<>]/
         \ containedin=texTabularArg
         \ nextgroup=texTabularPostPreArg
+        \ contained
 
   syntax region texTabularPostPreArg matchgroup=Delimiter
         \ start='{' end='}'
@@ -138,6 +144,7 @@ if exists('b:vimtex.packages.tabularx') || exists('b:vimtex.packages.array')
 
   syntax match texMathDelimSingle /\$\$\?/
         \ containedin=texTabularPostPreArg
+        \ contained
 
   highlight def link texTabularCol        Directory
   highlight def link texTabularAtSep      Type


### PR DESCRIPTION
The syntax highlighting introduced in 1c69a28bf293c2579e3a6837089710ea24d9f6cb (see also #1283) messed up with some preamble code, including code inside braces `{}` and definition of starred commands (`\newcommand*`).

The example below shows three cases that were not correctly highlighted after 1c69a28bf293c2579e3a6837089710ea24d9f6cb. They are all fixed in this PR.

```tex
\documentclass{article}

% Load tabularx to activate syntax highligting for tabular specifications.
\usepackage{tabularx}

\includeonly{
  file1,
  % file2,  % <-- not highlighted as comment!
}

% The starred version is not correctly highlighted:
\newcommand{\xmath}{$x$}
\newcommand*{\xmathstar}{$x$}

% Same for this luatex directive:
\pdfvariable objcompresslevel=0

\begin{document}

% This is still correctly highlighted:
\begin{tabular}{|>{\centering$}m{1cm}<{$}|}
  \hline
  Hello world !\tabularnewline
  \hline
\end{tabular}

\end{document}
```