### PR TITLE
Supports root-finding and TOC generation in rnoweb-like documents:

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -200,6 +200,12 @@ function! vimtex#init_options() abort " {{{1
   call s:init_option('vimtex_quickfix_blgparser', {})
   call s:init_option('vimtex_quickfix_autoclose_after_keystrokes', '0')
 
+  call s:init_option('vimtex_rnoweb_formats', [
+        \     {'ext': ['.Rnw', '.Rtex'],
+        \      'beforeincl': '\<\<.*child\s*\=\s*''',
+        \      'afterincl' : '''\s*\>\>\=',},
+        \])
+
   call s:init_option('vimtex_texcount_custom_arg', '')
 
   call s:init_option('vimtex_text_obj_enabled', 1)
@@ -363,7 +369,7 @@ function! s:init_buffer() abort " {{{1
         \ ]
     execute 'set suffixes+=' . l:suf
   endfor
-  setlocal suffixesadd=.tex,.sty,.cls
+  setlocal suffixesadd=join(vimtex#state#doc_formats(), ",") + ".sty,.cls"
   setlocal comments=sO:%\ -,mO:%\ \ ,eO:%%,:%
   setlocal commentstring=%%s
   setlocal iskeyword+=:

--- a/autoload/vimtex/parser/general.vim
+++ b/autoload/vimtex/parser/general.vim
@@ -97,6 +97,20 @@ function! s:parser.input_line_parser_tex(line, current_file, re) abort dict " {{
       return s:input_to_filename(
           \ substitute(copy(l:file), '{.{-}}', '', ''), l:root)
     endif
+  elseif l:file =~# g:vimtex#re#rnoweb_input_latex
+      " maps user-defined tex file type
+      let l:root = self.root
+      for l:format in g:vimtex_rnoweb_formats
+          let l:new_file = substitute(copy(l:file),
+              \ '\v%(' . l:format['beforeincl'] . ')', '', '')
+          let l:new_file = substitute(copy(l:new_file),
+              \ '\v%(' . l:format['afterincl'] . ')', '', '')
+          let l:filename = s:input_to_filename_simple(l:new_file, l:root)
+          if(!empty(l:filename))
+              return l:filename
+          endif
+      endfor
+      return ''
   else
     return s:input_to_filename(l:file, self.root)
   endif
@@ -144,6 +158,26 @@ function! s:input_to_filename(input, root) abort " {{{1
   if l:file !~# '\v^(\/|[A-Z]:)'
     let l:file = a:root . '/' . l:file
   endif
+
+
+  " Only return filename if it is readable
+  return filereadable(l:file) ? l:file : ''
+endfunction
+
+" }}}1
+
+function! s:input_to_filename_simple(input, root) abort " {{{1
+  let l:file = a:input
+  " Ensure that the file name has extension
+  if empty(fnamemodify(l:file, ':e'))
+    let l:file .= '.tex'
+  endif
+
+  " Use absolute paths
+  if l:file !~# '\v^(\/|[A-Z]:)'
+    let l:file = a:root . '/' . l:file
+  endif
+
 
   " Only return filename if it is readable
   return filereadable(l:file) ? l:file : ''

--- a/autoload/vimtex/re.vim
+++ b/autoload/vimtex/re.vim
@@ -15,10 +15,13 @@ let g:vimtex#re#tex_input_latex = '\v\\%('
       \        '|') . ')\s*\{'
 let g:vimtex#re#tex_input_import =
       \ '\v\\%(sub)?%(import|%(input|include)from)\*?\{[^\}]*\}\{'
+let g:vimtex#re#rnoweb_input_latex = join(map(deepcopy(g:vimtex_rnoweb_formats),
+        \ '"\\v%(" . v:val.beforeincl . ")"'), "|")
 
 let g:vimtex#re#tex_input = '\v^\s*%(' . join([
       \   g:vimtex#re#tex_input_latex,
       \   g:vimtex#re#tex_input_import,
+      \   g:vimtex#re#rnoweb_input_latex,
       \ ], '|') . ')'
 
 let g:vimtex#re#tex_include = g:vimtex#re#tex_input_root

--- a/autoload/vimtex/state.vim
+++ b/autoload/vimtex/state.vim
@@ -342,8 +342,15 @@ function! s:get_main_recurse(...) abort " {{{1
   let l:re_filter = g:vimtex#re#tex_input
         \ . '\s*\f*' . fnamemodify(l:file, ':t:r')
 
+
+  let l:file_list = []
+  let l:formats = vimtex#state#doc_suffixes()
+  for l:format in l:formats
   " Search through candidates found recursively upwards in the directory tree
-  for l:cand in s:findfiles_recursive('*.tex', fnamemodify(l:file, ':p:h'))
+    let l:file_list = extend(l:file_list, s:findfiles_recursive('*' . l:format, fnamemodify(l:file, ':p:h')))
+  endfor
+
+  for l:cand in l:file_list
     if index(l:tried[l:file], l:cand) >= 0 | continue | endif
     call add(l:tried[l:file], l:cand)
 
@@ -355,6 +362,18 @@ function! s:get_main_recurse(...) abort " {{{1
 
   return ''
 endfunction
+
+" }}}1
+function! vimtex#state#doc_suffixes() abort " {{{1
+  " get the files that matches desired extensions
+  let l:formats_exts_list = map(deepcopy(g:vimtex_rnoweb_formats), 'v:val.ext')
+  let l:formats = []
+  for l:format_exts in l:formats_exts_list
+      let l:formats = extend(l:formats, l:format_exts)
+  endfor
+  return l:formats + ['.tex']
+endfunction
+" }}}1
 
 " }}}1
 function! s:file_is_main(file) abort " {{{1

--- a/ftplugin/rnoweb.vim
+++ b/ftplugin/rnoweb.vim
@@ -1,0 +1,25 @@
+" vimtex - LaTeX plugin for Vim
+"
+" Maintainer: Karl Yngve Lervåg
+" Email:      karl.yngve@gmail.com
+"
+
+if !get(g:, 'vimtex_enabled', 1)
+  finish
+endif
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+if !(!get(g:, 'vimtex_version_check', 1)
+      \ || has('nvim-0.1.7')
+      \ || v:version >= 704)
+  echoerr 'Error: vimtex does not support your version of Vim'
+  echom 'Please update to Vim 7.4 or neovim 0.1.7 or later!'
+  echom 'For more info, please see :h vimtex_version_check'
+  finish
+endif
+
+call vimtex#init()


### PR DESCRIPTION
This commit allows better root finding and TOC generation in rnoweb-like documents (knitr in particular), by adding a user-defined option, allowing the user to support extensions to treat as TeX files, and two regular expressions to extract included filenames from import lines.

Default settings for knitr are provided.