### PR TITLE
Declare mathpar to be a math zone

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -372,6 +372,7 @@ call TexNewMathZone('I', 'gather', 1)
 call TexNewMathZone('J', 'multline', 1)
 call TexNewMathZone('K', 'xalignat', 1)
 call TexNewMathZone('L', 'xxalignat', 0)
+call TexNewMathZone('M', 'mathpar', 1)
 
 execute 'syntax match texBadMath ''\\end\s*{\s*\(' . join([
       \ 'align',


### PR DESCRIPTION
The mathpar environment is defined in the mathpartir package for
typesetting inference rules and it is reasonably popular in programming
language circles. So it is a good default to include with vimtex.