### PR TITLE
Add basic fzf.vim integration

### DIFF
--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -4,11 +4,19 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#fzf#run() abort " {{{1
+function! vimtex#fzf#run(...) abort " {{{1
+  " The filter argument may be used to select certain entry types
+  " according to the different "layers" of vimtex-toc:
+      " c:  content: This is the main part and the "real" ToC
+      " t:  todo: This shows TODOs from comments and `\todo{...}` commands
+      " l:  label: This shows `\label{...}` commands
+      " i:  include: This shows included files
+  " The default behavior is to show all entries, e.g. 'ctli'
+
   " The --with-nth 3.. option hides the first two words from the 
   " fzf window which we used to pass on the file name and line number
   call fzf#run({
-      \ 'source': <sid>parse_toc(),
+      \ 'source': <sid>parse_toc(a:0 == 0 ? 'ctli' : a:1),
       \ 'sink': function('vimtex#fzf#open_selection'),
       \ 'options': '--ansi --with-nth 3..',
       \})
@@ -22,7 +30,7 @@ endfunction
 
 " }}}1
 
-function! s:parse_toc() abort " {{{1
+function! s:parse_toc(filter) abort " {{{1
 " Parsing is mostly adapted from the Denite source
 " (see rplugin/python3/denite/source/vimtex.py)
 python3 << EOF
@@ -48,8 +56,8 @@ def format_number(n):
 
 def get_color(type):
   colors = {
-    'include' : Fore.BLUE,
     'content' : Fore.WHITE,
+    'include' : Fore.BLUE,
     'label' : Fore.GREEN,
     'todo' : Fore.RED,
   }
@@ -62,7 +70,8 @@ def create_candidate(e, depth):
 
 entries = vim.eval('vimtex#parser#toc(b:vimtex.tex)')
 depth = max([int(e['level']) for e in entries])
-candidates = [create_candidate(e, depth) for e in entries]
+filter = vim.eval("a:filter")
+candidates = [create_candidate(e, depth) for e in entries if e['type'][0] in filter]
 
 # json.dumps will convert single quotes to double quotes
 # so that vim understands the ansi escape sequences

--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -1,0 +1,48 @@
+" Parsing is mostly adapted from the Denite source
+function! s:parse_toc()
+python3 << EOF
+import vim
+
+def format_number(n):
+  if not n or not type(n) is dict or not 'chapter' in n:
+      return ''
+
+  num = [str(n[k]) for k in [
+         'chapter',
+         'section',
+         'subsection',
+         'subsubsection',
+         'subsubsubsection'] if n[k] != '0']
+
+  if n['appendix'] != '0':
+     num[0] = chr(int(num[0]) + 64)
+
+  return '.'.join(num)
+
+def create_candidate(e, depth):
+  number = format_number(dict(e['number']))
+
+  return f"{e.get('line', 0)} {e['file']} {e['title']:65} {number}"
+
+entries = vim.eval('vimtex#parser#toc(b:vimtex.tex)')
+depth = max([int(e['level']) for e in entries])
+candidates = [create_candidate(e, depth) for e in entries]
+vim.command(f"let candidates = {candidates}")
+EOF
+
+  return candidates
+endfunction
+
+function! vimtex#fzf#open_selection(sel)
+  execute printf('edit +%s %s', split(a:sel)[0], split(a:sel)[1])
+endfunction
+
+function! vimtex#fzf#run()
+  " The --with-nth 3.. option hides the first two words from the 
+  " fzf window which we used to pass on the file name and line number
+  call fzf#run({  'source':  <sid>parse_toc(),
+        \   'sink':    function('vimtex#fzf#open_selection'),
+        \   'options': '--ansi --with-nth 3..'  
+        \ })
+endfunction
+

--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -7,10 +7,11 @@
 function! vimtex#fzf#run() abort " {{{1
   " The --with-nth 3.. option hides the first two words from the 
   " fzf window which we used to pass on the file name and line number
-  call fzf#run({  'source':  <sid>parse_toc(),
-        \   'sink':    function('vimtex#fzf#open_selection'),
-        \   'options': '--ansi --with-nth 3..'  
-        \ })
+  call fzf#run({
+      \ 'source': <sid>parse_toc(),
+      \ 'sink': function('vimtex#fzf#open_selection'),
+      \ 'options': '--ansi --with-nth 3..',
+      \})
 endfunction
 
 " }}}1

--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -2,6 +2,8 @@
 function! s:parse_toc()
 python3 << EOF
 import vim
+import json
+from colorama import Fore, Style
 
 def format_number(n):
   if not n or not type(n) is dict or not 'chapter' in n:
@@ -19,15 +21,27 @@ def format_number(n):
 
   return '.'.join(num)
 
+def get_color(type):
+  colors = {
+    'include' : Fore.BLUE,
+    'content' : Fore.WHITE,
+    'label' : Fore.GREEN,
+    'todo' : Fore.RED,
+  }
+  return colors[type]
+
 def create_candidate(e, depth):
   number = format_number(dict(e['number']))
 
-  return f"{e.get('line', 0)} {e['file']} {e['title']:65} {number}"
+  return f"{e.get('line', 0)} {e['file']} {get_color(e['type'])}{e['title']:65}{Style.RESET_ALL} {number}"
 
 entries = vim.eval('vimtex#parser#toc(b:vimtex.tex)')
 depth = max([int(e['level']) for e in entries])
 candidates = [create_candidate(e, depth) for e in entries]
-vim.command(f"let candidates = {candidates}")
+
+# json.dumps will convert single quotes to double quotes
+# so that vim understands the ansi escape sequences
+vim.command(f"let candidates = {json.dumps(candidates)}") 
 EOF
 
   return candidates

--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -4,6 +4,19 @@
 " Email:      karl.yngve@gmail.com
 "
 
+function! vimtex#fzf#run()
+  " The --with-nth 3.. option hides the first two words from the 
+  " fzf window which we used to pass on the file name and line number
+  call fzf#run({  'source':  <sid>parse_toc(),
+        \   'sink':    function('vimtex#fzf#open_selection'),
+        \   'options': '--ansi --with-nth 3..'  
+        \ })
+endfunction
+
+function! vimtex#fzf#open_selection(sel)
+  execute printf('edit +%s %s', split(a:sel)[0], split(a:sel)[1])
+endfunction
+
 function! s:parse_toc()
 " Parsing is mostly adapted from the Denite source
 " (see rplugin/python3/denite/source/vimtex.py)
@@ -53,17 +66,3 @@ EOF
 
   return candidates
 endfunction
-
-function! vimtex#fzf#open_selection(sel)
-  execute printf('edit +%s %s', split(a:sel)[0], split(a:sel)[1])
-endfunction
-
-function! vimtex#fzf#run()
-  " The --with-nth 3.. option hides the first two words from the 
-  " fzf window which we used to pass on the file name and line number
-  call fzf#run({  'source':  <sid>parse_toc(),
-        \   'sink':    function('vimtex#fzf#open_selection'),
-        \   'options': '--ansi --with-nth 3..'  
-        \ })
-endfunction
-

--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -4,7 +4,7 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#fzf#run()
+function! vimtex#fzf#run() abort " {{{1
   " The --with-nth 3.. option hides the first two words from the 
   " fzf window which we used to pass on the file name and line number
   call fzf#run({  'source':  <sid>parse_toc(),
@@ -13,11 +13,15 @@ function! vimtex#fzf#run()
         \ })
 endfunction
 
-function! vimtex#fzf#open_selection(sel)
+" }}}1
+
+function! vimtex#fzf#open_selection(sel) abort " {{{1
   execute printf('edit +%s %s', split(a:sel)[0], split(a:sel)[1])
 endfunction
 
-function! s:parse_toc()
+" }}}1
+
+function! s:parse_toc() abort " {{{1
 " Parsing is mostly adapted from the Denite source
 " (see rplugin/python3/denite/source/vimtex.py)
 python3 << EOF
@@ -66,3 +70,5 @@ EOF
 
   return candidates
 endfunction
+
+" }}}1

--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -1,5 +1,12 @@
-" Parsing is mostly adapted from the Denite source
+" vimtex - LaTeX plugin for Vim
+"
+" Maintainer: Karl Yngve Lervåg
+" Email:      karl.yngve@gmail.com
+"
+
 function! s:parse_toc()
+" Parsing is mostly adapted from the Denite source
+" (see rplugin/python3/denite/source/vimtex.py)
 python3 << EOF
 import vim
 import json

--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -25,7 +25,15 @@ endfunction
 " }}}1
 
 function! vimtex#fzf#open_selection(sel) abort " {{{1
-  execute printf('edit +%s %s', split(a:sel)[0], split(a:sel)[1])
+  let line = split(a:sel)[0]
+  let file = split(a:sel)[1]
+  let curr_file = expand('%:p')
+
+  if curr_file == file
+    execute "normal! " . line . "gg" 
+  else
+    execute printf('edit +%s %s', line, file)
+  endif
 endfunction
 
 " }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3312,6 +3312,19 @@ define a mapping to vimtex#fzf#run() in your .vimrc, e.g.
 
   nnoremap <localleader>lt :call vimtex#fzf#run()<cr>
 
+You can also choose to only show certain entry "layers", according to 
+this table (see |vimtex-toc| for detailed explanation of the "layers")
+
+  c:  content: 
+  t:  todo: 
+  l:  label: 
+  i:  include: 
+
+E.g. to only show Content and Labels use
+  :call vimtex#fzf#run('ct')<cr>
+
+The default behavior is to show all layers, i.e. 'ctli'
+
 ==============================================================================
 COMPILER                                                      *vimtex-compiler*
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -71,6 +71,7 @@ CONTENTS                                                      *vimtex-contents*
     Table of contents                           |vimtex-toc|
       Custom mappings                           |vimtex-toc-custom-maps|
     Denite/Unite source                         |vimtex-denite| / |vimtex-unite|
+    fzf.vim integration                         |vimtex-fzf| 
   Compilation                                   |vimtex-compiler|
     Latexmk                                     |vimtex-latexmk|
     Latexrun                                    |vimtex-latexrun|
@@ -3183,8 +3184,8 @@ parsing the LaTeX project and displaying a table of contents in a separate
 window. For more info, see |vimtex-toc|.
 
 The "engine" for collecting the table-of-content entries may also be used as
-a backend for external plugins. There are sources for |denite.nvim| and
-|unite.vim| that should work well. The source code may be used as inspiration
+a backend for external plugins. There are sources for |denite.nvim|, |unite.vim| 
+and |fzf.vim| that should work well. The source code may be used as inspiration
 to write custom sources or sources for other, similar plugins.
 
 ------------------------------------------------------------------------------
@@ -3298,6 +3299,18 @@ one may override the default mapping, e.g.: >
 
   nnoremap <localleader>lt :<c-u>Denite vimtex<cr>
   nnoremap <localleader>lt :<c-u>Unite vimtex<cr>
+
+------------------------------------------------------------------------------
+FZF INTEGRATION                                                   *vimtex-fzf*
+
+                                           https://github.com/junegunn/fzf.vim
+                                               https://github.com/junegunn/fzf
+|fzf.vim| integrates the general-purpose command-line fuzzy finder |fzf| into 
+vim and neovim. Similar to the |denite.vim| and |unite.vim| source it may be 
+used to quickly navigate |vimtex|' built-in ToC feature. To use it, just
+define a mapping to vimtex#fzf#run() in your .vimrc, e.g.
+
+  nnoremap <localleader>lt :call vimtex#fzf#run()<cr>
 
 ==============================================================================
 COMPILER                                                      *vimtex-compiler*

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3315,13 +3315,13 @@ define a mapping to vimtex#fzf#run() in your .vimrc, e.g.
 You can also choose to only show certain entry "layers", according to 
 this table (see |vimtex-toc| for detailed explanation of the "layers")
 
-  c:  content: 
-  t:  todo: 
-  l:  label: 
-  i:  include: 
+  c:  content
+  t:  todo
+  l:  label 
+  i:  include 
 
 E.g. to only show Content and Labels use
-  :call vimtex#fzf#run('ct')<cr>
+  :call vimtex#fzf#run('ct')
 
 The default behavior is to show all layers, i.e. 'ctli'
 


### PR DESCRIPTION
I adapted the [Denite.vim](https://github.com/lervag/vimtex/blob/master/rplugin/python3/denite/source/vimtex.py) source for use with [fzf.vim](https://github.com/junegunn/fzf.vim). Right now, this is just a basic implementation, which lists all the entries from `vimtex#parser#toc` and lets you jump to the right file and line number. I've never written in vimscript before, so please excuse my beginner mistakes..

Some stuff I'd like to add before this is merged:

- [x] Add colored output 
- [x] Filtering the output, e.g. only show labels or todo items
- [ ] ~Maybe add preview for equations? Does vimtex already have a way to do this?~

