### PR TITLE
Add colors via ansi escape codes when colorama is not installed, c.f. Issue #1350

### DIFF
--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -70,7 +70,15 @@ def colorize(e):
              'todo' : Fore.RED}[e['type']]
     return f"{color}{e['title']:65}{Style.RESET_ALL}"
   except ModuleNotFoundError:
-    return f"{e['title']:65}"
+    import os
+    if os.name  == 'nt': #Windows...
+      return f"{e['title']:65}"
+    else:
+      color = {'content' : "\u001b[37m",
+               'include' : "\u001b[34m",
+               'label' : "\u001b[32m",
+               'todo' : "\u001b[31m"}[e['type']]
+      return f"{color}{e['title']:65}\u001b[0m"
 
 def create_candidate(e, depth):
   number = format_number(dict(e['number']))

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3350,8 +3350,8 @@ The default behavior is to show all layers, i.e. 'ctli'. To only show
 
   :call vimtex#fzf#run('ct')
 
-If the python package Colorama is available, it will be used to provide some
-colors to the listings.
+On Windows the python package Colorama is required for colored output. 
+For Linux and MacOS colors should work out-of-the-box, even without Colorama.
 
 ==============================================================================
 COMPILER                                                      *vimtex-compiler*


### PR DESCRIPTION
I can't test this on Windows right now, but on my Linux install this seems to work fine.