### PR TITLE
make packages_open works

### DIFF
--- a/autoload/vimtex/doc.vim
+++ b/autoload/vimtex/doc.vim
@@ -235,7 +235,7 @@ function! s:packages_open(context) abort " {{{1
         \         ? '!xdg-open'
         \         : (l:os ==# 'mac'
         \            ? '!open'
-        \            : '!start /b'))
+        \            : '!start'))
         \ . ' ' . l:url
         \ . (l:os ==# 'win' ? '' : ' &')
 


### PR DESCRIPTION
# `VimtexDocPackage` not works

I'm using vim 8.1 on windows 10, and <kbd>K</kbd> in normal mode, or equivalently `:VimtexDocPackage package`, dosen't seem to work for me.  After romving the option `/b` of `!start`, everything woks fine. 


I tried
```
start /b http://www.github.com
```
in `cmd.exe`, and it worked, i.e. it brought me to that page with my default browser.  But this command not works within vim, unless I remove `/b` opition from it.


<kbd>K</kbd> is so convenient, and makes me wondering whether it's a bug of vimtex or of my vim :P

# minimal working example
```tex
\documentclass{article}

\usepackage{amsmath}

\begin{document}
minimal working example
\end{document}
```