### PR TITLE
Add new delimiter indent behaviour (cf. #1389)

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1628,14 +1628,13 @@ OPTIONS                                                        *vimtex-options*
     close~
       List of regexes for closing delimiters that should reduce indents.
 
+    close_indented~
+      Set this to 1 if you want the line with the closing delimiter to stay
+      indented.
+
     include_modified_math~
       Set this to 0 if you do not want modified math delimiters such as
       `\left(` and `\right)` to add/reduce indents.
-
-    reduce_on_closing~
-      Set this to 0 if you do not want to reduce indent on the line that
-      contains the closing delimiter (default), but instead want to reduce the
-      indent on the following line.
 
   Note: Vimtex does not allow indents for parantheses only in math mode or any
         similar kind of context aware delimiter indents.
@@ -1645,10 +1644,10 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: >
     let g:vimtex_indent_delims = {
-          \ 'open' : ['{', '\\\@<!\\\['],
-          \ 'close' : ['}', '\\\]'],
+          \ 'open' : ['{'],
+          \ 'close' : ['}'],
+          \ 'close_indented' : 0,
           \ 'include_modified_math' : 1,
-          \ 'reduce_on_closing' : 1,
           \}
 
 *g:vimtex_indent_ignored_envs*

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1619,22 +1619,23 @@ OPTIONS                                                        *vimtex-options*
           \}
 
 *g:vimtex_indent_delims*
-  A dictionary that defines the list of opening and closing delimiters (in
-  regex form) that should add/reduce indents.
-
-  The dictionary has three keys:
+  A dictionary that specifies how to indent delimiters. The dictionary has
+  four keys:
 
     open~
-      List of regexes that defines opening delimiters that should add indents.
+      List of regexes for opening delimiters that should add indents.
 
     close~
-      List of regexes that defines closing delimiters that should reduce
-      indents.
+      List of regexes for closing delimiters that should reduce indents.
 
     include_modified_math~
-      Boolean (1 for True, 0 for False) that sets whether to indent on opening
-      and closing modified math delimiters such as `\left(` and `\right)`. If
-      this value is not set, it is assumed to be 1.
+      Set this to 0 if you do not want modified math delimiters such as
+      `\left(` and `\right)` to add/reduce indents.
+
+    reduce_on_closing~
+      Set this to 0 if you do not want to reduce indent on the line that
+      contains the closing delimiter (default), but instead want to reduce the
+      indent on the following line.
 
   Note: Vimtex does not allow indents for parantheses only in math mode or any
         similar kind of context aware delimiter indents.
@@ -1647,6 +1648,7 @@ OPTIONS                                                        *vimtex-options*
           \ 'open' : ['{', '\\\@<!\\\['],
           \ 'close' : ['}', '\\\]'],
           \ 'include_modified_math' : 1,
+          \ 'reduce_on_closing' : 1,
           \}
 
 *g:vimtex_indent_ignored_envs*

--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -209,22 +209,22 @@ let s:envs_enditem = s:envs_item . '\|' . s:envs_endlist
 
 " }}}1
 function! s:indent_delims(line, lnum, prev_line, prev_lnum) abort " {{{1
-  if s:re_opt.reduce_on_closing
+  if s:re_opt.close_indented
+    return s:sw*(s:count(a:prev_line, s:re_open)
+          \ - s:count(a:prev_line, s:re_close))
+  else
     return s:sw*(  max([  s:count(a:prev_line, s:re_open)
           \             - s:count(a:prev_line, s:re_close), 0])
           \      - max([  s:count(a:line, s:re_close)
           \             - s:count(a:line, s:re_open), 0]))
-  else
-    return s:sw*(s:count(a:prev_line, s:re_open)
-          \ - s:count(a:prev_line, s:re_close))
   endif
 endfunction
 
 let s:re_opt = extend({
       \ 'open' : ['{', '\\\@<!\\\['],
       \ 'close' : ['}', '\\\]'],
+      \ 'close_indented' : 0,
       \ 'include_modified_math' : 1,
-      \ 'reduce_on_closing' : 1,
       \}, get(g:, 'vimtex_indent_delims', {}))
 let s:re_open = join(s:re_opt.open, '\|')
 let s:re_close = join(s:re_opt.close, '\|')

--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -177,12 +177,12 @@ function! s:indent_envs(cur, prev) abort " {{{1
 
   " First for general environments
   let l:ind += s:sw*(
-        \    a:prev =~# '\\begin{.*}'
-        \ && a:prev !~# '\\end{.*}'
+        \    a:prev =~# s:envs_begin
+        \ && a:prev !~# s:envs_end
         \ && a:prev !~# s:envs_ignored)
   let l:ind -= s:sw*(
-        \    a:cur !~# '\\begin{.*}'
-        \ && a:cur =~# '\\end{.*}'
+        \    a:cur !~# s:envs_begin
+        \ && a:cur =~# s:envs_end
         \ && a:cur !~# s:envs_ignored)
 
   " Indentation for prolonged items in lists
@@ -193,8 +193,11 @@ function! s:indent_envs(cur, prev) abort " {{{1
   return l:ind
 endfunction
 
+let s:envs_begin = '\\begin{.*}\|\\\@<!\\\['
+let s:envs_end = '\\end{.*}\|\\\]'
 let s:envs_ignored = '\v'
       \ . join(get(g:, 'vimtex_indent_ignored_envs', ['document']), '|')
+
 let s:envs_lists = join(get(g:, 'vimtex_indent_lists', [
       \ 'itemize',
       \ 'description',
@@ -221,8 +224,8 @@ function! s:indent_delims(line, lnum, prev_line, prev_lnum) abort " {{{1
 endfunction
 
 let s:re_opt = extend({
-      \ 'open' : ['{', '\\\@<!\\\['],
-      \ 'close' : ['}', '\\\]'],
+      \ 'open' : ['{'],
+      \ 'close' : ['}'],
       \ 'close_indented' : 0,
       \ 'include_modified_math' : 1,
       \}, get(g:, 'vimtex_indent_delims', {}))

--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -209,16 +209,22 @@ let s:envs_enditem = s:envs_item . '\|' . s:envs_endlist
 
 " }}}1
 function! s:indent_delims(line, lnum, prev_line, prev_lnum) abort " {{{1
-  return s:sw*(  max([  s:count(a:prev_line, s:re_open)
-        \             - s:count(a:prev_line, s:re_close), 0])
-        \      - max([  s:count(a:line, s:re_close)
-        \             - s:count(a:line, s:re_open), 0]))
+  if s:re_opt.reduce_on_closing
+    return s:sw*(  max([  s:count(a:prev_line, s:re_open)
+          \             - s:count(a:prev_line, s:re_close), 0])
+          \      - max([  s:count(a:line, s:re_close)
+          \             - s:count(a:line, s:re_open), 0]))
+  else
+    return s:sw*(s:count(a:prev_line, s:re_open)
+          \ - s:count(a:prev_line, s:re_close))
+  endif
 endfunction
 
 let s:re_opt = extend({
       \ 'open' : ['{', '\\\@<!\\\['],
       \ 'close' : ['}', '\\\]'],
       \ 'include_modified_math' : 1,
+      \ 'reduce_on_closing' : 1,
       \}, get(g:, 'vimtex_indent_delims', {}))
 let s:re_open = join(s:re_opt.open, '\|')
 let s:re_close = join(s:re_opt.close, '\|')

--- a/test/vader/indentation.vader
+++ b/test/vader/indentation.vader
@@ -365,7 +365,59 @@ Expect tex:
   \end{document}
 
 Given:
+Execute (let g:vimtex_indent_delims = CLOSE_INDENTED):
+  let g:vimtex_indent_delims = {'close_indented': 1}
+
+Given tex (Indent: Various math with 'close_indented' set):
+  \documentclass{minimal}
+  \usepackage{amsmath}
+  \begin{document}
+
+  \[
+    f(x) = 1
+  \]
+
+  {Stuff here
+      asdasd}
+
+  \begin{equation}
+     \left(
+       f(x) = 3
+    \right)
+    \left.
+        f(x) = 3
+  \right.
+  \end{equation}
+  \end{document}
+
+Do:
+  gg=G
+
+Expect tex:
+  \documentclass{minimal}
+  \usepackage{amsmath}
+  \begin{document}
+
+  \[
+    f(x) = 1
+  \]
+
+  {Stuff here
+    asdasd}
+
+  \begin{equation}
+    \left(
+      f(x) = 3
+      \right)
+    \left.
+      f(x) = 3
+      \right.
+  \end{equation}
+  \end{document}
+
+Given:
 Execute (unlet g:vimtex_indent_...):
+  unlet g:vimtex_indent_delims
   unlet g:vimtex_indent_ignored_envs
   unlet g:vimtex_indent_on_ampersands
 


### PR DESCRIPTION
This PR aims to implement a solution for #1389.

A very good contribution to this PR would be to get a good and complicated example for testing that the indent algorithm works as intended.

TODO:
- [x] Ensure that `\[ ... \]` is handled properly
- [ ] Get feedback on the choice of option name
- [ ] Get feedback on whether the feature seems correctly implemented