### PR TITLE
Allow arbitrary hooks into latexmk output.

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -29,7 +29,6 @@ function! vimtex#init_options() abort " {{{1
   call s:init_option('vimtex_compiler_progname',
         \ get(v:, 'progpath', get(v:, 'progname')))
   call s:init_option('vimtex_compiler_callback_hooks', [])
-  call s:init_option('vimtex_compiler_callback_hooks_cont', [])
   call s:init_option('vimtex_compiler_latexmk_engines', {})
   call s:init_option('vimtex_compiler_latexrun_engines', {})
 

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -29,6 +29,7 @@ function! vimtex#init_options() abort " {{{1
   call s:init_option('vimtex_compiler_progname',
         \ get(v:, 'progpath', get(v:, 'progname')))
   call s:init_option('vimtex_compiler_callback_hooks', [])
+  call s:init_option('vimtex_compiler_callback_hooks_cont', [])
   call s:init_option('vimtex_compiler_latexmk_engines', {})
   call s:init_option('vimtex_compiler_latexrun_engines', {})
 

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -524,6 +524,11 @@ function! s:callback_continuous_output(channel, msg) abort " {{{1
   elseif a:msg ==# 'vimtex_compiler_callback_failure'
     call vimtex#compiler#callback(0)
   endif
+
+  for l:Hook in g:vimtex_compiler_callback_hooks_cont
+      call l:Hook(a:msg)
+  endfor
+
 endfunction
 
 " }}}1

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -41,12 +41,12 @@ let s:compiler = {
       \   '-synctex=1',
       \   '-interaction=nonstopmode',
       \ ],
+      \ 'hooks' : [],
       \ 'shell' : fnamemodify(&shell, ':t'),
       \}
 
 function! s:compiler.init(options) abort dict " {{{1
   call extend(self, a:options)
-
   call self.init_check_requirements()
   call self.init_build_dir_option()
   call self.init_pdf_mode_option()
@@ -525,10 +525,9 @@ function! s:callback_continuous_output(channel, msg) abort " {{{1
     call vimtex#compiler#callback(0)
   endif
 
-  for l:Hook in g:vimtex_compiler_callback_hooks_cont
-      call l:Hook(a:msg)
+  for l:Hook in b:vimtex.compiler.hooks
+    call l:Hook(a:msg)
   endfor
-
 endfunction
 
 " }}}1

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -605,6 +605,9 @@ function! s:callback_nvim_output(id, data, event) abort dict " {{{1
   elseif match(a:data, 'vimtex_compiler_callback_failure') != -1
     call vimtex#compiler#callback(0)
   endif
+  for l:Hook in b:vimtex.compiler.hooks
+    call l:Hook(a:data)
+  endfor
 endfunction
 
 " }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -814,6 +814,7 @@ OPTIONS                                                        *vimtex-options*
         \ 'callback' : 1,
         \ 'continuous' : 1,
         \ 'executable' : 'latexmk',
+        \ 'hooks' : [],
         \ 'options' : [
         \   '-verbose',
         \   '-file-line-error',
@@ -877,6 +878,10 @@ OPTIONS                                                        *vimtex-options*
 
   executable~
     The name/path to the `latexmk` executable.
+
+  hooks~
+    A list of funcrefs. If running in continuous mode, each hook will be
+    called for each line of output from `latexmk`, with that line as argument.
 
   options~
     This is a list of options that are passed to `latexmk`. The default


### PR DESCRIPTION
Sometimes when a document takes a long time to compile I'd like to know how far along the build is. This could be easily accomplished by matching latexmk output looking for "Run number [0-9]+ of rule" and doing something with that, but then I need to read latexmk output in a callback. Currently vimtex only allows callbacks when compilation finishes. 

To add more callback support we can mirror how `g:vimtex_compiler_callback_hooks` are handled already.

The option `g:vimtex_compiler_callback_hooks_cont` (`_cont` for continuous) is a list of funcrefs that will be called whenever a line is read as output from latexmk running in continuous mode. That line is passed as an argument to the hook. Funcrefs are used because `execute` with string concatenation will not work; the message can contain arbitrary strings (c.f. SQL injection).

Example usage:

> ``` viml
> function! LatexmkCallback(msg)
> 	let l:m =  matchlist(a:msg, '\vRun number ([0-9]+) of rule ''(.*)''')
> 	if !empty(l:m)
> 		echomsg l:m[2] . ' (' . l:m[1] . ')'
> 	endif
> endfunction
> let g:vimtex_compiler_callback_hooks_cont = [function('LatexmkCallback')]

Whenever a new command is started by latexmk, it is `echomsg`:d with the run number in parentheses.