### PR TITLE
Avoid undefined variable in callback (bug from #1415)

### DIFF
--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -597,6 +597,10 @@ endfunction
 
 " }}}1
 function! s:callback_nvim_output(id, data, event) abort dict " {{{1
+  if !exists('b:vimtex.compiler.hooks')
+    return
+  endif
+
   " Filter out unwanted newlines
   let l:data = split(substitute(join(a:data, 'QQ'), '^QQ\|QQ$', '', ''), 'QQ')
 


### PR DESCRIPTION
At first I wanted to create an issue, but maybe PR will be better.

**The bug**
When compilation was ongoing and I switched buffer to BibTeX file I got a lot of error messages because of usage of undefined variable `b:vimtex` in function `s:callback_nvim_output`. 

**Temporary solution**
I first tried adding check for `b:vimtex`, but it seems that it is defined in *.bib* files as empty dict. So I added check for what is actually used in the function - full `b:vimtex.compiler.hooks`. 

But this probably is not a good solution. I don't know a lot about these compiler hooks from #1415, but my solution will most probably just prevent calling some of them. Not sure how to overcome this, but it feels like a hook function should get some reference to the variable that it wants to use at the moment of hook registration, and not to rely on buffer specific variables, as the user can switch to another buffer any time during compilation. Maybe someone will be able to fix this properly.