### PR TITLE
Add imap `H for \hbar

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -133,6 +133,7 @@ function! vimtex#init_options() abort " {{{1
         \ { 'lhs' : '*',  'rhs' : '\times' },
         \ { 'lhs' : '<',  'rhs' : '\langle' },
         \ { 'lhs' : '>',  'rhs' : '\rangle' },
+        \ { 'lhs' : 'H',  'rhs' : '\hbar' },
         \ { 'lhs' : '[',  'rhs' : '\subseteq' },
         \ { 'lhs' : ']',  'rhs' : '\supseteq' },
         \ { 'lhs' : '(',  'rhs' : '\subset' },


### PR DESCRIPTION
I use `\hbar` a lot and it would be nice to have an imap for it. `` `h `` is taken for `\eta`, but `` `H `` is available.

I thought it logical to put it near `\langle` and `\rangle` because of bra-ket notation.