### PR TITLE
Detect *.cls files as tex filetypes.

### DIFF
--- a/ftdetect/tex.vim
+++ b/ftdetect/tex.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufFilePre,BufRead *.cls setfiletype tex


### PR DESCRIPTION
By default. neither vim nor neovim mark `*.cls` files as of the `tex` filetype.

This is a simple addition I had in my dotfiles that I thought would be a good fit to vimtex. I might be wrong. In case many people interpret  `*.cls` files as something else than a LaTeX class file, then disregard this pull request.