### PR TITLE
document root file name as unique with latexmain

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -547,6 +547,12 @@ File .latexmain specifier~
 <
   Here `path/file.tex.latexmain` indicates for `file1.tex` and `file2.tex`
   that `path/file.tex` is the main LaTeX file.
+  
+  Note that your root file name must be unique. You cannot have a 
+  `path/main.tex.latexmain` for a `path/main.tex` root file, while also 
+  having additional `main.tex` files in other paths, such as 
+  `path/section1/main.tex` and `path/section2/main.tex`.
+
 
 Recursive search~
   If no other method provides an appropriate candidate, then the recursive


### PR DESCRIPTION
I've spent some time fighting with `.latexmain` and vimtex, with the plugin not picking up the right file. I ended up understanding that if the root file has the same name as files inside other folders, it conflicts. Changing the root name file solved it.