### PR TITLE
Enhance regex for fold end marker

### DIFF
--- a/autoload/vimtex/fold/markers.vim
+++ b/autoload/vimtex/fold/markers.vim
@@ -20,7 +20,7 @@ let s:folder = {
       \}
 function! s:folder.init() abort dict " {{{1
   let self.re.start = '%.*' . self.open
-  let self.re.end = '%.*' . self.close
+  let self.re.end = '%[^\\\%]*' . self.close
   let self.re.text = [
         \ [self.re.start . '\d\?\s*\zs.*', '% ' . self.open . ' '],
         \ ['%\s*\zs.*\ze' . self.open, '% ' . self.open . ' '],


### PR DESCRIPTION
Instead of matching every line containing the fold end marker, this RE
matches only the last comment on a line, if the comment does not include
a command (Something started with a literal \).

Helps with #1536

Does not fix it for multiline commands, eg:
```LaTeX
% \emph{
%   \underline{
%     \thirdcommand{
%       content
% }}}
```