### PR TITLE
Add option to insert space after each imap

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -126,6 +126,7 @@ function! vimtex#init_options() abort " {{{1
 
   call s:init_option('vimtex_imaps_enabled', 1)
   call s:init_option('vimtex_imaps_disabled', [])
+  call s:init_option('vimtex_imaps_space', 0)
   call s:init_option('vimtex_imaps_list', [
         \ { 'lhs' : '0',  'rhs' : '\emptyset' },
         \ { 'lhs' : '6',  'rhs' : '\partial' },

--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -100,6 +100,10 @@ function! s:create_map(map) abort " {{{1
     let b:vimtex_context[l:key] = a:map.context
   endif
 
+  if g:vimtex_imaps_space
+    let a:map.rhs .= ' '
+  endif
+
   silent execute 'inoremap <expr><silent><nowait><buffer>' l:lhs
         \ l:wrapper . '("' . escape(l:lhs, '\') . '", ' . string(a:map.rhs) . ')'
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1596,6 +1596,12 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: See `autoload/vimtex.vim` (it's a long list)
 
+*g:vimtex_imaps_space*
+  Use this option to disable/enable the insertion of a space to the end of
+  each mapping.
+
+  Default value: 0
+
 *g:vimtex_include_indicators*
   Vimtex will recognize included files for a lot of different purposes. Most
   of these come from e.g. `\input{file}` or `\include{file}`. This option


### PR DESCRIPTION
This pull request adds the ability to insert a space to the end of the RHS for each imap definition.

I wanted this option personally as it allows for one to use an imap macro, and then continue without pressing the spacebar. For example: ``` `qx``` shall be expanded to `\theta x`, rather than `\thetax` under the current implementation. 

By default, this option is disabled as to not affect current users. When it is toggled on, it affects the definition of all imaps.