### PR TITLE
add and document linters for TeX and BibTeX by compiler files

### DIFF
--- a/compiler/bibertool.vim
+++ b/compiler/bibertool.vim
@@ -1,7 +1,7 @@
 if exists("current_compiler") | finish | endif
 let current_compiler = "bibertool"
 
-if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+if exists(":CompilerSet") != 2    " older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 

--- a/compiler/bibertool.vim
+++ b/compiler/bibertool.vim
@@ -1,0 +1,20 @@
+if exists("current_compiler") | finish | endif
+let current_compiler = "bibertool"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+CompilerSet makeprg=biber\ --tool\ --validate-datamodel\ %:S
+
+let &l:errorformat ="%-PINFO - Globbing data source '%f',"
+let &l:errorformat.="%EERROR - %*[^\\,]\\, line %l\\, %m,"
+setlocal errorformat+=%WWARN\ -\ Datamodel:\ %m
+setlocal errorformat+=%-G%.%#
+silent CompilerSet errorformat
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/compiler/bibertool.vim
+++ b/compiler/bibertool.vim
@@ -12,6 +12,7 @@ CompilerSet makeprg=biber\ --tool\ --validate-datamodel\ %:S
 
 let &l:errorformat ="%-PINFO - Globbing data source '%f',"
 let &l:errorformat.="%EERROR - %*[^\\,]\\, line %l\\, %m,"
+let &l:errorformat.="%WWARN - Datamodel: Entry '%s' (%f): %m,"
 setlocal errorformat+=%WWARN\ -\ Datamodel:\ %m
 setlocal errorformat+=%-G%.%#
 silent CompilerSet errorformat

--- a/compiler/chktex.vim
+++ b/compiler/chktex.vim
@@ -1,0 +1,15 @@
+if exists("current_compiler") | finish | endif
+let current_compiler = "chktex"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+CompilerSet makeprg=chktex\ --localrc\ --inputfiles\ --quiet\ -v6\ %:S
+CompilerSet errorformat="%f",\ line\ %l.%c:\ %m
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/compiler/lacheck.vim
+++ b/compiler/lacheck.vim
@@ -1,0 +1,15 @@
+if exists("current_compiler") | finish | endif
+let current_compiler = "lacheck"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+CompilerSet makeprg=lacheck\ %:S
+CompilerSet errorformat="%f",\ line\ %l:\ %m
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -66,7 +66,7 @@ CONTENTS                                                      *vimtex-contents*
   Indentation                                   |vimtex-indent|
   Syntax highlighting                           |vimtex-syntax|
   Navigation                                    |vimtex-navigation|
-    Include expression (|gf| command)             |vimtex-includeexpr|
+    Include expression (|gf| command)           |vimtex-includeexpr|
     Table of contents                           |vimtex-toc|
       Custom mappings                           |vimtex-toc-custom-maps|
     Denite/Unite source                         |vimtex-denite| / |vimtex-unite|
@@ -76,6 +76,7 @@ CONTENTS                                                      *vimtex-contents*
     Latexrun                                    |vimtex-latexrun|
     Tectonic                                    |vimtex-tectonic|
     Arara                                       |vimtex-arara|
+  Syntax Checking (Linting)                     |vimtex-lint|
   View                                          |vimtex-view|
     Synctex                                     |vimtex-synctex|
     Forward search                              |vimtex-synctex-forward-search|
@@ -3737,6 +3738,30 @@ and |vimtex-tectonic|, the viewer can be started automatically with
 |g:vimtex_view_automatic|.
 
 The compiler may be configured through the |g:vimtex_compiler_arara| option.
+
+==============================================================================
+LINT                                                              *vimtex-lint*
+
+|vimtex| provides syntax checking (linting) for TeX and BibTeX files by
+the `:compiler` command. To lint the open TeX file by lacheck [1] or chktex
+[2], call ':comp lacheck|lmake' respectively ':comp chktex|lmake'
+on the Vim command-line. To lint the currently open BibTeX file by biber [3],
+call ':comp bibertool|lmake' on the Vim command-line. See `:compiler`.
+
+Hint: Often a syntax error in a BibTeX file is due to a missing comma after an
+entry. This command that you may define in after/ftplugin/bib.vim
+
+command! -buffer -range=% -bar AddMissingCommas keeppatterns
+       \ <line1>,<line2>substitute:\v([}"])(\s*\n)+(\s*\a+\s*\=):\1,\2\3:giep
+
+adds them. To call it automatically after saving a BibTeX file, add moreover
+
+autocmd BufWrite <buffer> exe
+      \ 'normal! m`' | silent AddMissingCommas | silent! exe 'normal! g``'
+
+[1] https://ctan.org/pkg/lacheck
+[2] https://www.nongnu.org/chktex
+[3] https://github.com/plk/biber
 
 ==============================================================================
 VIEW                                                              *vimtex-view*

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3765,6 +3765,18 @@ To automatically lint a (BibTeX) file after saving, add to
 
   autocmd BufWrite <buffer=abuf> compiler bibertool | lmake!
 
+If you mind that Vim is unresponsive while linting, run it as a background job
+by replacing the command :lmake by a command :Make such as
+
+- that of vim-dispatch [4], or
+- with AsyncRun.vim [5] installed, such as >
+
+  command! -bang -nargs=* -complete=file Make
+          \ AsyncRun<bang> -auto=make -program=make
+
+The quickfix window that lists the grammar mistakes can then be opened by
+`:cwindow` and they can be jumped to by `:cN` respectively `:cp`.
+
 Hint: Often a syntax error in a BibTeX file is due to a missing comma after an
 entry. This command that you may define in after/ftplugin/bib.vim : >
 
@@ -3781,6 +3793,8 @@ For more full-fledged linting in Vim, see the plug-ins in |vimtex-non-features|.
 [1] https://ctan.org/pkg/lacheck
 [2] https://www.nongnu.org/chktex
 [3] https://github.com/plk/biber
+[4] https://github.com/tpope/vim-dispatch
+[5] https://github.com/skywind3000/asyncrun.vim
 
 ==============================================================================
 VIEW                                                              *vimtex-view*

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3740,24 +3740,44 @@ and |vimtex-tectonic|, the viewer can be started automatically with
 The compiler may be configured through the |g:vimtex_compiler_arara| option.
 
 ==============================================================================
-LINT                                                              *vimtex-lint*
+SYNTAX CHECKING (LINTING)                                       *vimtex-lint*
 
 |vimtex| provides syntax checking (linting) for TeX and BibTeX files by
 the `:compiler` command. To lint the open TeX file by lacheck [1] or chktex
 [2], call ':comp lacheck|lmake' respectively ':comp chktex|lmake'
 on the Vim command-line. To lint the currently open BibTeX file by biber [3],
-call ':comp bibertool|lmake' on the Vim command-line. See `:compiler`.
+call ':comp bibertool|lmake' on the Vim command-line. See |compiler-select|.
+
+The location-list window that lists the compiler messages can then be opened by
+|:lwindow| and they can be jumped to by |:lN| respectively |:lp|. See
+|location-list|.
+
+For convenience, define a command for linting for each file type. For example,
+for BibTeX by adding to ~/.vim/after/ftplugin/bib.vim  >
+
+  command! -buffer -bang Lint compiler bibertool | lmake<bang>
+
+To automatically lint a (BibTeX) file after saving, add to
+~/.vim/after/ftplugin/bib.vim : >
+
+  autocmd BufWrite <buffer=abuf> compiler bibertool | lmake!
+
+To automatically open the location-list window after linting finished, add >
+
+  autocmd QuickFixCmdPost lmake lwindow`
 
 Hint: Often a syntax error in a BibTeX file is due to a missing comma after an
-entry. This command that you may define in after/ftplugin/bib.vim
+entry. This command that you may define in after/ftplugin/bib.vim : >
 
-command! -buffer -range=% -bar AddMissingCommas keeppatterns
-       \ <line1>,<line2>substitute:\v([}"])(\s*\n)+(\s*\a+\s*\=):\1,\2\3:giep
+  command! -buffer -range=% -bar AddMissingCommas keeppatterns
+        \ <line1>,<line2>substitute:\v([}"])(\s*\n)+(\s*\a+\s*\=):\1,\2\3:giep
 
-adds them. To call it automatically after saving a BibTeX file, add moreover
+adds them. To call it automatically after saving a BibTeX file, add moreover >
 
-autocmd BufWrite <buffer> exe
-      \ 'normal! m`' | silent AddMissingCommas | silent! exe 'normal! g``'
+  autocmd BufWrite <buffer> exe
+        \ 'normal! m`' | silent AddMissingCommas | silent! exe 'normal! g``'
+
+For more full-fledged linting in Vim, see the plug-ins in |vimtex-non-features|.
 
 [1] https://ctan.org/pkg/lacheck
 [2] https://www.nongnu.org/chktex

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3748,11 +3748,14 @@ the `:compiler` command. To lint the open TeX file by lacheck [1] or chktex
 on the Vim command-line. To lint the currently open BibTeX file by biber [3],
 call ':comp bibertool|lmake' on the Vim command-line. See |compiler-select|.
 
-The location-list window that lists the compiler messages can then be opened by
-|:lwindow| and they can be jumped to by |:lN| respectively |:lp|. See
-|location-list|.
+The location-list window that lists the compiler messages can then be opened
+by |:lwindow| and they can be jumped to by |:lN| respectively |:lp|. See
+|location-list|. To automatically open the location-list window after linting
+finished, add to your |vimrc| >
 
-For convenience, define a command for linting for each file type. For example,
+  autocmd QuickFixCmdPost lmake lwindow
+
+For convenience, define a command for linting for each file type: For example,
 for BibTeX by adding to ~/.vim/after/ftplugin/bib.vim  >
 
   command! -buffer -bang Lint compiler bibertool | lmake<bang>
@@ -3761,10 +3764,6 @@ To automatically lint a (BibTeX) file after saving, add to
 ~/.vim/after/ftplugin/bib.vim : >
 
   autocmd BufWrite <buffer=abuf> compiler bibertool | lmake!
-
-To automatically open the location-list window after linting finished, add >
-
-  autocmd QuickFixCmdPost lmake lwindow`
 
 Hint: Often a syntax error in a BibTeX file is due to a missing comma after an
 entry. This command that you may define in after/ftplugin/bib.vim : >


### PR DESCRIPTION
The support for the Lacheck linter was removed in 79783537c5cb33d37057fa04df6b8f3e0671b924 because 

> ... there exist several (good) external plugins for syntax checking files. These are general purpose plugins that work for multiple file types ...

like [Ale](https://github.com/w0rp/ale) or [syntastic](https://github.com/vim-syntastic/syntastic).

However, as said above, these are general purpose. Instead of installing over a hundred linters, this patch provides simple compiler files that you are interested in as a TeX author to lint  your TeX or bibTeX file because of mysterious compilation errors.

My main motivation is that I found `compiler/bibertool.vim` useful for linting a BibTeX file, showing syntax errors LaTeX sometimes does not point to clearly, and warnings of missing or unknown entries. In making it public, this place deemed the most pertinent one.