### PR TITLE
add positioning for pdf viewer

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -295,6 +295,8 @@ function! vimtex#init_options() abort " {{{1
   call s:init_option('vimtex_view_skim_activate', 0)
   call s:init_option('vimtex_view_skim_reading_bar', 1)
   call s:init_option('vimtex_view_zathura_options', '')
+  call s:init_option('vimtex_view_zathura_move', '0 0')
+  call s:init_option('vimtex_view_zathura_size', '1366 742')
 endfunction
 
 " }}}1

--- a/autoload/vimtex/view/common.vim
+++ b/autoload/vimtex/view/common.vim
@@ -185,3 +185,26 @@ function! s:xwin_template.xwin_send_keys(keys) dict abort " {{{1
 endfunction
 
 " }}}1
+function! s:move(x, y) dict abort " {{{1
+  if !executable('xdotool') || self.xwin_id <= 0
+    return
+  endif
+
+  let l:cmd = 'xdotool windowmove ' . self.xwin_get_id() 
+  let l:cmd .= ' ' . x,' ' y
+  let self.process = vimtex#process#start(l:cmd)
+endfunction
+
+" }}}1
+function! s:resize(width, height) dict abort " {{{1
+  if !executable('xdotool') || self.xwin_id <= 0
+    return
+  endif
+
+  let l:cmd = 'xdotool windowsize ' . self.xwin_get_id() 
+  let l:cmd .= ' ' . width, ' ', height
+  let self.process = vimtex#process#start(l:cmd)
+endfunction
+
+" }}}1
+

--- a/autoload/vimtex/view/common.vim
+++ b/autoload/vimtex/view/common.vim
@@ -190,8 +190,8 @@ function! s:move(x, y) dict abort " {{{1
     return
   endif
 
-  let l:cmd = 'xdotool windowmove ' . self.xwin_get_id() 
-  let l:cmd .= ' ' . x,' ' y
+  let l:cmd = 'xdotool windowmove ' . self.xwin_get_id()
+  let l:cmd .= ' ' x,' ' y
   let self.process = vimtex#process#start(l:cmd)
 endfunction
 
@@ -201,10 +201,9 @@ function! s:resize(width, height) dict abort " {{{1
     return
   endif
 
-  let l:cmd = 'xdotool windowsize ' . self.xwin_get_id() 
-  let l:cmd .= ' ' . width, ' ', height
+  let l:cmd = 'xdotool windowsize ' . self.xwin_get_id()
+  let l:cmd .= ' ' width, ' ', height
   let self.process = vimtex#process#start(l:cmd)
 endfunction
 
 " }}}1
-

--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -59,6 +59,24 @@ function! s:zathura.start(outfile) dict abort " {{{1
 
   call self.xwin_get_id()
   let self.outfile = a:outfile
+  call self.move()
+  call self.size()
+endfunction
+
+"set zathura viewer position to the desired coordinate
+function! s:zathura.move() dict abort " {{{1
+  let l:cmd  = 'xdotool'
+  let l:cmd .= ' windowmove ' . self.xwin_get_id() 
+  let l:cmd .= ' ' . g:vimtex_view_zathura_move
+  let self.process = vimtex#process#start(l:cmd)
+endfunction
+
+"set zathura viewer size to the desired dimension
+function! s:zathura.size() dict abort " {{{1
+  let l:cmd  = 'xdotool'
+  let l:cmd .= ' windowsize ' . self.xwin_get_id() 
+  let l:cmd .= ' ' . g:vimtex_view_zathura_size
+  let self.process = vimtex#process#start(l:cmd)
 endfunction
 
 " }}}1


### PR DESCRIPTION
Hi Karl,

Thank you for the great Plugin.

I (am not a i3 user and therefore) needed a way to position my zathura viewer after opening it.

Well, I ended up spending a while to figure it out. Would be great if it could go upstream (maybe in a modified version).

Especially default values should be checked and probably an on/off-switch added. Some additional documentation could also not be a bad idea. Let me know if you want me to help you with that despite my obvious lack of vimscipt knowledge :)

Best,
Tobias