### PR TITLE
Fix usage of vim and add some notes on running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,16 @@ When submitting code for vimtex, please adhere to the following standards:
     that when folded, I get a nice structural overview of a file
   - See some of the files for examples of how I do this
 
+## Running tests
+
+New functionality should be accompanied by tests.
+Tests can be run from the test/tests folder by executing `make`.
+Running tests requires the following, which may not come with all Linux distributions and may need to be installed with your favorite package manager (e.g. yum, apt-get, or brew on Mac).
+
+- wget
+- chronic (from [moreutils](https://joeyh.name/code/moreutils/))
+
+Other tips
+
+By default, tests execute with the Neovim executable `nvim`. You can change the executable by setting the environment variable `MYVIM` before running.
+To run with vanilla vim, use `MYVIM="vim -T dumb --not-a-term --noplugin -n" make`.

--- a/test/tests/test-completion-glossary/Makefile
+++ b/test/tests/test-completion-glossary/Makefile
@@ -10,12 +10,12 @@ TARGETS := glossaries glossaries-extra
 test: $(TARGETS)
 
 glossaries: glossaries.aux
-	@nvim --headless -u $@.vim
+	@$(MYVIM) -u $@.vim
 	@latexmk -C $@.tex >/dev/null 2>&1
 
 glossaries-extra:
-	@TEXFILE=$@-1.tex nvim --headless -u $@.vim
-	@TEXFILE=$@-2.tex nvim --headless -u $@.vim
+	@TEXFILE=$@-1.tex $(MYVIM) -u $@.vim
+	@TEXFILE=$@-2.tex $(MYVIM) -u $@.vim
 
 %.aux: %.tex
 	@latexmk $< >/dev/null 2>&1


### PR DESCRIPTION
The glossaries test was hardcoded to use `nvim --headless` instead of `MYVIM`, so it failed even when the variable was overridden.

I also made some notes in the CONTRIBUTING document on how to run tests. I'm happy to edit as  you see fit.