### PR TITLE
Add an imap for Feynman slash notation

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -140,6 +140,7 @@ function! vimtex#init_options() abort " {{{1
         \ { 'lhs' : '>',  'rhs' : '\rangle' },
         \ { 'lhs' : 'H',  'rhs' : '\hbar' },
         \ { 'lhs' : '+',  'rhs' : '\dagger' },
+        \ { 'lhs' : '/',  'rhs' : ':call vimtex#imaps#feynmanslash()' },
         \ { 'lhs' : '[',  'rhs' : '\subseteq' },
         \ { 'lhs' : ']',  'rhs' : '\supseteq' },
         \ { 'lhs' : '(',  'rhs' : '\subset' },

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -140,7 +140,7 @@ function! vimtex#init_options() abort " {{{1
         \ { 'lhs' : '>',  'rhs' : '\rangle' },
         \ { 'lhs' : 'H',  'rhs' : '\hbar' },
         \ { 'lhs' : '+',  'rhs' : '\dagger' },
-        \ { 'lhs' : '/',  'rhs' : ':call vimtex#imaps#feynmanslash()' },
+        \ { 'lhs' : '/',  'rhs' : 'vimtex#imaps#feynmanslash()', 'expr' : 1 },
         \ { 'lhs' : '[',  'rhs' : '\subseteq' },
         \ { 'lhs' : ']',  'rhs' : '\supseteq' },
         \ { 'lhs' : '(',  'rhs' : '\subset' },

--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -149,6 +149,11 @@ function! vimtex#imaps#wrap_environment(lhs, rhs) abort " {{{1
   return l:return
 endfunction
 
+function! vimtex#imaps#feynmanslash()
+  let l:c = getchar()
+  execute "normal a\\slashed{" . nr2char(l:c) . "}\<Esc>"
+endfunction
+
 " }}}1
 
 "

--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -99,9 +99,12 @@ function! s:create_map(map) abort " {{{1
     endif
     let b:vimtex_context[l:key] = a:map.context
   endif
+  if ! get(a:map, 'expr', 0)
+    let a:map.rhs = string(a:map.rhs)
+  endif
 
   silent execute 'inoremap <expr><silent><nowait><buffer>' l:lhs
-        \ l:wrapper . '("' . escape(l:lhs, '\') . '", ' . string(a:map.rhs) . ')'
+        \ l:wrapper . '("' . escape(l:lhs, '\') . '", ' . a:map.rhs . ')'
 
   let s:created_maps += [a:map]
 endfunction
@@ -151,7 +154,7 @@ endfunction
 
 function! vimtex#imaps#feynmanslash()
   let l:c = getchar()
-  execute "normal a\\slashed{" . nr2char(l:c) . "}\<Esc>"
+  return '\slashed{' . nr2char(l:c) . '}'
 endfunction
 
 " }}}1


### PR DESCRIPTION
```
`/p -> \slashed{p}
```

One can also imagine similar mappings like `` `_v -> \mathbf{v} ``.