### PR TITLE
Add imaps of the type <leader>xc -> \$command{c}.

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -198,7 +198,7 @@ function! vimtex#init_options() abort " {{{1
         \ { 'lhs' : 'b',  'rhs' : 'vimtex#imaps#style("mathbf")', 'expr' : 1, 'leader' : '#'},
         \ { 'lhs' : 'f',  'rhs' : 'vimtex#imaps#style("mathfrak")', 'expr' : 1, 'leader' : '#'},
         \ { 'lhs' : 'c',  'rhs' : 'vimtex#imaps#style("mathcal")', 'expr' : 1, 'leader' : '#'},
-        \ { 'lhs' : '-',  'rhs' : 'vimtex#imaps#format("overline")', 'expr' : 1, 'leader' : '#'},
+        \ { 'lhs' : '-',  'rhs' : 'vimtex#imaps#style("overline")', 'expr' : 1, 'leader' : '#'},
         \])
 
   call s:init_option('vimtex_mappings_enabled', 1)

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -199,6 +199,7 @@ function! vimtex#init_options() abort " {{{1
         \ { 'lhs' : 'f',  'rhs' : 'vimtex#imaps#style("mathfrak")', 'expr' : 1, 'leader' : '#'},
         \ { 'lhs' : 'c',  'rhs' : 'vimtex#imaps#style("mathcal")', 'expr' : 1, 'leader' : '#'},
         \ { 'lhs' : '-',  'rhs' : 'vimtex#imaps#style("overline")', 'expr' : 1, 'leader' : '#'},
+        \ { 'lhs' : 'B',  'rhs' : 'vimtex#imaps#style("mathbb")', 'expr' : 1, 'leader' : '#'},
         \])
 
   call s:init_option('vimtex_mappings_enabled', 1)

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -194,6 +194,11 @@ function! vimtex#init_options() abort " {{{1
         \ { 'lhs' : 'vk', 'rhs' : '\varkappa' },
         \ { 'lhs' : 'vq', 'rhs' : '\vartheta' },
         \ { 'lhs' : 'vr', 'rhs' : '\varrho' },
+        \ { 'lhs' : '/',  'rhs' : 'vimtex#imaps#style("slashed")', 'expr' : 1, 'leader' : '#'},
+        \ { 'lhs' : 'b',  'rhs' : 'vimtex#imaps#style("mathbf")', 'expr' : 1, 'leader' : '#'},
+        \ { 'lhs' : 'f',  'rhs' : 'vimtex#imaps#style("mathfrak")', 'expr' : 1, 'leader' : '#'},
+        \ { 'lhs' : 'c',  'rhs' : 'vimtex#imaps#style("mathcal")', 'expr' : 1, 'leader' : '#'},
+        \ { 'lhs' : '-',  'rhs' : 'vimtex#imaps#format("overline")', 'expr' : 1, 'leader' : '#'},
         \])
 
   call s:init_option('vimtex_mappings_enabled', 1)

--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -155,6 +155,9 @@ function! vimtex#imaps#wrap_environment(lhs, rhs) abort " {{{1
 endfunction
 
 function! vimtex#imaps#style(command)
+  if !s:is_math()
+    return ''
+  endif
   let l:c = getchar()
   return '\' . a:command . '{' . nr2char(l:c) . '}'
 endfunction

--- a/autoload/vimtex/imaps.vim
+++ b/autoload/vimtex/imaps.vim
@@ -101,9 +101,12 @@ function! s:create_map(map) abort " {{{1
     endif
     let b:vimtex_context[l:key] = a:map.context
   endif
+  if !get(a:map, 'expr')
+    let a:map.rhs = string(a:map.rhs)
+  endif
 
   silent execute 'inoremap <expr><silent><nowait><buffer>' l:lhs
-        \ l:wrapper . '("' . escape(l:lhs, '\') . '", ' . string(a:map.rhs) . ')'
+        \ l:wrapper . '("' . escape(l:lhs, '\') . '", ' . a:map.rhs . ')'
 
   let s:created_maps += [a:map]
 endfunction
@@ -151,6 +154,10 @@ function! vimtex#imaps#wrap_environment(lhs, rhs) abort " {{{1
   return l:return
 endfunction
 
+function! vimtex#imaps#style(command)
+  let l:c = getchar()
+  return '\' . a:command . '{' . nr2char(l:c) . '}'
+endfunction
 " }}}1
 
 "

--- a/test/tests/test-imaps/test.vim
+++ b/test/tests/test-imaps/test.vim
@@ -35,6 +35,11 @@ call vimtex#test#keys('$i#bv',
       \['$2+2 = $'],
       \['$2+2 = \mathbf{v}$'])
 
+" Should not gobble a character outside of math mode
+call vimtex#test#keys('$a#bv',
+      \['$2+2 = $'],
+      \['$2+2 = $#bv'])
+
 " Test ;; -> ; (leader escape)
 call vimtex#test#keys('$i;;',
       \['$;; = $'],

--- a/test/tests/test-imaps/test.vim
+++ b/test/tests/test-imaps/test.vim
@@ -30,6 +30,11 @@ call vimtex#test#keys('$i;b;;',
       \['$2+2 = $'],
       \['$2+2 = \beta;$'])
 
+" Test #bv -> \mathbf{v}
+call vimtex#test#keys('$i#bv',
+      \['$2+2 = $'],
+      \['$2+2 = \mathbf{v}$'])
+
 " Test ;; -> ; (leader escape)
 call vimtex#test#keys('$i;;',
       \['$;; = $'],


### PR DESCRIPTION
Useful for commands such as mathbf, mathfrak, mathcal.  For now, specify these like
`    \ { 'lhs' : 'b',  'rhs' : 'vimtex#imaps#style("mathbf")', 'expr' : 1, 'leader' : '#'},`
where `'expr'` makes vimtex evaluate the rhs as an expression, and `vimtex#imaps#style` is a helper function.

Refactoring and generalization of #1611.