### PR TITLE
Avoid SyntaxWarning on Py38.

### DIFF
--- a/rplugin/python3/denite/source/vimtex.py
+++ b/rplugin/python3/denite/source/vimtex.py
@@ -22,7 +22,7 @@ class Source(Base):
                'section',
                'subsection',
                'subsubsection',
-               'subsubsubsection'] if n[k] is not 0]
+               'subsubsubsection'] if n[k] != 0]
 
         if n['appendix']:
             num[0] = chr(int(num[0]) + 64)


### PR DESCRIPTION
`n[k] is not 0` results in
`SyntaxWarning: "is not" with a literal. Did you mean "!="?`
on Py3.8.