### PR TITLE
Add tsf for toggling inline vs displayed fractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ disabled if desired.
     `csc`/`cse`/`cs$`/`csd`
   - Toggle starred command or environment with `tsc`/`tse`
   - Toggle between e.g. `()` and `\left(\right)` with `tsd`
+  - Toggle (inline) fractions with `tsf`
   - Close the current environment/delimiter in insert mode with `]]`
   - Insert new command with `<F7>`
   - Convenient insert mode mappings for faster typing of e.g. maths

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -491,6 +491,7 @@ function! s:init_default_mappings() abort " {{{1
   call s:map('n', 'dsc',  '<plug>(vimtex-cmd-delete)')
   call s:map('n', 'csc',  '<plug>(vimtex-cmd-change)')
   call s:map('n', 'tsc',  '<plug>(vimtex-cmd-toggle-star)')
+  call s:map('n', 'tsf',  '<plug>(vimtex-cmd-toggle-frac)')
   call s:map('i', '<F7>', '<plug>(vimtex-cmd-create)')
   call s:map('n', '<F7>', '<plug>(vimtex-cmd-create)')
   call s:map('x', '<F7>', '<plug>(vimtex-cmd-create)')

--- a/autoload/vimtex/test.vim
+++ b/autoload/vimtex/test.vim
@@ -50,9 +50,26 @@ function! vimtex#test#keys(keys, context, expected) abort " {{{1
   call append(1, a:context)
   normal! ggdd
 
-  silent execute 'normal' a:keys
+  let l:fail_msg = ['keys: ' . a:keys]
+  let l:fail_msg += ['context:']
+  let l:fail_msg += map(copy(a:context), '"  " . v:val')
+  let l:fail_msg += ['expected:']
+  let l:fail_msg += map(copy(a:expected), '"  " . v:val')
 
-  call vimtex#test#assert_equal(getline(1, line('$')), a:expected)
+  try
+    silent execute 'normal' a:keys
+  catch
+    let l:fail_msg += ['error:']
+    let l:fail_msg += ['  ' . v:exception]
+    call s:fail(l:fail_msg)
+  endtry
+
+  let l:result = getline(1, line('$'))
+  if l:result ==# a:expected | return 1 | endif
+
+  let l:fail_msg += ['result:']
+  let l:fail_msg += map(l:result, '"  " . v:val')
+  call s:fail(l:fail_msg)
 endfunction
 
 " }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -171,6 +171,7 @@ FEATURE OVERVIEW                                              *vimtex-features*
     `csc`/`cse`/`cs$`/`csd`
   - Toggle starred command or environment with `tsc`/`tse`
   - Toggle between e.g. `()` and `\left(\right)` with `tsd`/`tsD`
+  - Toggle (inline) fractions with `tsf`
   - Close the current environment/delimiter in insert mode with `]]`
   - Insert new command with `<F7>`
   - Convenient insert mode mappings for faster typing of e.g. maths
@@ -741,6 +742,7 @@ This feature is explained in more detail later, see |vimtex-imaps|.
    csc              |<plug>(vimtex-cmd-change)|                     `n`
    cs$              |<plug>(vimtex-env-change-math)|                `n`
    csd              |<plug>(vimtex-delim-change-math)|              `n`
+   tsf              |<plug>(vimtex-cmd-toggle-frac)|                `n`
    tsc              |<plug>(vimtex-cmd-toggle-star)|                `n`
    tse              |<plug>(vimtex-env-toggle-star)|                `n`
    tsd              |<plug>(vimtex-delim-toggle-modifier)|          `nx`

--- a/test/tests/test-commands/test-toggles.vim
+++ b/test/tests/test-commands/test-toggles.vim
@@ -28,4 +28,34 @@ call vimtex#test#keys('f+tsd', [
       \ '\( a^2 + b^2 = c^2 \)',
       \])
 
+" tsf  /  Toggle surrounding fraction
+for [s:in, s:out] in [
+      \ ['$\frac{x+1}{x-1}$', '$(x+1)/(x-1)$'],
+      \ ['$\frac {x+1}  {x-1}$', '$(x+1)/(x-1)$'],
+      \ ['$\frac {x-1} x$', '$(x-1)/x$'],
+      \ ['$\frac x  {x-1}$', '$x/(x-1)$'],
+      \ ['$x / (x-1)$', '$\frac{x}{x-1}$'],
+      \ ['$(x-1) /x$', '$\frac{x-1}{x}$'],
+      \ ['$(x+1)  /(x-1)$', '$\frac{x+1}{x-1}$'],
+      \ ['$(x+1)/ (x-1)$', '$\frac{x+1}{x-1}$'],
+      \ ['$\alpha/\mu$', '$\frac{\alpha}{\mu}$'],
+      \ ['$\frac{\alpha}{\mu}$', '$\alpha/\mu$'],
+      \ ['$(r+t)/((\mu))$', '$\frac{r+t}{(\mu)}$'],
+      \ ['$((\mu))/(r+t)$', '$\frac{(\mu)}{r+t}$'],
+      \ ['$\frac{\delta_{02}}{\delta_{02} + \delta_{01}}$',
+      \  '$(\delta_{02})/(\delta_{02} + \delta_{01})$'],
+      \ ['$(\delta_{02})/(\delta_{02} + \delta_{01})$',
+      \  '$\frac{\delta_{02}}{\delta_{02} + \delta_{01}}$'],
+      \ ['\(a/p_\text{b}\)', '\(\frac{a}{p_\text{b}}\)'],
+      \ ['$f(x+y)/g(z)$', '$\frac{f(x+y)}{g(z)}$'],
+      \ ['$f(x)g(y)/h(z)$', '$\frac{f(x)g(y)}{h(z)}$'],
+      \]
+  if s:in =~# '\/'
+    call vimtex#test#keys('f/ltsf', [s:in], [s:out])
+    call vimtex#test#keys('f/htsf', [s:in], [s:out])
+  else
+    call vimtex#test#keys('f{tsf', [s:in], [s:out])
+  endif
+endfor
+
 quit!


### PR DESCRIPTION
I've finally made a prototype version of this feature (cf. #1390). It is not going to be perfect (I won't fix all edge cases), but it is probably still not quite ready. Please feel free to test and provide feedback!

It would be good to get some example of inline sentences that does not work as expected. Examples should be given as:

1. A single line of text in which fraction toggle should work.
2. The position in the line where the toggle is activated.
3. The expected result.
4. The observed result.

PS! Sorry for taking so very long to work on this issue! However, I think this should be not so far from finished now.