### PR TITLE
doc: vimtex_delim_{,insert_}timeout - specify unit

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1314,10 +1314,10 @@ OPTIONS                                                        *vimtex-options*
 
 *g:vimtex_delim_timeout*
 *g:vimtex_delim_insert_timeout*
-  Timeout when searching for matching delimiters. It is used for the {timeout}
-  argument of |search()|-like function calls. If the option is increased it
-  will make the matching more accurate, at the expense of potential lags. The
-  default value should work well for most people.
+  Timeout (in milliseconds) when searching for matching delimiters. It is used
+  for the {timeout} argument of |search()|-like function calls. If the option
+  is increased it will make the matching more accurate, at the expense of
+  potential lags. The default value should work well for most people.
 
   Default values: 300, 60 (respectively)
 


### PR DESCRIPTION
Specify the unit (in this case milliseconds) of the values to the two options
`g:vimtex_delim_timeout` and `g:vimtex_delim_insert_timeout`.

When I read the docs for the above two functions I was ok. But later I realised the values are not seconds but milliseconds even though the default values pretty much look seconds like. Therefore, I suggest to explicitly state what unit the the values for these options have.

*Important:* I have not checked whether all uses of these two variables in the vimtex codebase are indeed milliseconds. I relied on the documentation stating that it is used for the `search()` function whose argument is in milliseconds.