### PR TITLE
Recognize \subfileinclude{file} as file include

### DIFF
--- a/autoload/vimtex/re.vim
+++ b/autoload/vimtex/re.vim
@@ -11,7 +11,7 @@ let g:vimtex#re#tex_input_root =
       \ '\v^\s*\%\s*!?\s*[tT][eE][xX]\s+[rR][oO][oO][tT]\s*\=\s*\zs.*\ze\s*$'
 let g:vimtex#re#tex_input_latex = '\v\\%('
       \ . join(get(g:, 'vimtex_include_indicators',
-      \            ['input', 'include', 'subfile']),
+      \            ['input', 'include', 'subfile', 'subfileinclude']),
       \        '|') . ')\s*\{'
 let g:vimtex#re#tex_input_import =
       \ '\v\\%(sub)?%(import|%(input|include)from)\*?\{[^\}]*\}\{'

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1656,7 +1656,7 @@ OPTIONS                                                        *vimtex-options*
   Note: This option is read during initialization of vimtex, and so it must be
         set early. I.e., it can not be set in `after/ftplugin/tex.vim`.
 
-  Default value: ['input', 'include', 'subfile']
+  Default value: ['input', 'include', 'subfile', 'subfileinclude']
 
 *g:vimtex_include_search_enabled*
   Vimtex sets 'includeexpr' to recognize included files. If a file isn't found


### PR DESCRIPTION
Add 'subfileinclude' to the recognized include indicators (option
g:vimtex_include_indicators). \subfileinclude is a variant of \subfile
and is provided by the subfiles [0] package (since version 1.5).

[0] https://www.ctan.org/pkg/subfiles