### PR TITLE
Use non-greedy match for lstinline/lstinputlisting

### DIFF
--- a/autoload/vimtex/syntax/p/listings.vim
+++ b/autoload/vimtex/syntax/p/listings.vim
@@ -10,9 +10,9 @@ function! vimtex#syntax#p#listings#load() abort " {{{1
 
   " First some general support
   syntax match texInputFile
-        \ "\\lstinputlisting\s*\(\[.*\]\)\={.\{-}}"
+        \ "\\lstinputlisting\s*\(\[.\{-}\]\)\={.\{-}}"
         \ contains=texStatement,texInputCurlies,texInputFileOpt
-  syntax match texZone "\\lstinline\s*\(\[.*\]\)\={.\{-}}"
+  syntax match texZone "\\lstinline\s*\(\[.\{-}\]\)\={.\{-}}"
 
   " Set all listings environments to listings
   syntax cluster texFoldGroup add=texZoneListings


### PR DESCRIPTION
Use a non-greedy match (`.\{-}`) instead of `.*` for matching the contents of square brackets after `\lstinline` or `\lstinputlisting`.

This PR fixes an issue where:

`\lstinline[language=Bash]{cd ..} some text and another \lstinline[language=Bash]{ls}`

would be all matched and highlighted as an entire texZone/texInputFile instead of two separate regions.