### PR TITLE
Allow customizing FZF parameters

### DIFF
--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -13,13 +13,23 @@ function! vimtex#fzf#run(...) abort " {{{1
   "     i:  include: This shows included files
   " The default behavior is to show all entries, e.g. 'ctli'
 
+  " A second argument can be passed to this function to customize the FZF
+  " options. It should be an object containing the parameters passed to
+  " fzf#run().
+
   " The --with-nth 3.. option hides the first two words from the fzf window
   " which we used to pass on the file name and line number
-  call fzf#run({
+  let default_parameters = {
       \ 'source': <sid>parse_toc(a:0 == 0 ? 'ctli' : a:1),
       \ 'sink': function('vimtex#fzf#open_selection'),
       \ 'options': '--ansi --with-nth 3..',
-      \})
+      \}
+
+  if a:0 > 1
+    call extend(default_parameters, a:2)
+  endif
+
+  call fzf#run(default_parameters)
 endfunction
 
 " }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3702,6 +3702,14 @@ The default behavior is to show all layers, i.e. 'ctli'. To only show
 On Windows the python package Colorama is required for colored output.
 For Linux and MacOS colors should work out-of-the-box, even without Colorama.
 
+A second argument can be passed to this function to customize the FZF options. 
+It should be an object containing the parameters passed to `fzf#run()`. For 
+example, if you've defined `g:fzf_layout`, then those options can be passed to 
+`vimtex#fzf#run`: >
+
+    :call vimtex#fzf#run('ctli', g:fzf_layout)
+
+
 ==============================================================================
 COMPILER                                                      *vimtex-compiler*
 


### PR DESCRIPTION
Hey!

I had defined a custom default FZF layout for myself using `let g:fzf_layout = { ... }`, but this didn't customize the Vimtex FZF window. So, I figured that it would be nice to allow the FZF window to be customized.

I suppose that another approach would be to use the `g:fzf_layout` variable automatically if it has been defined. But that might have some unexpected consequences for some people so I implemented a more explicit configuration method.

I didn't add/change any tests since I couldn't find anything related to the FZF integration.