### PR TITLE
Fix bug where stopping and starting compile causes multiple hooks registered

### DIFF
--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -43,8 +43,11 @@ function! vimtex#view#init_state(state) abort " {{{1
   " Add compiler callback to callback hooks (if it exists)
   "
   if exists('*l:v.compiler_callback')
-    call add(g:vimtex_compiler_callback_hooks,
-          \ 'b:vimtex.viewer.compiler_callback')
+    if index(g:vimtex_compiler_callback_hooks,
+          \ 'b:vimtex.viewer.compiler_callback') == -1
+      call add(g:vimtex_compiler_callback_hooks,
+            \ 'b:vimtex.viewer.compiler_callback')
+    endif
   endif
 
   "


### PR DESCRIPTION
`g:vimtex_compiler_callback_hooks` gets multiple entries of `b:vimtex.viewer.compiler_callback` in it. This stops that and ensures just one gets added.