### PR TITLE
Allow vimtex to override global mappings that use the same key sequences.

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -204,6 +204,7 @@ function! vimtex#init_options() abort " {{{1
 
   call s:init_option('vimtex_mappings_enabled', 1)
   call s:init_option('vimtex_mappings_disable', {})
+  call s:init_option('vimtex_mappings_override_existing', 0)
 
   call s:init_option('vimtex_matchparen_enabled', 1)
   call s:init_option('vimtex_motion_enabled', 1)
@@ -470,7 +471,8 @@ function! s:init_default_mappings() abort " {{{1
   function! s:map(mode, lhs, rhs, ...) abort
     if !hasmapto(a:rhs, a:mode)
           \ && index(get(g:vimtex_mappings_disable, a:mode, []), a:lhs) < 0
-          \ && (empty(maparg(a:lhs, a:mode)) || a:0 > 0)
+          \ && (a:0 > 0 || get(g:, 'vimtex_mappings_override_existing', 0) > 0
+                \ || empty(maparg(a:lhs, a:mode)))
       silent execute a:mode . 'map <silent><nowait><buffer>' a:lhs a:rhs
     endif
   endfunction

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1782,6 +1782,14 @@ OPTIONS                                                        *vimtex-options*
 <
   Default value: {}
 
+*g:vimtex_mappings_override_existing*
+  Control behaviour on mapping conflicts, in particular whether or not to
+  override pre-existing mappings. By default, vimtex does not override existing
+  mappings. If this option is enabled, then vimtex will override existing
+  mappings on conflict.
+
+  Default value: 0
+
 *g:vimtex_matchparen_enabled*
   Enable highlighting of matching delimiters.
 


### PR DESCRIPTION
For example, vim-textobj-entire defines `ie` and `ae` which conflict with vimtex's mappings for an environment, so by default vimtex doesn't define its own `ie` and `ae`.

Use:

```vim
let g:vimtex_mappings_override_global = 1
```

In your vimrc to have vimtex define its own mappings even though they will shadow those from a different package.

Tested with vim-textobj-entire, after setting `g:vimtex_mappings_override_global` in my vimrc I was able to use `vie` and `vae` to select a LaTeX environment and not the entire contents of the buffer. The vim-textobj-entire mappings still worked outside of this context.

Also tested the operator-pending mapping with `dae`.

And inspected the mappings to confirm the buffer-local one from vimtex was shadowing the one from vim-textobj-entire:

```vim
:xmap ie
x  ie           @<Plug>(vimtex-ie)
x  ie            <Plug>(textobj-entire-i)
```

cc @kiryph, since this PR is a follow up for #1709.

Also motivated by https://vi.stackexchange.com/q/25633.
