### PR TITLE
Install bibtex and bibparse from Ubuntu packages rather than CPAN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,14 @@ jobs:
     - name: Install packages
       run: |
         sudo apt update
-        sudo apt install neovim
-        sudo apt install texlive texlive-latex-extra texlive-extra-utils
-        sudo apt install texlive-bibtex-extra libtext-bibtex-perl
-        sudo apt install latexmk
-        sudo apt install gcc moreutils
-        sudo apt install libmodule-build-perl
-        sudo apt install libconfig-autoconf-perl
-        sudo apt install libextutils-libbuilder-perl
+        sudo apt install neovim \
+          texlive texlive-latex-extra texlive-extra-utils \
+          texlive-bibtex-extra libtext-bibtex-perl \
+          latexmk \
+          gcc moreutils \
+          libmodule-build-perl \
+          libconfig-autoconf-perl \
+          libextutils-libbuilder-perl
     - uses: actions/checkout@master
       with:
         fetch-depth: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,19 +24,12 @@ jobs:
         sudo apt update
         sudo apt install neovim
         sudo apt install texlive texlive-latex-extra texlive-extra-utils
+        sudo apt install texlive-bibtex-extra libtext-bibtex-perl
         sudo apt install latexmk
         sudo apt install gcc moreutils
         sudo apt install libmodule-build-perl
         sudo apt install libconfig-autoconf-perl
         sudo apt install libextutils-libbuilder-perl
-    - name: Install bibparse
-      run: |
-        wget https://search.cpan.org/CPAN/authors/id/A/AM/AMBS/Text-BibTeX-0.85.tar.gz
-        tar zxf Text-BibTeX-0.85.tar.gz
-        cd Text-BibTeX-0.85
-        perl Build.PL
-        ./Build
-        sudo ./Build install
     - uses: actions/checkout@master
       with:
         fetch-depth: 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,20 +16,14 @@ FROM ubuntu
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt -qq update
-RUN apt -qq -y install \
+RUN apt -qq update && apt -qq -y install \
   vim neovim moreutils \
   gcc git make wget tree \
   texlive texlive-latex-extra texlive-extra-utils latexmk \
+  texlive-bibtex-extra libtext-bibtex-perl \
   libmodule-build-perl \
   libconfig-autoconf-perl \
   libextutils-libbuilder-perl
-RUN wget https://search.cpan.org/CPAN/authors/id/A/AM/AMBS/Text-BibTeX-0.85.tar.gz; \
-  tar zxf Text-BibTeX-0.85.tar.gz; \
-  cd Text-BibTeX-0.85; \
-  perl Build.PL; \
-  ./Build; \
-  ./Build install
 
 WORKDIR /vimtex
 


### PR DESCRIPTION
This should simplify and speed up initialization of the test container/VM.

Also simplify the Dockerfile a little further by using a single RUN command that does both `apt update` and `apt install`.

Tested the Dockerfile use case using podman:

```text
$ podman build -t vimtex-test docker/
$ podman run --volume "${PWD}":/vimtex vimtex-test make -C test/tests
```

The GitHub Actions case should be tested when the PR is opened.