### PR TITLE
[issue: #1742] Fixed LaTeX errors in 'test/tests/test-compiler-selected/'

### DIFF
--- a/test/tests/test-compiler-selected/reference1.tex
+++ b/test/tests/test-compiler-selected/reference1.tex
@@ -1,7 +1,7 @@
 \documentclass[14pt]{article}
 
 \def\E{}
-\renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{##1}\!\left[##2\right]}
+\renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{#1}\!\left[#2\right]}
 \def\PP{\ensuremath\mathrm{P}}
 
 \begin{document}

--- a/test/tests/test-compiler-selected/reference3.tex
+++ b/test/tests/test-compiler-selected/reference3.tex
@@ -1,7 +1,7 @@
 \documentclass[14pt]{article}
 
 \def\E{}
-\renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{##1}\!\left[##2\right]}
+\renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{#1}\!\left[#2\right]}
 \def\PP{\ensuremath\mathrm{P}}
 
 \begin{document}

--- a/test/tests/test-compiler-selected/test-template.tex
+++ b/test/tests/test-compiler-selected/test-template.tex
@@ -1,7 +1,7 @@
 \documentclass[14pt]{article}
 
 \def\E{}
-\renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{##1}\!\left[##2\right]}
+\renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{#1}\!\left[#2\right]}
 \def\PP{\ensuremath\mathrm{P}}
 
 \begin{document}

--- a/test/tests/test-compiler-selected/vimtex-template.tex
+++ b/test/tests/test-compiler-selected/vimtex-template.tex
@@ -1,7 +1,7 @@
 \documentclass[14pt]{article}
 
 \def\E{}
-\renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{##1}\!\left[##2\right]}
+\renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{#1}\!\left[#2\right]}
 \def\PP{\ensuremath\mathrm{P}}
 
 \begin{document}


### PR DESCRIPTION
[issue: #1742] Fixed LaTeX errors in 'test/tests/test-compiler-selected/*.tex' files

Details: several (global scope) LaTeX macro definitions  used `##1` and `##2` syntax
for variable expansion causing errors. Replaced with `#1` and `#2` respectively.