### PR TITLE
Add 'clip' to list of tikz commands

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -314,6 +314,7 @@ let s:tikz_commands = '\v\\%(' . join([
         \ 'path',
         \ 'node',
         \ 'coordinate',
+	\ 'clip',
         \ 'add%(legendentry|plot)',
       \ ], '|') . ')'
 


### PR DESCRIPTION
Minor change, make 'clip' indent the same way 'path' does.