### PR TITLE
callback hooks: prepend instead of append compiler callback

### DIFF
--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -45,7 +45,7 @@ function! vimtex#view#init_state(state) abort " {{{1
   if exists('*l:v.compiler_callback')
         \ && index(g:vimtex_compiler_callback_hooks,
         \          'b:vimtex.viewer.compiler_callback') == -1
-    call add(g:vimtex_compiler_callback_hooks,
+    call insert(g:vimtex_compiler_callback_hooks,
           \ 'b:vimtex.viewer.compiler_callback')
   endif
 


### PR DESCRIPTION
This ensures that user-defined callbacks are executed after the default
compiler callback.

Use case (tested with latexmk & skim):
I want to do a forward search after successful compilation with the following custom callback hook:
```vim
function! VimtexViewCallback(status)
    VimtexView
endfunction

let g:vimtex_compiler_callback_hooks = ['VimtexViewCallback']
```
However the viewer does not jump to the right page because the compiler callback is called after my custom callback. I think in any case the compiler callback should be executed first to ensure that its behaviour can be overridden by a user-defined callback.

Alternatively I propose the following solution: I feel that customizing vimtex by using events is more user-friendly than with callback hooks. I suggest to define a `VimtexEventCompileSuccess` event that is always triggered after successful compilation. Then instead of defining a custom callback, the same could be achieved by `autocmd User VimtexEventCompileSuccess VimtexView`. If you agree with this I can make another pr.