### PR TITLE
Added QoL quickfix window resize options

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -245,6 +245,8 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_quickfix_open_on_warning', '1')
   call s:init_option('vimtex_quickfix_blgparser', {})
   call s:init_option('vimtex_quickfix_autoclose_after_keystrokes', '0')
+  call s:init_option('vimtex_quickfix_resize_to_content', '0')
+  call s:init_option('vimtex_quickfix_max_size', '10')
 
   call s:init_option('vimtex_syntax_enabled', 1)
   call s:init_option('vimtex_syntax_nested', {

--- a/autoload/vimtex/qf.vim
+++ b/autoload/vimtex/qf.vim
@@ -81,7 +81,18 @@ function! vimtex#qf#open(force) abort " {{{1
 
   if a:force || (g:vimtex_quickfix_mode > 0 && l:errors_or_warnings)
     let s:previous_window = win_getid()
-    botright cwindow
+
+    if g:vimtex_quickfix_resize_to_content == 1
+      let l:content_size = len(getqflist())
+
+      if l:content_size >= g:vimtex_quickfix_max_size
+        let l:content_size = g:vimtex_quickfix_max_size
+      endif
+
+      call execute('botright copen' . l:content_size)
+    else
+      botright cwindow
+    endif
     if g:vimtex_quickfix_mode == 2
       call win_gotoid(s:previous_window)
     endif
@@ -93,6 +104,7 @@ function! vimtex#qf#open(force) abort " {{{1
     endif
     redraw
   endif
+
 endfunction
 
 " }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1902,6 +1902,23 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: 2
 
+*g:vimtex_quickfix_resize_to_content*
+  This option controls the size of the |quickfix| window. The recognized options
+  are:
+
+  Value Effect ~
+  0     The quickfix window will always open at default size
+  1     The quickfix window will resize itself to fit content, at most
+        g:vimtex_quickfix_max_size lines tall.
+
+  Default value: 0
+
+*g:vimtex_quickfix_max_size*
+  This option controls the maximum size of the |quickfix| window when
+  g:vimtex_quickfix_resize_to_content is set to 1.
+
+  Default value: 10
+
 *g:vimtex_quickfix_autoclose_after_keystrokes*
   If set to value greater than zero, then the quickfix window will close after
   this number of motions (i.e. |CursorMoved| and |CursorMovedI| events). This


### PR DESCRIPTION
Hey there, first off, really cool plugin, thanks for all your work maintaining it. The one issue that I have with it is that the quickfix window is always 10 lines tall, even if the error or warning only takes up one line.

This is a fix for that issue, the quickfix window now resizes itself to fit the content up to a maximum height. The fix can be turned on or off.