### PR TITLE
Add option `g:vimtex_enable_mutate_iskeyword`

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -70,7 +70,9 @@ function! s:init_buffer() abort " {{{1
   " Apply some filetype specific settings
   if &filetype ==# 'tex'
     setlocal suffixesadd=.tex,.sty,.cls
-    setlocal iskeyword+=:
+    if g:vimtex_enable_mutate_iskeyword
+      setlocal iskeyword+=:
+    endif
     setlocal includeexpr=vimtex#include#expr()
     let &l:include = g:vimtex#re#tex_include
     let &l:define  = '\\\([egx]\|char\|mathchar\|count\|dimen\|muskip\|skip'

--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -355,6 +355,8 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_view_zathura_options', '')
   call s:init_option('vimtex_view_zathura_check_libsynctex', 1)
 
+  call s:init_option('vimtex_enable_mutate_iskeyword', 1)
+
   let s:initialized = v:true
 endfunction
 


### PR DESCRIPTION
I HATE the way vimtex changes `iskeyword` without my permission. I don't
want `\textbf{test}` to be one word. I want it to behave as I expect. I
have shot myself in the foot with this so many times hitting ^W in
insert mode and deleting way too much.