### PR TITLE
handle \input{...} when compiling a selection

### DIFF
--- a/autoload/vimtex/parser/tex.vim
+++ b/autoload/vimtex/parser/tex.vim
@@ -197,11 +197,11 @@ function! s:parse_preamble(file, opts, parsed_files) abort " {{{1
       break
     endif
 
-    call add(l:lines, l:line)
-
     if l:line =~# g:vimtex#re#tex_input
       let l:file = s:input_parser(l:line, a:file, a:opts.root)
       call extend(l:lines, s:parse_preamble(l:file, a:opts, a:parsed_files))
+    else
+      call add(l:lines, l:line)
     endif
   endfor
 

--- a/test/tests/test-compiler-selected/Makefile
+++ b/test/tests/test-compiler-selected/Makefile
@@ -5,9 +5,10 @@ MYVIM ?= nvim --headless
 INMAKE := 1
 export INMAKE
 
-test: output1 output2
+test: output1 output2 output3
 	@diff output1.tex reference1.tex
 	@diff output2.tex reference2.tex
+	@diff output3.tex reference3.tex
 	@rm -f output*.tex
 
 output%:

--- a/test/tests/test-compiler-selected/inputfile.tex
+++ b/test/tests/test-compiler-selected/inputfile.tex
@@ -1,0 +1,5 @@
+\newenvironment{LRmath}{
+  \def\E{}
+  \renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{##1}\!\left[##2\right]}
+  \def\PP{\ensuremath\mathrm{P}}
+}{}

--- a/test/tests/test-compiler-selected/test.tex
+++ b/test/tests/test-compiler-selected/test.tex
@@ -1,10 +1,6 @@
 \documentclass[12pt]{article}
 
-\newenvironment{LRmath}{
-  \def\E{}
-  \renewcommand{\E}[2][]{\ensuremath\mathrm{E}_{##1}\!\left[##2\right]}
-  \def\PP{\ensuremath\mathrm{P}}
-}{}
+\input{inputfile}
 
 \begin{document}
 \begin{LRmath}

--- a/test/tests/test-compiler-selected/test.vim
+++ b/test/tests/test-compiler-selected/test.vim
@@ -7,18 +7,18 @@ set nomore
 silent edit test.tex
 
 call vimtex#parser#selection_to_texfile({
-      \ 'range': [14, 16],
+      \ 'range': [10, 12],
       \ 'name': 'output1',
       \})
 
 call vimtex#parser#selection_to_texfile({
-      \ 'range': [14, 16],
+      \ 'range': [10, 12],
       \ 'name': 'output2',
       \ 'template_name': 'NONE',
       \})
 
 call vimtex#parser#selection_to_texfile({
-      \ 'range': [14, 16],
+      \ 'range': [10, 12],
       \ 'name': 'output3',
       \ 'template_name': 'template.tex',
       \})


### PR DESCRIPTION
Without this, when compiling a selection, both the line `\input{...}` and the contents of the file are included in the temporary tex file. This was broken in 8b41f09e47fac4ee8fc4bd07a3a717bc69828859.

I am not sure what `parse_current` in `autoload/vimtex/parser/tex.vim` is used for. It might need a similar fix.