### PR TITLE
Compiler vlty: support LanguageTool as installed by pacman

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -123,6 +123,7 @@ function! vimtex#options#init() abort " {{{1
         \})
   call s:init_option('vimtex_grammar_vlty', {
         \ 'lt_directory': '~/lib/LanguageTool',
+        \ 'lt_command': '',
         \ 'lt_disable': 'WHITESPACE_RULE',
         \ 'lt_enable': '',
         \ 'lt_disablecategories': '',

--- a/compiler/vlty.vim
+++ b/compiler/vlty.vim
@@ -40,12 +40,10 @@ if s:vlty.server !=# 'lt'
       call s:installation_error('vlty compiler - lt_command not valid')
       finish
     endif
-  else
-    if !filereadable(fnamemodify(s:vlty.lt_directory
+  elseif !filereadable(fnamemodify(s:vlty.lt_directory
         \ . '/languagetool-commandline.jar', ':p'))
-      call s:installation_error('vlty compiler - lt_directory path not valid')
-      finish
-    endif
+    call s:installation_error('vlty compiler - lt_directory path not valid')
+    finish
   endif
 endif
 
@@ -57,9 +55,8 @@ let s:language = substitute(s:language, '_', '-', '')
 
 let &l:makeprg =
       \ s:python . ' -m yalafi.shell'
-      \ . ' --lt-command "' . s:vlty.lt_command . '"'
       \ . (s:vlty.lt_command != ''
-      \    ? ''
+      \    ? ' --lt-command ' . s:vlty.lt_command
       \    : ' --lt-directory ' . s:vlty.lt_directory)
       \ . (s:vlty.server ==# 'no'
       \    ? ''

--- a/compiler/vlty.vim
+++ b/compiler/vlty.vim
@@ -17,8 +17,7 @@ if !executable(s:python)
   finish
 endif
 
-call system(s:python . ' -c "import sys; assert sys.version_info.major >= 3'
-            \ . ' and sys.version_info.minor >= 6"')
+call system(s:python . ' -c "import sys; assert sys.version_info >= (3, 6)"')
 if v:shell_error != 0
   call s:installation_error('vlty compiler requires at least Python version 3.6')
   finish
@@ -36,10 +35,17 @@ if s:vlty.server !=# 'lt'
     finish
   endif
 
-  if !filereadable(fnamemodify(s:vlty.lt_directory
+  if s:vlty.lt_command != ''
+    if !executable(s:vlty.lt_command)
+      call s:installation_error('vlty compiler - lt_command not valid')
+      finish
+    endif
+  else
+    if !filereadable(fnamemodify(s:vlty.lt_directory
         \ . '/languagetool-commandline.jar', ':p'))
-    call s:installation_error('vlty compiler - lt_directory path not valid')
-    finish
+      call s:installation_error('vlty compiler - lt_directory path not valid')
+      finish
+    endif
   endif
 endif
 
@@ -51,9 +57,12 @@ let s:language = substitute(s:language, '_', '-', '')
 
 let &l:makeprg =
       \ s:python . ' -m yalafi.shell'
-      \ . ' --lt-directory ' . s:vlty.lt_directory
+      \ . ' --lt-command "' . s:vlty.lt_command . '"'
+      \ . (s:vlty.lt_command != ''
+      \    ? ''
+      \    : ' --lt-directory ' . s:vlty.lt_directory)
       \ . (s:vlty.server ==# 'no'
-      \    ?  ''
+      \    ? ''
       \    : ' --server ' . s:vlty.server)
       \ . ' --language ' . s:language
       \ . ' --disable "' . s:vlty.lt_disable . '"'

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1616,6 +1616,8 @@ OPTIONS                                                        *vimtex-options*
 
     lt_directory~
       Path to the `LanguageTool` software.
+    lt_command~
+      Name of `LanguageTool` executable, if installed via packet manager.
 
     lt_disable~
     lt_enable~
@@ -1634,7 +1636,7 @@ OPTIONS                                                        *vimtex-options*
       `lt`    Contact the Web server provided by `LanguageTool`. In this case,
             no local installation is necessary. Please see the following page
             for conditions and restrictions:
-            http://wiki.languagetool.org/public-http-api
+            https://dev.languagetool.org/public-http-api
 
     shell_options~
       Pass additional options to `YaLafi`, e.g., `--equation-punctuation displ`;
@@ -1649,6 +1651,7 @@ OPTIONS                                                        *vimtex-options*
 
       let g:vimtex_grammar_vlty = {
             \ 'lt_directory': '~/lib/LanguageTool',
+            \ 'lt_command': '',
             \ 'lt_disable': 'WHITESPACE_RULE',
             \ 'lt_enable': '',
             \ 'lt_disablecategories': '',
@@ -4060,8 +4063,12 @@ plain text and combines this with the proofreading software `LanguageTool` [2].
 
 In order to use `vlty`, you need local installations of both components. An
 archive of `LanguageTool` can be downloaded from [3]. After uncompressing at
-a suitable place, the path to it is specified as shown below. `YaLafi` itself
-can be installed with: >
+a suitable place, the path to it is specified as shown below. On a system like
+`Arch Linux`, `LanguageTool` may also be installed with: >
+
+  pacman -S languagetool
+
+`YaLafi` itself can be installed with: >
 
   pip install --user yalafi
 
@@ -4072,8 +4079,15 @@ As a minimal example, one could write in |vimrc|: >
   set spelllang=en_gb
 
 The given directory has to contain the `LanguageTool` software, including for
-instance the file `languagetool-server.jar`. A separated `:compiler vlty` will
-raise an error message, if some component cannot be found.
+instance the file `languagetool-server.jar`.
+If `LanguageTool` has been installed via a packet manager as given above,
+one would write in |vimrc|: >
+
+  let g:vimtex_grammar_vlty = {'lt_command': 'languagetool'}
+  set spelllang=en_gb
+
+A separated `:compiler vlty` will raise an error message, if some component
+cannot be found.
 
 Note: Spell checking with `LanguageTool` is only enabled if a country code is
       specified in |'spelllang'|.

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1615,7 +1615,8 @@ OPTIONS                                                        *vimtex-options*
   with the following keys (see |vimtex-grammar-vlty| for more details):
 
     lt_directory~
-      Path to the `LanguageTool` software.
+      Path to the `LanguageTool` software, if installed manually.
+
     lt_command~
       Name of `LanguageTool` executable, if installed via packet manager.
 
@@ -4066,7 +4067,7 @@ archive of `LanguageTool` can be downloaded from [3]. After uncompressing at
 a suitable place, the path to it is specified as shown below. On a system like
 `Arch Linux`, `LanguageTool` may also be installed with: >
 
-  pacman -S languagetool
+  sudo pacman -S languagetool
 
 `YaLafi` itself can be installed with: >
 
@@ -4079,9 +4080,8 @@ As a minimal example, one could write in |vimrc|: >
   set spelllang=en_gb
 
 The given directory has to contain the `LanguageTool` software, including for
-instance the file `languagetool-server.jar`.
-If `LanguageTool` has been installed via a packet manager as given above,
-one would write in |vimrc|: >
+instance the file `languagetool-server.jar`. If `LanguageTool` has been
+installed via a packet manager as given above, one would write in |vimrc|: >
 
   let g:vimtex_grammar_vlty = {'lt_command': 'languagetool'}
   set spelllang=en_gb


### PR DESCRIPTION
This PR addresses an issue raised in the [discussion of vlty](https://github.com/lervag/vimtex/pull/1714#issuecomment-650387467). Under Arch Linux, one now can use LanguageTool as installed with
```
pacman -S languagetool
```
The minimal vimrc is given in the documentation.
This requires YaLafi version 1.1.5. It has been uploaded to PyPI, such that it is available via pip.