### PR TITLE
Enhance fold labels on folded beamer frames

### DIFF
--- a/autoload/vimtex/fold/envs.vim
+++ b/autoload/vimtex/fold/envs.vim
@@ -171,8 +171,14 @@ function! s:folder.parse_caption_frame(line) abort dict " {{{1
   let i = v:foldstart
   while i <= v:foldend
     if getline(i) =~# '^\s*\\frametitle'
-      return matchstr(getline(i),
+      let frametitle = matchstr(getline(i),
             \ '^\s*\\frametitle\(\[.*\]\)\?{\zs.\{-1,}\ze\(}\s*\)\?$')
+      if i+1 <= v:foldend && getline(i+1) =~# '^\s*\\framesubtitle'
+        let framesubtitle = matchstr(getline(i+1),
+              \ '^\s*\\framesubtitle\(\[.*\]\)\?{\zs.\{-1,}\ze\(}\s*\)\?$')
+        return printf('%S: %S', frametitle, framesubtitle)
+      end
+      return frametitle
     end
     let i += 1
   endwhile

--- a/autoload/vimtex/fold/envs.vim
+++ b/autoload/vimtex/fold/envs.vim
@@ -178,7 +178,7 @@ function! s:folder.parse_caption_frame(line) abort dict " {{{1
   endwhile
 
   " If no caption found, check for a caption comment
-  return matchstr(a:line,'\\begin\*\?{.*}\s*%\s*\zs.*')
+  return matchstr(a:line,'\\begin\*\?{.*}\(\[.*\]\)\?\s*%\s*\zs.*')
 endfunction
 
 " }}}1

--- a/test/test-folding/main.tex
+++ b/test/test-folding/main.tex
@@ -201,4 +201,17 @@ this fold worked before issue #1515
     \end{proof}
 \end{enumerate}
 
+% The frames need to be in this order for the test to pass. This is likely a
+% bug in vim, see https://github.com/lervag/vimtex/pull/1830#issuecomment-775527621
+\begin{frame}
+  \frametitle{Title}
+  \framesubtitle{Subtitle}
+
+  hello world
+\end{frame}
+
+\begin{frame}[noframenumbering]  % Title page
+  hello world
+\end{frame}
+
 \end{document}

--- a/test/test-folding/test.vim
+++ b/test/test-folding/test.vim
@@ -56,6 +56,15 @@ call vimtex#test#assert_equal(3, foldlevel(186))
 call vimtex#test#assert_equal(1, foldlevel(190))
 call vimtex#test#assert_equal(2, foldlevel(202))
 
+call vimtex#test#assert_equal(2, foldlevel(206))
+call vimtex#test#assert_equal(
+      \ '\begin{frame}       Title: Subtitle',
+      \ foldtextresult(206))
+call vimtex#test#assert_equal(2, foldlevel(213))
+call vimtex#test#assert_equal(
+      \ '\begin{frame}       Title page',
+      \ foldtextresult(213))
+
 call vimtex#test#assert_equal(1, foldlevel(line('$')-1))
 
 quit!


### PR DESCRIPTION
Hello,

this PR enhances (IMHO) the labels on folded frames in LaTeX beamer documents.

1. The first commit changes the regex parsing comments on the `\begin{frame}` line. So far the comments where only found if they were separated from the `\begin{frame}` only by whitespace. Now optional `[...]` are allowed, as in `\begin{frame}[noframenumbering]  % Title page`.
2. The second commit extends the search for `\frametitle()` by looking for `\framesubtitle()` on the following line and, if both are found, displaying them on the fold as `frametitle: framesubtitle`.
3. The third commit to me is optional due to commit (1). It changes the regex looking for `frametitle`, so that commented out `frametitle`s are found as well. This originally was a workaround for the first commit, but still could be useful.
