### PR TITLE
Add autocomplete support for \defbibentryset{}

### DIFF
--- a/autoload/vimtex/complete.vim
+++ b/autoload/vimtex/complete.vim
@@ -85,6 +85,7 @@ let s:completer_bib = {
       \   '\v\\bibentry\s*\{[^}]*$',
       \   '\v\\%(text|block)cquote\*?%(\s*\[[^]]*\]){0,2}\{[^}]*$',
       \   '\v\\%(for|hy)\w+cquote\*?\{[^}]*\}%(\s*\[[^]]*\]){0,2}\{[^}]*$',
+      \   '\v\\defbibentryset\{[^}]*\}\{[^}]*$',
       \  ],
       \ 'initialized' : 0,
       \}


### PR DESCRIPTION
Hello! I just added one regex that enables citation autocompletion inside `\defbibentryset{setname}{...}`.