### PR TITLE
Compiler vlty: ensure compatibility with vim-dispatch

### DIFF
--- a/compiler/vlty.vim
+++ b/compiler/vlty.vim
@@ -77,15 +77,11 @@ silent CompilerSet makeprg
 
 let &l:errorformat = '%I=== %f ===,%C%*\d.) Line %l\, column %v\, Rule ID:%.%#,'
 if s:vlty.show_suggestions == 0
-  let &l:errorformat .= '%CMessage: %m,'
-  " see vimtex issue #1854: properly consume all message lines,
-  " otherwise problems with plugin vim-dispatch
-  let &l:errorformat .= '%C%.%#,%C%.%#,%C%.%#,%Z,'
-  let &l:errorformat .= '%-G=== %.%#'
+  " final duplicated '%-G%.%#': compatibility with vim-dispatch;
+  " see issue #199 of vim-dispatch and issue #1854 of vimtex
+  let &l:errorformat .= '%ZMessage: %m,%-G%.%#,%-G%.%#'
 else
-  let &l:errorformat .= '%CMessage: %m,%+CSuggestion:%m,'
-  let &l:errorformat .= '%C%.%#,%C%.%#,%Z,'
-  let &l:errorformat .= '%-G=== %.%#'
+  let &l:errorformat .= '%CMessage: %m,%Z%m,%-G%.%#,%-G%.%#'
 endif
 silent CompilerSet errorformat
 

--- a/compiler/vlty.vim
+++ b/compiler/vlty.vim
@@ -77,9 +77,15 @@ silent CompilerSet makeprg
 
 let &l:errorformat = '%I=== %f ===,%C%*\d.) Line %l\, column %v\, Rule ID:%.%#,'
 if s:vlty.show_suggestions == 0
-  let &l:errorformat .= '%ZMessage: %m,%-G%.%#'
+  let &l:errorformat .= '%CMessage: %m,'
+  " see vimtex issue #1854: properly consume all message lines,
+  " otherwise problems with plugin vim-dispatch
+  let &l:errorformat .= '%C%.%#,%C%.%#,%C%.%#,%Z,'
+  let &l:errorformat .= '%-G=== %.%#'
 else
-  let &l:errorformat .= '%CMessage: %m,%Z%m,%-G%.%#'
+  let &l:errorformat .= '%CMessage: %m,%+CSuggestion:%m,'
+  let &l:errorformat .= '%C%.%#,%C%.%#,%Z,'
+  let &l:errorformat .= '%-G=== %.%#'
 endif
 silent CompilerSet errorformat
 


### PR DESCRIPTION
This relates to issue #1854. An [issue from vim-dispatch](https://github.com/tpope/vim-dispatch/issues/88) loosely relates to ours.

The proposed solution should be less dubious than the quick fix from #1854. The latter just said *twice:* "Please ignore all other lines." No clue, why this works as intended.

In the new `errorformat`, all message lines from YaLafi are explicitly consumed.

The part `%+CSuggestion:%m` is a bit special. If one simply says `%C%m` for picking up LT's replacement suggestions, then this will add the complete remainder of the multi-line message.