### PR TITLE
No autocmd when opening QuickFix window

### DIFF
--- a/autoload/vimtex/qf.vim
+++ b/autoload/vimtex/qf.vim
@@ -81,7 +81,7 @@ function! vimtex#qf#open(force) abort " {{{1
 
   if a:force || (g:vimtex_quickfix_mode > 0 && l:errors_or_warnings)
     let s:previous_window = win_getid()
-    botright cwindow
+    noautocmd botright cwindow
     if g:vimtex_quickfix_mode == 2
       call win_gotoid(s:previous_window)
     endif


### PR DESCRIPTION
Disables firing of autocommands when opening the QuickFix window.

Fixes #1595. While the bug is ultimately `neovim`'s, firing a `CursorMoved` more often than in `vim` is a `neovim` design choice.