### PR TITLE
Syntax support for def-like commands

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -549,6 +549,7 @@ function! s:init_highlights() abort " {{{1
   highlight def link texCmdBib               texCmd
   highlight def link texCmdClass             texCmd
   highlight def link texCmdDef               texCmd
+  highlight def link texCmdLet               texCmd
   highlight def link texCmdEnv               texCmd
   highlight def link texCmdE3                texCmd
   highlight def link texCmdFootnote          texCmd

--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -544,24 +544,26 @@ function! s:init_highlights() abort " {{{1
   highlight def texStyleItal gui=italic      cterm=italic
 
   " Inherited groups
+  highlight def link texArgNew               texCmd
   highlight def link texAuthorOpt            texOpt
   highlight def link texCmdAccent            texCmd
   highlight def link texCmdAuthor            texCmd
   highlight def link texCmdBib               texCmd
   highlight def link texCmdClass             texCmd
-  highlight def link texCmdDef               texCmd
+  highlight def link texCmdDef               texCmdNew
   highlight def link texCmdEnv               texCmd
   highlight def link texCmdE3                texCmd
   highlight def link texCmdFootnote          texCmd
   highlight def link texCmdGreek             texCmd
   highlight def link texCmdInput             texCmd
   highlight def link texCmdItem              texCmdEnv
-  highlight def link texCmdLet               texCmd
+  highlight def link texCmdLet               texCmdNew
   highlight def link texCmdLigature          texSpecialChar
   highlight def link texCmdMath              texCmd
   highlight def link texCmdMathEnv           texCmdEnv
   highlight def link texCmdMathText          texCmd
-  highlight def link texCmdNewcmd            texCmd
+  highlight def link texCmdNew               texCmd
+  highlight def link texCmdNewcmd            texCmdNew
   highlight def link texCmdNewenv            texCmd
   highlight def link texCmdNoSpell           texCmd
   highlight def link texCmdPackage           texCmd
@@ -579,7 +581,7 @@ function! s:init_highlights() abort " {{{1
   highlight def link texCmdVerb              texCmd
   highlight def link texCommentAcronym       texComment
   highlight def link texCommentURL           texComment
-  highlight def link texDefArgName           texCmd
+  highlight def link texDefArgName           texArgNew
   highlight def link texDefParm              texParm
   highlight def link texE3Cmd                texCmd
   highlight def link texE3Delim              texDelim
@@ -593,7 +595,7 @@ function! s:init_highlights() abort " {{{1
   highlight def link texFilesOpt             texFileOpt
   highlight def link texGroupError           texError
   highlight def link texLetArgEqual          texSymbol
-  highlight def link texLetArgName           texCmd
+  highlight def link texLetArgName           texArgNew
   highlight def link texLigature             texSymbol
   highlight def link texMathArg              texMathRegion
   highlight def link texMathArrayArg         texOpt
@@ -612,7 +614,7 @@ function! s:init_highlights() abort " {{{1
   highlight def link texMathSub              texMathRegion
   highlight def link texMathSuper            texMathRegion
   highlight def link texMathSymbol           texCmd
-  highlight def link texNewcmdArgName        texCmd
+  highlight def link texNewcmdArgName        texArgNew
   highlight def link texNewcmdOpt            texOpt
   highlight def link texNewcmdParm           texParm
   highlight def link texNewenvArgName        texEnvArgName

--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -251,11 +251,12 @@ function! vimtex#syntax#core#init() abort " {{{1
   call vimtex#syntax#core#new_arg('texDefArgBody')
 
   " \let
-  " Note: define texLetArgEqual after texLetArgBody; order matters
-  " E.g. in '\def\eq==' we want: 1st = is texLetArgEqual, 2nd = is texLetArgBody
   syntax match texCmdLet "\\let\>" nextgroup=texLetArgName skipwhite skipnl
   syntax match texLetArgName  contained nextgroup=texLetArgBody,texLetArgEqual skipwhite skipnl "\\[a-zA-Z@]\+"
   syntax match texLetArgName  contained nextgroup=texLetArgBody,texLetArgEqual skipwhite skipnl "\\[^a-zA-Z@]"
+  " Note: define texLetArgEqual after texLetArgBody; order matters
+  " E.g. in '\let\eq==' we want: 1st = is texLetArgEqual, 2nd = is texLetArgBody
+  " Reversing lines results in:  1st = is texLetArgBody,  2nd = is unmatched
   syntax match texLetArgBody  contained contains=TOP,@Nospell "\\[a-zA-Z@]\+\|\\[^a-zA-Z@]\|\S"
   syntax match texLetArgEqual contained nextgroup=texLetArgBody skipwhite skipnl "="
 
@@ -549,13 +550,13 @@ function! s:init_highlights() abort " {{{1
   highlight def link texCmdBib               texCmd
   highlight def link texCmdClass             texCmd
   highlight def link texCmdDef               texCmd
-  highlight def link texCmdLet               texCmd
   highlight def link texCmdEnv               texCmd
   highlight def link texCmdE3                texCmd
   highlight def link texCmdFootnote          texCmd
   highlight def link texCmdGreek             texCmd
   highlight def link texCmdInput             texCmd
   highlight def link texCmdItem              texCmdEnv
+  highlight def link texCmdLet               texCmd
   highlight def link texCmdLigature          texSpecialChar
   highlight def link texCmdMath              texCmd
   highlight def link texCmdMathEnv           texCmdEnv
@@ -580,8 +581,6 @@ function! s:init_highlights() abort " {{{1
   highlight def link texCommentURL           texComment
   highlight def link texDefArgName           texCmd
   highlight def link texDefParm              texParm
-  highlight def link texLetArgName           texCmd
-  highlight def link texLetArgEqual          texSymbol
   highlight def link texE3Cmd                texCmd
   highlight def link texE3Delim              texDelim
   highlight def link texE3Func               texCmdType
@@ -593,6 +592,8 @@ function! s:init_highlights() abort " {{{1
   highlight def link texFilesArg             texFileArg
   highlight def link texFilesOpt             texFileOpt
   highlight def link texGroupError           texError
+  highlight def link texLetArgEqual          texSymbol
+  highlight def link texLetArgName           texCmd
   highlight def link texLigature             texSymbol
   highlight def link texMathArg              texMathRegion
   highlight def link texMathArrayArg         texOpt

--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -250,6 +250,15 @@ function! vimtex#syntax#core#init() abort " {{{1
   syntax match texDefParm contained "#\+\d" containedin=texDefParmPre,texDefArgBody
   call vimtex#syntax#core#new_arg('texDefArgBody')
 
+  " \let
+  " Note: define texLetArgEqual after texLetArgBody; order matters
+  " E.g. in '\def\eq==' we want: 1st = is texLetArgEqual, 2nd = is texLetArgBody
+  syntax match texCmdLet "\\let\>" nextgroup=texLetArgName skipwhite skipnl
+  syntax match texLetArgName  contained nextgroup=texLetArgBody,texLetArgEqual skipwhite skipnl "\\[a-zA-Z@]\+"
+  syntax match texLetArgName  contained nextgroup=texLetArgBody,texLetArgEqual skipwhite skipnl "\\[^a-zA-Z@]"
+  syntax match texLetArgBody  contained contains=TOP,@Nospell "\\[a-zA-Z@]\+\|\\[^a-zA-Z@]\|\S"
+  syntax match texLetArgEqual contained nextgroup=texLetArgBody skipwhite skipnl "="
+
   " Reference and cite commands
   syntax match texCmdRef nextgroup=texRefArg           skipwhite skipnl "\\nocite\>"
   syntax match texCmdRef nextgroup=texRefArg           skipwhite skipnl "\\label\>"
@@ -570,6 +579,8 @@ function! s:init_highlights() abort " {{{1
   highlight def link texCommentURL           texComment
   highlight def link texDefArgName           texCmd
   highlight def link texDefParm              texParm
+  highlight def link texLetArgName           texCmd
+  highlight def link texLetArgEqual          texSymbol
   highlight def link texE3Cmd                texCmd
   highlight def link texE3Delim              texDelim
   highlight def link texE3Func               texCmdType

--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -219,7 +219,10 @@ function! vimtex#syntax#core#init() abort " {{{1
 
   " \newcommand
   syntax match texCmdNewcmd nextgroup=texNewcmdArgName skipwhite skipnl "\\\%(re\)\?newcommand\>"
-  call vimtex#syntax#core#new_arg('texNewcmdArgName', {'next': 'texNewcmdOpt,texNewcmdArgBody'})
+  call vimtex#syntax#core#new_arg('texNewcmdArgName', {
+        \ 'next': 'texNewcmdOpt,texNewcmdArgBody',
+        \ 'contains': ''
+        \})
   call vimtex#syntax#core#new_opt('texNewcmdOpt', {
         \ 'next': 'texNewcmdOpt,texNewcmdArgBody',
         \ 'opts': 'oneline',

--- a/autoload/vimtex/syntax/p/amsmath.vim
+++ b/autoload/vimtex/syntax/p/amsmath.vim
@@ -39,8 +39,8 @@ function! vimtex#syntax#p#amsmath#load(cfg) abort " {{{1
         \})
   call vimtex#syntax#core#new_arg('texDeclmathoperArgBody')
 
-  highlight link texCmdDeclmathoper     texCmd
-  highlight link texDeclmathoperArgName texCmd
+  highlight link texCmdDeclmathoper     texCmdNew
+  highlight link texDeclmathoperArgName texArgNew
 endfunction
 
 " }}}1

--- a/autoload/vimtex/syntax/p/amsmath.vim
+++ b/autoload/vimtex/syntax/p/amsmath.vim
@@ -30,6 +30,18 @@ function! vimtex#syntax#p#amsmath#load(cfg) abort " {{{1
   syntax match texMathCmdEnv contained contains=texCmdMathEnv                                            "\\end{subarray}"
   syntax match texMathCmdEnv contained contains=texCmdMathEnv                                            "\\end{x\?alignat\*\?}"
   syntax match texMathCmdEnv contained contains=texCmdMathEnv                                            "\\end{xxalignat}"
+
+  " DeclareMathOperator
+  syntax match texCmdDeclmathoper nextgroup=texDeclmathoperArgName skipwhite skipnl "\\DeclareMathOperator\>\*\?"
+  call vimtex#syntax#core#new_arg('texDeclmathoperArgName', {
+        \ 'next': 'texDeclmathoperArgBody',
+        \ 'contains': ''
+        \})
+  call vimtex#syntax#core#new_arg('texDeclmathoperArgBody')
+
+  highlight link texCmdDeclmathoper     texCmd
+  highlight link texDeclmathoperArgName texCmd
+
 endfunction
 
 " }}}1

--- a/autoload/vimtex/syntax/p/amsmath.vim
+++ b/autoload/vimtex/syntax/p/amsmath.vim
@@ -41,7 +41,6 @@ function! vimtex#syntax#p#amsmath#load(cfg) abort " {{{1
 
   highlight link texCmdDeclmathoper     texCmd
   highlight link texDeclmathoperArgName texCmd
-
 endfunction
 
 " }}}1


### PR DESCRIPTION
This PR attempts to enhance the syntax support for def-like commands: `\let`, `\newcommand`, and `\DeclareMathOperator`, as proposed in #1873.

1. As shown in the following screenshot, one may now assign colors to the commands `\let` and `\DeclareMathOperator`, differently from regular commands such as `\widehat` or `\overline`. This has been supported only for `\def` and `\newcommand`.<br>
The relevant hlgroups are `texCmdLet` and `texCmdDeclmathoper`. The default link for the hlgroups is `texCmd`.

2. One may color the terms to be defined (e.g., `\myname`, `\hat`, `\norm`, etc.) in `\let`, `\DeclareMathOperator`, and `\newcommand`. So far this has been supported only for `\def`.<br>
The relevant hlgroups are `texLetArgName`, `texDeclmathoperArgName`, and `texNewcmdArgName`. The default link is `texCmd`.


![pr](https://user-images.githubusercontent.com/47399860/100693843-b5cbb980-335b-11eb-997a-2eeca9bc8782.png)
