### PR TITLE
fix rm shell command

### DIFF
--- a/autoload/vimtex/compiler/tectonic.vim
+++ b/autoload/vimtex/compiler/tectonic.vim
@@ -120,12 +120,11 @@ function! s:compiler.clean(...) abort dict " {{{1
 
   " If a full clean is required
   if a:0 > 0 && a:1
-    call extend(l:intermediate, ['pdf'])
+    call extend(l:files, ['pdf'])
   endif
 
-  let l:basename = self.build_dir . '/' . fnamemodify(self.target_path, ':t:r')
-  call map(l:files, 'l:basename . v:val')
-
+  let l:basename = self.build_dir . '/' . fnamemodify(self.target_path, ':t:r:S')
+  call map(l:files, 'l:basename . "." . v:val')
   call vimtex#process#run('rm -f ' . join(l:files))
   call vimtex#log#info('Compiler clean finished')
 endfunction


### PR DESCRIPTION
Original command misses dot between root file name and extension and doesn't
consider name escape in shell.