### PR TITLE
Add imapping for ``

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -142,7 +142,7 @@ function! vimtex#options#init() abort " {{{1
 
   call s:init_option('vimtex_imaps_enabled', 1)
   call s:init_option('vimtex_imaps_disabled', [])
-  call s:init_option('vimtex_imaps_list', [
+	let l:vimtex_imaps_list = [
         \ { 'lhs' : '0',  'rhs' : '\emptyset' },
         \ { 'lhs' : '6',  'rhs' : '\partial' },
         \ { 'lhs' : '8',  'rhs' : '\infty' },
@@ -214,7 +214,12 @@ function! vimtex#options#init() abort " {{{1
         \ { 'lhs' : 'c',  'rhs' : 'vimtex#imaps#style_math("mathcal")', 'expr' : 1, 'leader' : '#'},
         \ { 'lhs' : '-',  'rhs' : 'vimtex#imaps#style_math("overline")', 'expr' : 1, 'leader' : '#'},
         \ { 'lhs' : 'B',  'rhs' : 'vimtex#imaps#style_math("mathbb")', 'expr' : 1, 'leader' : '#'},
-        \])
+        \]
+	if get(g:, 'vimtex_imaps_leader', '`') ==# '`'
+		call add(l:vimtex_imaps_list, { 'lhs' : '`',  'rhs' : '``', 'wrapper' : 'vimtex#imaps#wrap_trivial' })
+	endif
+
+  call s:init_option('vimtex_imaps_list', l:vimtex_imaps_list)
 
   call s:init_option('vimtex_indent_enabled', 1)
   call s:init_option('vimtex_indent_bib_enabled', 1)

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1711,7 +1711,7 @@ OPTIONS                                                        *vimtex-options*
   The list of mappings to generate on start up. The list of activated mappings
   can be viewed with |VimtexImapsList|.
 
-  Default value: See `autoload/vimtex.vim` (it's a long list)
+  Default value: See `autoload/vimtex/options.vim` (it's a long list)
 
 *g:vimtex_include_indicators*
   Vimtex will recognize included files for a lot of different purposes. Most


### PR DESCRIPTION
This mapping allows users to type ``` `` ``` and get ``` `` ```, rather than having to type ``` ```` ```.

The mapping is tightly focused, so hopefully it will not affect people who have customized `imaps_list` and `imap_leader`.

In addition, the default `imaps_list` location moved; this updates the docs with that move.

Fixes https://github.com/lervag/vimtex/issues/325.