### PR TITLE
fix typo calling 'ᵨ' delta instead of rho

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -716,7 +716,7 @@ let s:re_super = '[-+=()<>:;0-9a-pr-zABDEG-PRTUVW]'
 
 let s:map_sub = [
       \ ['\\beta\>',  'ᵦ'],
-      \ ['\\delta\>', 'ᵨ'],
+      \ ['\\rho\>', 'ᵨ'],
       \ ['\\phi\>',   'ᵩ'],
       \ ['\\gamma\>', 'ᵧ'],
       \ ['\\chi\>',   'ᵪ'],


### PR DESCRIPTION
`autoload/vimtex/syntax/core.vim` has a typo where the character `ᵨ` is used to conceal a subscript delta instead of a subscript rho. This should fix it.