### PR TITLE
Update vimtex-faq-zathura-osx

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -4958,6 +4958,7 @@ A: Yes, it should work.  The following recipe has been reported to work [0].
 
    5. Now install Zathura (most recean version, aka HEAD): >
 
+      brew tap zegervdv/zathura 
       brew install girara --HEAD
       brew install zathura --HEAD --with-synctex
       brew install zathura-pdf-poppler


### PR DESCRIPTION
For a fresh zathura installation, we need to tap [zegervdv/zathura](https://github.com/zegervdv/homebrew-zathura) first.



P.s.: maybe `vimtex-faq-zathura-macos` would be a better name for that documentation section since `OS X` is now officially called `macOS`?