### PR TITLE
VimtexDocPackage: add support for environments

### DIFF
--- a/autoload/vimtex/doc.vim
+++ b/autoload/vimtex/doc.vim
@@ -62,9 +62,24 @@ function! s:packages_get_from_cursor() abort " {{{1
     return s:packages_from_usepackage(l:cmd)
   elseif l:cmd.name ==# '\documentclass'
     return s:packages_from_documentclass(l:cmd)
+  elseif l:cmd.name ==# '\begin'
+    return s:packages_from_environment(l:cmd)
+  elseif l:cmd.name ==# '\end'
+    return s:packages_from_environment(l:cmd)
   else
     return s:packages_from_command(strpart(l:cmd.name, 1))
   endif
+endfunction
+
+" }}}1
+function! s:packages_from_environment(env) abort " {{{1
+  try
+    let l:env = a:env.args[0].text
+  catch
+    call vimtex#log#warning('Could not parse the environment name!')
+    return {}
+  endtry
+  return s:packages_from_command('\begin{' . l:env . '}')
 endfunction
 
 " }}}1
@@ -129,7 +144,7 @@ function! s:packages_from_command(cmd) abort " {{{1
   endwhile
 
   let l:candidates = []
-  let l:filter = 'v:val =~# ''^' . a:cmd . '\>'''
+  let l:filter = 'v:val =~# ''^' . escape(a:cmd, '\') . '\(\W\|$\)'''
   for l:package in l:packages
     let l:cmds = filter(readfile(s:complete_dir . l:package), l:filter)
     if empty(l:cmds) | continue | endif


### PR DESCRIPTION
Previously calling VimtexDocPackage with the cursor over `\begin{foo}`
showed documentation related to \begin. Showing documentation
related to foo is probably always more useful.

As the environments are stored in the same completion file as the
commands (in the format ^\begin{foo}$), we can mostly wrap the code for
commands to get nice documentation for environments.