### PR TITLE
fix typo: exlusive -> exclusive

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3031,83 +3031,83 @@ object, see |text-objects|.
 
 *<plug>(vimtex-]])*
   go to [count] next end of a section.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-][)*
   go to [count] next beginning of a section.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[])*
   go to [count] previous end of a section.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[[)*
   go to [count] previous beginning of a section.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-]m)*
   go to [count] next start of an environment `\begin`.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-]M)*
   go to [count] next end of an environment `\end`.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[m)*
   go to [count] previous start of an environment `\begin`.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[M)*
   go to [count] previous end of an environment `\end`.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-]n)*
   go to [count] next start of a math zone.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-]N)*
   go to [count] next end of a math zone.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[n)*
   go to [count] previous start of a math zone.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[N)*
   go to [count] previous end of a math zone.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-]r)*
   go to [count] next start of a frame environment.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-]R)*
   go to [count] next end of a frame environment.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[r)*
   go to [count] previous start of a frame environment.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[R)*
   go to [count] previous end of a frame environment.
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-]/)*
   go to [count] next start of a LaTeX comment "%".
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-]star)*
   go to [count] next end of a LaTeX comment "%".
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[/)*
   go to [count] previous start of a LaTeX comment "%".
-  |exlusive| motion.
+  |exclusive| motion.
 
 *<plug>(vimtex-[star)*
   go to [count] previous end of a LaTeX comment "%".
-  |exlusive| motion.
+  |exclusive| motion.
 
 ------------------------------------------------------------------------------
 INSERT MODE MAPPINGS                                             *vimtex-imaps*


### PR DESCRIPTION
This fixes a typo in the doc file.