### PR TITLE
Document potential conflict with coc.nvim for nmap K to show docs

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3493,6 +3493,13 @@ description as it is specified on the project web page: >
   coc.source.vimtex.priority           priority of source, default 99
   coc.source.vimtex.shortcut           shortcut used in menu of completion item
 
+The README of `coc.nvim` suggests using `noremap K` to show documentation.
+This is also used by vimtex for the same purpose. To enable vimtex's mapping
+(since `coc.nvim` does not have a doc source) for .tex files, put the
+following in $HOME/.vim/after/ftplugin/tex.vim: >
+
+  map <buffer> K <Plug>(vimtex-doc-package)
+
 deoplete~
                                                      *vimtex-complete-deoplete*
 |deoplete| is a modern remake of |neocomplete|, and was originally written


### PR DESCRIPTION
As briefly discussed as part of https://github.com/lervag/vimtex/issues/1349

This conflict is probably worth documenting because it is quite likely to arise, and unlikely to go away with time (both vimtex and coc.nvim will stick to the K mapping). 