### PR TITLE
Expand filenames, for example "~"

### DIFF
--- a/autoload/vimtex/context/cite.vim
+++ b/autoload/vimtex/context/cite.vim
@@ -138,6 +138,7 @@ endfunction
 
 " }}}1
 function! s:actions.open_pdf() abort dict " {{{1
+  call map(self.pdfs, "expand(v:val)") " :h filereadable
   let l:readable = filter(self.pdfs, {_, x -> filereadable(x)})
   if empty(l:readable)
     call vimtex#log#warning('Could not open PDF file!')


### PR DESCRIPTION
Example use case:

I keep the pdfs in a folder that is synced across different machines. So my HOME changes. So I would like to not hardcode it in the file links.