### PR TITLE
Fix ac/ic text objects for non-alphanumeric spacing commands

### DIFF
--- a/autoload/vimtex/cmd.vim
+++ b/autoload/vimtex/cmd.vim
@@ -649,8 +649,8 @@ endfunction
 
 " }}}1
 function! s:get_cmd_name(next) abort " {{{1
-  let [l:lnum, l:cnum] = searchpos('\v\\(\a+\*?|[,:;!])', a:next ? 'nW' : 'cbnW')
-  let l:match = matchstr(getline(l:lnum), '^\v\\([,:;!]|\a*\*?)', l:cnum-1)
+  let [l:lnum, l:cnum] = searchpos('\v\\%(\a+\*?|[,:;!])', a:next ? 'nW' : 'cbnW')
+  let l:match = matchstr(getline(l:lnum), '^\v\\%([,:;!]|\a*\*?)', l:cnum-1)
   return [l:lnum, l:cnum, l:match]
 endfunction
 

--- a/autoload/vimtex/cmd.vim
+++ b/autoload/vimtex/cmd.vim
@@ -649,8 +649,8 @@ endfunction
 
 " }}}1
 function! s:get_cmd_name(next) abort " {{{1
-  let [l:lnum, l:cnum] = searchpos('\v\\\a+\*?', a:next ? 'nW' : 'cbnW')
-  let l:match = matchstr(getline(l:lnum), '^\v\\\a*\*?', l:cnum-1)
+  let [l:lnum, l:cnum] = searchpos('\v\\(\a+\*?|[,:;!])', a:next ? 'nW' : 'cbnW')
+  let l:match = matchstr(getline(l:lnum), '^\v\\([,:;!]|\a*\*?)', l:cnum-1)
   return [l:lnum, l:cnum, l:match]
 endfunction
 

--- a/test/test-textobj/test-other.vim
+++ b/test/test-textobj/test-other.vim
@@ -19,4 +19,8 @@ call vimtex#test#keys('f\dac',
       \ ['a + \test[opt1][opt2]{arg} + f'],
       \ ['a +  + f'])
 
+call vimtex#test#keys('f\dac',
+      \ ['a + \; f'],
+      \ ['a +  f'])
+
 quit!


### PR DESCRIPTION
The `ac` and `ic` text objects did not match the math mode spacing commands `\, \: \; \!`.

Fixed by modifying the defining regexp. Also includes a test.