### PR TITLE
Add an option to disable the extra indent of multi-line TikZ commands

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -222,6 +222,7 @@ function! vimtex#options#init() abort " {{{1
 
   call s:init_option('vimtex_indent_enabled', 1)
   call s:init_option('vimtex_indent_bib_enabled', 1)
+  call s:init_option('vimtex_indent_tikz_enabled', 1)
   call s:init_option('vimtex_indent_conditionals', {
         \ 'open': '\v%(\\newif)@<!\\if%(field|name|numequal|thenelse)@!',
         \ 'else': '\\else\>',

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1784,6 +1784,12 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: 1
 
+*g:vimtex_indent_tikz_enabled*
+  Use this option to disable/enable VimTeX indentation of multi-line commands
+  in TikZ pictures.
+
+  Default value: 1
+
 *g:vimtex_indent_conditionals*
   This is a dictionary that defines regexes for indenting conditionals. Set it
   to an empty dictionary to disable this type of indentation.
@@ -3800,6 +3806,7 @@ for bibliography files (`.bib` files).
 Associated settings:
   |g:vimtex_indent_enabled|
   |g:vimtex_indent_bib_enabled|
+  |g:vimtex_indent_tikz_enabled|
   |g:vimtex_indent_delims|
   |g:vimtex_indent_ignored_envs|
   |g:vimtex_indent_lists|

--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -61,7 +61,9 @@ function! VimtexIndent(lnum) abort " {{{1
   let l:ind += s:indent_envs(l:line, l:prev_line)
   let l:ind += s:indent_delims(l:line, a:lnum, l:prev_line, l:prev_lnum)
   let l:ind += s:indent_conditionals(l:line, a:lnum, l:prev_line, l:prev_lnum)
-  let l:ind += s:indent_tikz(l:prev_lnum, l:prev_line)
+  if g:vimtex_indent_tikz_enabled
+    let l:ind += s:indent_tikz(l:prev_lnum, l:prev_line)
+  endif
 
   return l:ind
 endfunction


### PR DESCRIPTION
(Partially) fixes #1960.