### PR TITLE
pushd/popd root when parsing bib for context menu

### DIFF
--- a/autoload/vimtex/context/cite.vim
+++ b/autoload/vimtex/context/cite.vim
@@ -39,10 +39,13 @@ endfunction
 
 " }}}1
 function! s:handler.get_actions() abort dict " {{{1
+  " Work in root, as in completer_bib.gather_candidates
+  call vimtex#paths#pushd(b:vimtex.root)
   let l:entries = []
   for l:file in vimtex#bib#files()
     let l:entries += vimtex#parser#bib(l:file, {'backend': 'vim'})
   endfor
+  call vimtex#paths#popd()
 
   let l:entry = get(
         \ filter(copy(l:entries), {_, x -> x.key ==# self.selected}), 0, {})

--- a/autoload/vimtex/context/cite.vim
+++ b/autoload/vimtex/context/cite.vim
@@ -39,7 +39,7 @@ endfunction
 
 " }}}1
 function! s:handler.get_actions() abort dict " {{{1
-  " Work in root, as in completer_bib.gather_candidates
+  " Ensure we're at the root directory when locating bib files
   call vimtex#paths#pushd(b:vimtex.root)
   let l:entries = []
   for l:file in vimtex#bib#files()


### PR DESCRIPTION
Finding the bib files for the context menu for cite items doesn't work unless we're in the right dir. To fix this, I made these changes, inspired by `completer_bib.gather_candidates`