### PR TITLE
Remove texZone link for Asymptote syntax

### DIFF
--- a/autoload/vimtex/syntax/p/asymptote.vim
+++ b/autoload/vimtex/syntax/p/asymptote.vim
@@ -11,8 +11,6 @@ function! vimtex#syntax#p#asymptote#load(cfg) abort " {{{1
 
   call vimtex#syntax#core#new_region_env('texAsymptoteZone', 'asy', l:opts)
   call vimtex#syntax#core#new_region_env('texAsymptoteZone', 'asydef', l:opts)
-
-  highlight def link texAsymptoteZone texZone
 endfunction
 
 " }}}1


### PR DESCRIPTION
Because `texAsymptoteZone` includes the `asy` syntax file, linking it to `texZone` makes otherwise unassigned parts of the code (e.g. variable names) to be in the `texZone` color instead of the default color; this pull request removes this link so that Asymptote code is highlight as if it were in a standalone `.asy` file.

Screenshots from `test/test-syntax/test-asymptote.tex` (with `:colo default`):

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/45520974/110155200-4b3f7500-7db3-11eb-8492-311d9041376c.png) | ![image](https://user-images.githubusercontent.com/45520974/110155216-50042900-7db3-11eb-8048-78c5880c0c5d.png) |

