### PR TITLE
Handle % in URL arguments properly

### DIFF
--- a/autoload/vimtex/syntax/p/hyperref.vim
+++ b/autoload/vimtex/syntax/p/hyperref.vim
@@ -21,9 +21,9 @@ function! vimtex#syntax#p#hyperref#load(cfg) abort " {{{1
 
   syntax match texCmdHyperref "\\url\>" nextgroup=texUrlArg skipwhite
   syntax region texUrlArg matchgroup=texDelim
-        \ contained contains=@NoSpell,texComment
+        \ contained contains=@NoSpell
         \ start="\z([^\ta-zA-Z]\)" end="\z1"
-  call vimtex#syntax#core#new_arg('texUrlArg', {'contains': 'texComment,@NoSpell'})
+  call vimtex#syntax#core#new_arg('texUrlArg', {'contains': '@NoSpell'})
 
 
   highlight def link texCmdHyperref   texCmd

--- a/test/test-syntax/test-hyperref.tex
+++ b/test/test-syntax/test-hyperref.tex
@@ -5,6 +5,7 @@
 
 \url{http://www.google.com}
 \url+http://www.google.com+
+\url{https://www.example.com/Spaces%20In%20URL/}
 \href{http://example.com}{Title text $with math$}
 \urldef{\mysite}\url{http://example.com}
 \hyperref[asdasd]{asd}

--- a/test/test-syntax/test-hyperref.vim
+++ b/test/test-syntax/test-hyperref.vim
@@ -5,6 +5,6 @@ silent edit test-hyperref.tex
 if empty($INMAKE) | finish | endif
 
 call vimtex#test#assert(vimtex#syntax#in('texUrlArg', 6, 25))
-call vimtex#test#assert(vimtex#syntax#in('texRefArg', 16, 35))
+call vimtex#test#assert(vimtex#syntax#in('texRefArg', 17, 35))
 
 quit!


### PR DESCRIPTION
Percent signs are fairly common in URLs to encode special characters such as spaces (`%20`), so they should not be recognized as a TeX comment marker within URLs provided to `\url` and `\href`.