### PR TITLE
Highlight \fbox argument as text mode

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -405,7 +405,7 @@ function! vimtex#syntax#core#init() abort " {{{1
   syntax match texMathSuperSub "[_^]" contained
 
   " Text Inside Math regions
-  syntax match texCmdMathText "\\\(\(inter\)\?text\|mbox\)\>" nextgroup=texMathTextArg
+  syntax match texCmdMathText "\\\(\(inter\)\?text\|mbox\|fbox\)\>" nextgroup=texMathTextArg
   call vimtex#syntax#core#new_arg('texMathTextArg')
 
   " Math style commands


### PR DESCRIPTION
`\fbox`, which is useful for enclosing an important result in a box in math mode, takes a text mode argument; change the syntax highlighting to reflect this fact.