### PR TITLE
fix: fzf toc display and jump error when spaces in file path

### DIFF
--- a/autoload/vimtex/fzf.vim
+++ b/autoload/vimtex/fzf.vim
@@ -21,10 +21,12 @@ function! vimtex#fzf#run(...) abort " {{{1
   " Note: The '--with-nth 3..' option hides the first two words from the fzf
   "       window. These words are the file name and line number and are used by
   "       the sink.
+  "       Using \u2007 as delimiter allows spaces in the file path, while
+  "       keeping the visuals in fzf window unaffected.
   let l:opts = extend({
       \ 'source': <sid>parse_toc(a:0 == 0 ? 'ctli' : a:1),
       \ 'sink': function('vimtex#fzf#open_selection'),
-      \ 'options': '--ansi --with-nth 3..',
+      \ 'options': "--ansi --with-nth 3.. --delimiter '\u2007'",
       \}, a:0 > 1 ? a:2 : {})
 
   call fzf#run(l:opts)
@@ -32,8 +34,8 @@ endfunction
 
 " }}}1
 function! vimtex#fzf#open_selection(sel) abort " {{{1
-  let line = split(a:sel)[0]
-  let file = split(a:sel)[1]
+  let line = split(a:sel, '\%u2007')[0]
+  let file = split(a:sel, '\%u2007')[1]
   let curr_file = expand('%:p')
 
   if curr_file == file
@@ -91,7 +93,9 @@ def colorize(e):
 
 def create_candidate(e, depth):
   number = format_number(dict(e['number']))
-  return f"{e.get('line', 0)} {e['file']} {colorize(e)} {number}"
+  return (
+    f"{e.get('line', 0)}\u2007{e['file']}\u2007{colorize(e)}\u2007{number}"
+  )
 
 entries = vim.eval('vimtex#parser#toc()')
 depth = max([int(e['level']) for e in entries])


### PR DESCRIPTION
The file path and heading extracted by splitting at spaces would be wrong if the path contains spaces itself. Using \u2007 as a hack to preserve formatting (junegunn/fzf#585)