### PR TITLE
Fix(syntax): \lstset syntax highlighting

### DIFF
--- a/autoload/vimtex/syntax/p/listings.vim
+++ b/autoload/vimtex/syntax/p/listings.vim
@@ -91,7 +91,6 @@ function! vimtex#syntax#p#listings#load(cfg) abort " {{{1
   highlight def link texLstOpt        texOpt
   highlight def link texLstZone       texZone
   highlight def link texLstZoneInline texVerbZoneInline
-  highlight def link texLstsetGroup   texGroup
 endfunction
 
 " }}}1

--- a/autoload/vimtex/syntax/p/listings.vim
+++ b/autoload/vimtex/syntax/p/listings.vim
@@ -15,8 +15,8 @@ function! vimtex#syntax#p#listings#load(cfg) abort " {{{1
 
   " Match \lstset
   syntax match texCmdLstset "\\lstset\>"
-        \ nextgroup=texLstsetArg,texLstsetGroup skipwhite skipnl
-  call vimtex#syntax#core#new_arg('texLstsetGroup', {
+        \ nextgroup=texLstsetArg,texLstsetArg skipwhite skipnl
+  call vimtex#syntax#core#new_arg('texLstsetArg', {
         \ 'contains': 'texCmdSize,texCmdStyle,@texClusterOpt'
         \})
 
@@ -51,7 +51,7 @@ function! vimtex#syntax#p#listings#load(cfg) abort " {{{1
     execute 'syntax match texLstsetArg'
           \ '"\c{\_[^}]*language=' . l:nested . '\%(\s*,\|}\)"'
           \ 'nextgroup=' . l:grp 'skipwhite skipnl'
-          \ 'contains=texLstsetGroup'
+          \ 'contains=texLstsetArg'
 
     call vimtex#syntax#core#new_region_env(l:grp, 'lstlisting', {
           \ 'contains': 'texLstEnvBgn,' . l:cluster,
@@ -91,6 +91,7 @@ function! vimtex#syntax#p#listings#load(cfg) abort " {{{1
   highlight def link texLstOpt        texOpt
   highlight def link texLstZone       texZone
   highlight def link texLstZoneInline texVerbZoneInline
+  highlight def link texLstsetArg     texOpt
 endfunction
 
 " }}}1

--- a/autoload/vimtex/syntax/p/listings.vim
+++ b/autoload/vimtex/syntax/p/listings.vim
@@ -91,7 +91,7 @@ function! vimtex#syntax#p#listings#load(cfg) abort " {{{1
   highlight def link texLstOpt        texOpt
   highlight def link texLstZone       texZone
   highlight def link texLstZoneInline texVerbZoneInline
-  highlight def link texLstsetGroup   texOpt
+  highlight def link texLstsetGroup   texGroup
 endfunction
 
 " }}}1

--- a/autoload/vimtex/syntax/p/listings.vim
+++ b/autoload/vimtex/syntax/p/listings.vim
@@ -17,7 +17,7 @@ function! vimtex#syntax#p#listings#load(cfg) abort " {{{1
   syntax match texCmdLstset "\\lstset\>"
         \ nextgroup=texLstsetArg,texLstsetGroup skipwhite skipnl
   call vimtex#syntax#core#new_arg('texLstsetGroup', {
-        \ 'contains': 'texComment,texLength,texOptSep,texOptEqual'
+        \ 'contains': 'texCmdSize,texCmdStyle,@texClusterOpt'
         \})
 
   " Match unspecified lstlisting environment

--- a/test/test-syntax/test-listings.tex
+++ b/test/test-syntax/test-listings.tex
@@ -41,4 +41,10 @@ fn main() {
 
 \lstset{language=x,numbers=none}
 
+\lstset{
+    language=C,
+    basicstyle=\color[RGB]{0,0,0},
+    numberstyle=\small
+}
+
 \end{document}

--- a/test/test-syntax/test-listings.vim
+++ b/test/test-syntax/test-listings.vim
@@ -10,7 +10,7 @@ call vimtex#test#assert(vimtex#syntax#in('texLstZoneInline', 9, 14))
 call vimtex#test#assert(vimtex#syntax#in('texLstZone', 15, 1))
 call vimtex#test#assert(vimtex#syntax#in('texLstZoneC', 23, 1))
 call vimtex#test#assert(vimtex#syntax#in('texLstZonePython', 30, 1))
-call vimtex#test#assert(vimtex#syntax#in('texLstZoneRust', 36, 1))
+call vimtex#test#assert(vimtex#syntax#in('texLstZoneRust', 37, 1))
 
 call vimtex#test#assert(vimtex#syntax#in('texLstsetGroup', 42, 10))
 

--- a/test/test-syntax/test-listings.vim
+++ b/test/test-syntax/test-listings.vim
@@ -12,7 +12,7 @@ call vimtex#test#assert(vimtex#syntax#in('texLstZoneC', 23, 1))
 call vimtex#test#assert(vimtex#syntax#in('texLstZonePython', 30, 1))
 call vimtex#test#assert(vimtex#syntax#in('texLstZoneRust', 37, 1))
 
-call vimtex#test#assert(vimtex#syntax#in('texLstsetGroup', 42, 10))
+call vimtex#test#assert(vimtex#syntax#in('texLstsetArg', 42, 10))
 
 call vimtex#test#assert(vimtex#syntax#in('texCmd', 46, 20))
 call vimtex#test#assert(vimtex#syntax#in('texCmdSize', 47, 20))

--- a/test/test-syntax/test-listings.vim
+++ b/test/test-syntax/test-listings.vim
@@ -14,4 +14,7 @@ call vimtex#test#assert(vimtex#syntax#in('texLstZoneRust', 37, 1))
 
 call vimtex#test#assert(vimtex#syntax#in('texLstsetGroup', 42, 10))
 
+call vimtex#test#assert(vimtex#syntax#in('texCmd', 46, 20))
+call vimtex#test#assert(vimtex#syntax#in('texCmdSize', 47, 20))
+
 quit!


### PR DESCRIPTION
## Fixes #2000 

### Before fix
![image](https://user-images.githubusercontent.com/44112701/112018868-e6816a00-8b69-11eb-8131-3e027cf72eb0.png)

**Note** that the red `}` is somehow classified into a `texGroupError`:
![image](https://user-images.githubusercontent.com/44112701/112019720-ab336b00-8b6a-11eb-9b40-f8ba4056b35b.png)

### After fix
![20210322235220](https://raw.githubusercontent.com/144026/rsrc/master/img/20210322235220.png)