### PR TITLE
update example using VimtexClean upon quit

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3362,8 +3362,8 @@ Examples: >
   " Compile on initialization, cleanup on quit
   augroup vimtex_event_1
     au!
-    au User VimtexEventQuit     call vimtex#compiler#clean(0)
-    au User VimtexEventInitPost call vimtex#compiler#compile()
+    au User VimtexEventQuit     VimtexClean
+    au User VimtexEventInitPost VimtexCompile
   augroup END
 
   " Close viewers when VimTeX buffers are closed


### PR DESCRIPTION
The example is using some outdated function (I think).
I wanted to get the behaviour described, and I got it using `VimtexClean` instead of `call vimtex#compiler#clean(0)` which didn't do anything (as I don't think that function exists?)