### PR TITLE
Set foldmethod=diff when doing diff.

### DIFF
--- a/autoload/vimtex/fold.vim
+++ b/autoload/vimtex/fold.vim
@@ -85,9 +85,13 @@ endfunction
 " }}}1
 
 function! vimtex#fold#refresh(map) abort " {{{1
-  setlocal foldmethod=expr
-  execute 'normal!' a:map
-  setlocal foldmethod=manual
+  if &diff
+    setlocal foldmethod=diff
+  else
+    setlocal foldmethod=expr
+    execute 'normal!' a:map
+    setlocal foldmethod=manual
+  endif
 endfunction
 
 " }}}1


### PR DESCRIPTION
Thanks for this great project! I find vimtex very helpful for my work.
Currently, when `g:vimtex_fold_manual=1`, vimtex enforces folding based on the content of the tex file even in the diff mode.
This PR changes it by setting `foldmethod=diff` during diff-ing, which I think is a more plausible and convenient behavior.
Please consider merging it.