### PR TITLE
Fix test_globbed.vim to detect shortcomings of the implementation

### DIFF
--- a/test/test-completion-bibtex/test_globbed.vim
+++ b/test/test-completion-bibtex/test_globbed.vim
@@ -4,15 +4,39 @@ filetype plugin on
 
 nnoremap q :qall!<cr>
 
+let s:build_dir = expand('<sfile>:r') . '.dir'
 let g:vimtex_cache_root = '.'
 let g:vimtex_cache_persistent = 0
+let g:vimtex_log_verbose = 0
+let g:vimtex_compiler_method = 'latexmk'
+let g:vimtex_compiler_latexmk = {
+      \ 'callback' : 0,
+      \ 'continuous' : 0,
+      \ 'build_dir' : s:build_dir,
+      \}
+
+
+function! Clean()
+  if isdirectory(s:build_dir)
+    call delete(s:build_dir, 'rf')
+  endif
+endfunction
+
+function! TestCompletion(expected)
+  let l:candidates = vimtex#test#completion('\cite{', '')
+  call vimtex#test#assert_equal(a:expected, len(l:candidates))
+
+  call Clean()
+endfunction
+
+au! User
+au  User VimtexEventCompileFailed  cquit
+au  User VimtexEventCompileSuccess call TestCompletion(1) | quit!
 
 silent edit test_globbed.tex
 
 if empty($INMAKE) | finish | endif
 
-let s:candidates = vimtex#test#completion('\cite{', '')
-call vimtex#test#assert_equal(1, len(s:candidates))
-
-
-quit!
+call Clean()
+call TestCompletion(1)
+silent call vimtex#compiler#compile()


### PR DESCRIPTION
This fixes the test to take both code paths where globbing is needed (cf. #2035).

The test used to always take the second path because vimtex doesn't know about the biblatex package being loaded before a compile.

This doesn't need to be merged because it will also be part of #2035, I just want to illustrate why that bug wasn't uncovered by the existing test and that it indeed fails if done properly.

I would also like to discuss a way to test more than one .tex file within the same vimscript, but am not experienced enough in vimscript to do that with the current asynchronous implementation. The following happens when I want to edit another file and compile it:
```
Error detected while processing function TestCompletion[12]..vimtex#compiler#compile:
line    1:
E121: Undefined variable: b:vimtex
```
Maybe it would be better to do it synchronously, but I also haven't found out how to wait for an event.