### PR TITLE
Append success/failure commands of latexmk instead of overwriting.

### DIFF
--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -22,6 +22,14 @@ endfunction
 
 "}}}1
 
+function! vimtex#compiler#latexmk#wrap_append_cmd_option(name, value) abort " {{{1
+  return has('win32')
+        \ ? ' -e "$' . a:name . ' .= '';' . a:value . '''"'
+        \ : ' -e ''$' . a:name . ' .= ";' . a:value . '"'''
+endfunction
+
+"}}}1
+
 function! vimtex#compiler#latexmk#get_rc_opt(root, opt, type, default) abort " {{{1
   "
   " Parse option from .latexmkrc.
@@ -263,7 +271,7 @@ function! s:compiler.build_cmd() abort dict " {{{1
               \ 'failure_cmd' : 'vimtex_compiler_callback_failure',
               \})
           let l:func = 'echo ' . l:val
-          let l:cmd .= vimtex#compiler#latexmk#wrap_option(l:opt, l:func)
+          let l:cmd .= vimtex#compiler#latexmk#wrap_append_cmd_option(l:opt, l:func)
         endfor
       elseif empty(v:servername)
         call vimtex#log#warning('Can''t use callbacks with empty v:servername')
@@ -280,7 +288,7 @@ function! s:compiler.build_cmd() abort dict " {{{1
                 \ . vimtex#util#shellescape('""')
                 \ . ' --servername ' . vimtex#util#shellescape(v:servername)
                 \ . ' --remote-expr ' . l:callback
-          let l:cmd .= vimtex#compiler#latexmk#wrap_option(l:opt, l:func)
+          let l:cmd .= vimtex#compiler#latexmk#wrap_append_cmd_option(l:opt, l:func)
         endfor
       endif
     endif


### PR DESCRIPTION
Append success and failure callbacks to `success_cmd` and `failure_cmd` instead of overwriting them. This allows to use them in a latexmkrc-file, where right now they are overwritten and hence not executed. This fixes #1237. 

I introduce a function `wrap_append_cmd_option` that only differs from `wrap_option` by 

1.  using `.=` instead of `=` which is appending in perl
2. adding a `;` before the appended value. This separates shell commands. It is no problem if the variable was empty beforehand.

I am unsure if this works correctly on windows since I never did scripting there and do not know if `;` has the same effect. One could easily use the old variant for windows if this does not work. 

The change only influences `success_cmd` and `failure_cmd` since I did not change `wrap_option` here. In my opinion overwriting is the right thing to do at the other places it is used.