### PR TITLE
Fixed appending to success_cmd

### DIFF
--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -626,9 +626,11 @@ endfunction
 " Utility functions
 "
 function! s:wrap_option_appendcmd(name, value) abort " {{{1
+  " Do not use with $ in value. On linux, we use double quoted perl strings
+  " that interpolate.
   return has('win32')
-        \ ? ' -e "$' . a:name . ' .= '';' . a:value . '''"'
-        \ : ' -e ''$' . a:name . ' .= ";' . a:value . '"'''
+        \ ? ' -e "$' . a:name . ' = ($' . a:name . ' ? $' . a:name . ' . '' & '' : '''') . ''' . a:value . '''"'
+        \ : ' -e ''$' . a:name . ' = ($' . a:name . ' ? $' . a:name . ' . " ; " : "") . "' . a:value . '"'''
 endfunction
 
 "}}}1

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -263,7 +263,7 @@ function! s:compiler.build_cmd() abort dict " {{{1
               \ 'failure_cmd' : 'vimtex_compiler_callback_failure',
               \})
           let l:func = 'echo ' . l:val
-          let l:cmd .= vimtex#compiler#latexmk#wrap_option(l:opt, l:func)
+          let l:cmd .= s:wrap_option_appendcmd(l:opt, l:func)
         endfor
       elseif empty(v:servername)
         call vimtex#log#warning('Can''t use callbacks with empty v:servername')
@@ -280,7 +280,7 @@ function! s:compiler.build_cmd() abort dict " {{{1
                 \ . vimtex#util#shellescape('""')
                 \ . ' --servername ' . vimtex#util#shellescape(v:servername)
                 \ . ' --remote-expr ' . l:callback
-          let l:cmd .= vimtex#compiler#latexmk#wrap_option(l:opt, l:func)
+          let l:cmd .= s:wrap_option_appendcmd(l:opt, l:func)
         endfor
       endif
     endif


### PR DESCRIPTION
DO NOT MERGE before testing this on windows. I cannot.

We are very officially in escaping-hell (not to be confused with escaping hell, we do not do that here). Generally, we want to create the following string:

` -e '$success_cmd = ($success_cmd ? $success_cmd . ";" : "")  . "echo something"'`

with `&` instead of `;` on windows. In perl, this checks if `$success_cmd` is non-empty, if so, it adds a `;` after it. To this we append the wanted command. This will break if someone writes `$success_cmd = ' '` in their latexmkrc, but I really do not care.

On linux, we want to use single-quoted strings in the command line, since otherwise, the shell will substitute variables and what not. We would like to also use single quoted strings in the perl expression, since the same applies there, but we cannot escape single quotes in a single-quoted shell string. We could use `'"'"'` to end the single-quoted string, insert a double-quoted single quote and start the single-quoted string again, but this expands to `''"''"''` in vim and that's just unreadable. Hence, we use double quotes in perl and this should be no problem in our use cases.

On windows, there are only double-quoted strings in the cmd.exe, so we use them. Then, we can just use single quotes for perl strings. The command separator is `&`. I am unsure if this has to be specially escaped even if it is quoted, cmd.exe seems to be weird about this. Someone should test this before merging.