### PR TITLE
Add "Open arXiv" action to cite context menu

### DIFF
--- a/autoload/vimtex/context/cite.vim
+++ b/autoload/vimtex/context/cite.vim
@@ -92,6 +92,11 @@ function! s:actions.create(entry) abort dict " {{{1
   if has_key(a:entry, 'doi')
     call add(l:new.menu, {'name': 'Open doi', 'func': 'open_doi'})
   endif
+  
+  let s:is_arxiv = (has_key(a:entry, 'archiveprefix') && a:entry.archiveprefix == 'arXiv' || a:entry.eprint[0:6] == 'arXiv')
+  if (has_key(a:entry, 'eprint') && s:is_arxiv)
+    call add(l:new.menu, {'name': 'Open arXiv', 'func': 'open_arxiv'})
+  endif
 
   if has_key(a:entry, 'url')
     call add(l:new.menu, {'name': 'Open url', 'func': 'open_url'})
@@ -164,6 +169,11 @@ function! s:actions.open_pdf() abort dict " {{{1
   call vimtex#process#start(
         \ g:vimtex_context_pdf_viewer
         \ . ' ' . vimtex#util#shellescape(l:file))
+endfunction
+
+" }}}1
+function! s:actions.open_arxiv() abort dict " {{{1
+  call vimtex#util#www('http://arxiv.org/abs/' . self.entry.eprint)
 endfunction
 
 " }}}1

--- a/autoload/vimtex/context/cite.vim
+++ b/autoload/vimtex/context/cite.vim
@@ -93,9 +93,8 @@ function! s:actions.create(entry) abort dict " {{{1
     call add(l:new.menu, {'name': 'Open doi', 'func': 'open_doi'})
   endif
   
-  let s:is_arxiv = (has_key(a:entry, 'archiveprefix') && a:entry.archiveprefix == 'arXiv' || a:entry.eprint[0:6] == 'arXiv')
-  if (has_key(a:entry, 'eprint') && s:is_arxiv)
-    call add(l:new.menu, {'name': 'Open arXiv', 'func': 'open_arxiv'})
+  if (has_key(a:entry, 'eprint') && (has_key(a:entry, 'archiveprefix') && a:entry.archiveprefix == 'arXiv' || a:entry.eprint[0:4] == 'arXiv'))
+      call add(l:new.menu, {'name': 'Open arXiv', 'func': 'open_arxiv'})
   endif
 
   if has_key(a:entry, 'url')


### PR DESCRIPTION
Makes a new item to the VimtexContextMenu, so when doing `<localleader>la` on a citation, you get the option to open it on arXiv.org if the citation is an arXiv preprint.

This PR is just something I had done in my own branch so I could use it. I thought I'd make it available to others this way. I hope I'm following the correct procedure here (should I have suggested it in an issue first? I don't know the etiquette.  Should I have created some tests too?  It worked for me with the following citations).


```bib
@article{0801.1144,
	author = {John Kitchin and Karsten Reuter and Matthias Scheffler},
	doi = {10.1103/PhysRevB.77.075437},
	eprint = {arXiv:0801.1144},
	title = {Alloy surface segregation in reactive environments: A first-principles atomistic thermodynamics study of Ag3Pd(111) in oxygen atmospheres},
	year = {2008}}

@misc{wilcox.e:2021,
	archiveprefix = {arXiv},
	author = {Ethan Gotlieb Wilcox and Pranali Vani and Roger P. Levy},
	eprint = {2106.03232},
	primaryclass = {cs.CL},
	title = {A Targeted Assessment of Incremental Processing in Neural Language Models and Humans},
	year = {2021}}
```