### PR TITLE
hotfix to disable bib folding by default

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -62,7 +62,7 @@ function! vimtex#options#init() abort " {{{1
     let g:vimtex_fold_bib_enabled = 0
   else
     call s:init_option('vimtex_fold_enabled', 0)
-    call s:init_option('vimtex_fold_bib_enabled', 1)
+    call s:init_option('vimtex_fold_bib_enabled', 0)
   endif
   call s:init_option('vimtex_fold_bib_max_key_width', 0)
   call s:init_option('vimtex_fold_manual', 0)

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1627,7 +1627,7 @@ OPTIONS                                                        *vimtex-options*
 *g:vimtex_fold_bib_enabled*
   Use this option to enable/disable folding in .bib files.
 
-  Default value: 1
+  Default value: 0
 
 *g:vimtex_fold_bib_max_key_width*
   This option is used to specify a length to truncate identifiers (e.g.
@@ -4018,7 +4018,7 @@ In order to get slightly cleaner fold text, I recommend setting the global
 Note: Remember to include the whitespace after backslash!
 
 In addition, VimTeX also provides basic folding in .bib files. It is
-enabled by default, but can be turned off with |g:vimtex_fold_bib_enabled|.
+disabled by default, but can be turned on with |g:vimtex_fold_bib_enabled|.
 
 Associated settings:
 * |g:vimtex_fold_enabled|


### PR DESCRIPTION
This seems like the easiest way to let the user control tex and bib folding separately (as opposed to making it conditional on `g:vimtex_fold_enabled`, for example).