### PR TITLE
Do not parse .blg files if bibunits is used.

### DIFF
--- a/autoload/vimtex/bib.vim
+++ b/autoload/vimtex/bib.vim
@@ -16,7 +16,7 @@ function! vimtex#bib#files() abort " {{{1
   endif
 
   let l:file = b:vimtex.ext('blg')
-  if filereadable(l:file)
+  if filereadable(l:file) && !has_key(b:vimtex.packages, 'bibunits')
     let l:bibs = map(
           \ filter(readfile(l:file), 'v:val =~# ''^Database file #\d'''),
           \ {_, x -> matchstr(x, '#\d\+: \zs.*\ze\.bib$')})


### PR DESCRIPTION
The [bibunits](https://www.ctan.org/pkg/bibunits) package provides a way to use multiple bibliographies in one document.

A .bib file can be included using bibunits via the commands `\putbib[...]` or `\defaultbibliography{...}`.  Vimtex can be told about these .bib files by changing the `g:vimtex_bibliography_commands` variable.  

However, bibunits generates separate .blg files (sequentially named bu1.blg, bu2.blg, etc.) for each bibliography and because of this, the main .blg file (if it gets generated) does not contain any information about the .bib files that are actually used.  But it is the main .blg file that Vimtex parses and since there is nothing in it, Vimtex cannot find the right .bib files.  This in turn prevents omni completion of the bibliographic entries.

Hence, if bibunits is used, one should resort to manual parsing of the document using the `s:files_manual()` function to find the right .bib files.
