### PR TITLE
Closes #2101. improves documentation wording on the -recorder option passed by default to latexmk

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -682,9 +682,10 @@ The package list is determined in two ways: >
 
 1. If a `.fls` file exists having the name of the main file, it is scanned.
    This file is created by `latex` (or `pdflatex`, `xelatex`, ...) if it is
-   run with the `-recorder` option. This is enabled by default with `latexmk`.
-   Parsing the `.fls` file is done both at VimTeX initialization and after
-   each successful compilation, if possible.
+   run with the `-recorder` option (which is set by default when using
+   latexmk, unless overridden in an initialization file). Parsing the `.fls`
+   file is done both at VimTeX initialization and after each successful
+   compilation, if possible.
 
    Note: Parsing after successful compilations requires that one uses
          a) continuous compilation with callbacks (see the `callback` option


### PR DESCRIPTION
Happy to work on the wording, and rewrite the sentence any number of times until the idea is clearly conveyed.