### PR TITLE
Motion mappings doc update for g:vimtex_motion_enabled

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -161,7 +161,7 @@ FEATURE OVERVIEW                                              *vimtex-features*
     - give enhanced |gf| command
 - Easy access to (online) documentation of packages
 - Word count (through `texcount`)
-- Motions
+- Motions                                                      *vimtex-motions*
   - Move between section boundaries with `[[`, `[]`, `][`, and `]]`
   - Move between environment boundaries with `[m`, `[M`, `]m`, and `]M`
   - Move between math environment boundaries with `[n`, `[N`, `]n`, and `]N`
@@ -1970,8 +1970,8 @@ OPTIONS                                                        *vimtex-options*
   Default value: 1
 
 *g:vimtex_motion_enabled*
-  This option enables the motion mappings `%`, `[[`, `[]`, `][`, and `]]`. It
-  also enables the highlighting of matching delimiters.
+  This option enables the motion mappings, see |vimtex-motions|. It also
+  enables the highlighting of matching delimiters.
 
   Default value: 1
 


### PR DESCRIPTION
It looks like the documentation wording for `g:vimtex_motion_enabled` has not been updated to account for the motions added to vimtex since the original set.  This PR has a minor documentation update which includes the full range of motions supported currently. 

The updated list is slightly re-ordered to be consistent with the order presented in README.md and in the feature-overview section at the top of the help file.