### PR TITLE
Include option parameters with environments in folding

### DIFF
--- a/autoload/vimtex/fold/envs.vim
+++ b/autoload/vimtex/fold/envs.vim
@@ -103,7 +103,7 @@ function! s:folder.text(line, level) abort dict " {{{1
   if strlen(env) > width_env - 8
     let env = strpart(env, 0, width_env - 11) . '...'
   endif
-  let env = '\begin{' . env . '}'
+  let env = '\begin{' . env . '}' . ' ' . matchstr(a:line, '\[\zs.*\ze\]')
 
   let title = printf('%*S%-*S %-*S  %*S',
         \ width_ind, '',

--- a/autoload/vimtex/fold/envs.vim
+++ b/autoload/vimtex/fold/envs.vim
@@ -68,12 +68,15 @@ function! s:folder.text(line, level) abort dict " {{{1
 
   " Set caption/label based on type of environment
   if env ==# 'frame'
+    let option = ''
     let label = ''
     let caption = self.parse_caption_frame(a:line)
   elseif env ==# 'table'
+    let option = ''
     let label = self.parse_label()
     let caption = self.parse_caption_table(a:line)
   else
+    let option = matchstr(a:line, '\[\zs.*\ze\]')
     let label = self.parse_label()
     let caption = self.parse_caption(a:line)
   endif
@@ -103,7 +106,7 @@ function! s:folder.text(line, level) abort dict " {{{1
   if strlen(env) > width_env - 8
     let env = strpart(env, 0, width_env - 11) . '...'
   endif
-  let env = '\begin{' . env . '}' . ' ' . matchstr(a:line, '\[\zs.*\ze\]')
+  let env = '\begin{' . env . '}' . ' ' . option
 
   let title = printf('%*S%-*S %-*S  %*S',
         \ width_ind, '',

--- a/autoload/vimtex/fold/envs.vim
+++ b/autoload/vimtex/fold/envs.vim
@@ -71,12 +71,12 @@ function! s:folder.text(line, level) abort dict " {{{1
     let option = ''
     let label = ''
     let caption = self.parse_caption_frame(a:line)
-  elseif env ==# 'table'
+  elseif env ==# 'table' || env ==# 'figure'
     let option = ''
     let label = self.parse_label()
     let caption = self.parse_caption_table(a:line)
   else
-    let option = matchstr(a:line, '\[\zs.*\ze\]')
+    let option = matchstr(a:line, '\[.*\]')
     let label = self.parse_label()
     let caption = self.parse_caption(a:line)
   endif
@@ -106,7 +106,7 @@ function! s:folder.text(line, level) abort dict " {{{1
   if strlen(env) > width_env - 8
     let env = strpart(env, 0, width_env - 11) . '...'
   endif
-  let env = '\begin{' . env . '}' . ' ' . option
+  let env = '\begin{' . env . '}' . option
 
   let title = printf('%*S%-*S %-*S  %*S',
         \ width_ind, '',

--- a/test/test-folding/test-env-options.tex
+++ b/test/test-folding/test-env-options.tex
@@ -1,0 +1,72 @@
+\documentclass{memoir}
+
+\begin{document}
+
+\section{test1}
+\label{sec:test1}
+
+% The fold for the definition below should contain the environment, the options, and the label:
+%\begin{defn}[Definition1]								(defn:definition_1)
+\begin{defn}[Definition 1]
+\label{defn:definition_1}
+A simple environment with simple contents.
+\end{defn}
+
+Filler text
+
+% The fold for the figure below should contain the environment, NOT the options, the caption, and the label:
+%\begin{figure}		Simple figure							(fig:simple_theorem)
+\begin{figure}[ht] % A standalone figure with label and caption
+    \centering
+%     \input{proof}
+    \caption{Simple figure}
+    \label{fig:simple_figure}
+\end{figure}
+
+Filler text
+
+\subsection{subtests 1}
+\label{sub:subtests_1}
+
+These tests feature nesting.
+
+% The fold for the theorem below should contain the environment, the options, and the label:
+%\begin{thm}[Example Title of Theorem]								(thm:example_title_of_theorem)
+\begin{thm}[Example Title of Theorem]
+\label{thm:example_title_of_theorem}
+Suppose A and B.
+
+	 \begin{itemize}
+		\item If C, then D
+		\item \(A \wedge B \implies D \iff A \wedge B \implies C\)
+	\end{itemize}
+
+	We demonstrate this by the figure.
+% The fold for the figure below should contain the environment, NOT the options, the caption, and the label:
+%\begin{figure}		A visual proof of the Example Theorem					(fig:visual_theorem)
+\begin{figure}[ht] % Comment
+    \centering
+%     \input{proof}
+    \caption{A visual proof of Example Theorem}
+    \label{fig:visual_theorem}
+\end{figure}
+
+\end{thm}
+
+Filler text
+
+% If one has an unusual case of captioning in a nonstandard environment (i.e. not figure or table), the following conflict may occur:
+% \begin{defn}[Definition 2] A caption for an environment typically without caption								% (defn:defini
+\begin{defn}[Definition 2]
+\label{defn:definition_2}
+A sample definition.
+
+\caption{A caption for an environment typically without caption}
+\end{defn}
+% The proper folding should be:
+% \begin{defn}[Definition 2] A caption for an environment typically without caption								% (defn:definition)
+
+% However, the spacing in the envs.vim folding mechanisms does not account for the spacing of both the options and the caption, and so the label is incorrectly fit within the fold.
+
+
+\end{document}


### PR DESCRIPTION
I added an option variable in case down the road it is deemed worthwhile to create a more robust parse_option() function, or get options for frames/tables. I also did it this way so that way the options from tables and frames wouldn't be included (as they are often parameters and hence not pertinent information in a fold).

I chose to use a lookahead and add a space between the environment for aesthetic purposes. Hence,

```tex
\begin{defn}[Holomorphic]
Lorem Ipsum
\end{defn}
```

will be folded as

`\begin{defn} Holomorphic ----------------`

If instead you prefer

`\begin{defn}[Holomorphic] ---------------`

then replace the command on line 79 from

`     let option = matchstr(a:line, '\[\zs.*\ze\]')`

to

`     let option = matchstr(a:line, '\[.*\]')`