### PR TITLE
Replaces the style-check URL page with github source code repo link

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -4899,7 +4899,7 @@ VimTeX provides several compilers for grammar checking TeX files through the
 |compiler-select| feature in Vim:
 
   style-check~
-    http://www.cs.umd.edu/~nspring/software/style-check-readme.html
+    https://github.com/nspring/style-check.git
 
   textidote~
     See more details here: |vimtex-grammar-textidote|

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -682,9 +682,10 @@ The package list is determined in two ways: >
 
 1. If a `.fls` file exists having the name of the main file, it is scanned.
    This file is created by `latex` (or `pdflatex`, `xelatex`, ...) if it is
-   run with the `-recorder` option. This is enabled by default with `latexmk`.
-   Parsing the `.fls` file is done both at VimTeX initialization and after
-   each successful compilation, if possible.
+   run with the `-recorder` option (which is set by default when using
+   latexmk, unless overridden in an initialization file). Parsing the `.fls`
+   file is done both at VimTeX initialization and after each successful
+   compilation, if possible.
 
    Note: Parsing after successful compilations requires that one uses
          a) continuous compilation with callbacks (see the `callback` option


### PR DESCRIPTION
With no offense to style-check's author, the homepage seems to point to a fairly old-style. Users are left wondering if `style-check.rb` is an ancient hand-written (and never updated) ruby script, which might seem anachronous in this day and age of community-driven open-source development.

However, Lo and Behold, style-check.rb indeed has a Github page, and the author seems to be actively accepting patches through pull-requests (the last one being this February). So, by replacing the dated URL page with a link to the repo, VimTeX user's can know  a bit more about the commit history of the project, and inspect the source code diffs etc.

The Github's README page is quite comprehensive explaining the various facets of the program, and therefore this is a loss-less conversion.