### PR TITLE
Allow optional group and more than one mandatory argument in nospell commands

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -287,7 +287,7 @@ function! vimtex#syntax#core#init() abort " {{{1
     execute 'syntax match texCmdNoSpell nextgroup=texNoSpellOpt,texNoSpellArg skipwhite skipnl "\\' . l:macro . '"'
   endfor
   call vimtex#syntax#core#new_opt('texNoSpellOpt', {'next': 'texNoSpellArg'})
-  call vimtex#syntax#core#new_arg('texNoSpellArg', {'contains': 'TOP,@Spell'})
+  call vimtex#syntax#core#new_arg('texNoSpellArg', {'next': 'texNoSpellArg', 'contains': 'TOP,@Spell'})
 
   " \begin \end environments
   syntax match texCmdEnv "\v\\%(begin|end)>" nextgroup=texEnvArgName

--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -284,8 +284,9 @@ function! vimtex#syntax#core#init() abort " {{{1
 
   " Add @NoSpell for commands per configuration (TOP,@Spell implies NoSpell!)
   for l:macro in g:vimtex_syntax_nospell_commands
-    execute 'syntax match texCmdNoSpell nextgroup=texNoSpellArg skipwhite skipnl "\\' . l:macro . '"'
+    execute 'syntax match texCmdNoSpell nextgroup=texNoSpellOpt,texNoSpellArg skipwhite skipnl "\\' . l:macro . '"'
   endfor
+  call vimtex#syntax#core#new_opt('texNoSpellOpt', {'next': 'texNoSpellArg'})
   call vimtex#syntax#core#new_arg('texNoSpellArg', {'contains': 'TOP,@Spell'})
 
   " \begin \end environments
@@ -758,6 +759,7 @@ function! vimtex#syntax#core#init_highlights() abort " {{{1
   highlight def link texNewthmArgName      texArg
   highlight def link texNewthmOptCounter   texOpt
   highlight def link texNewthmOptNumberby  texOpt
+  highlight def link texNoSpellOpt         texOpt
   highlight def link texOptEqual           texSymbol
   highlight def link texParboxOptHeight    texError
   highlight def link texParboxOptIPos      texError


### PR DESCRIPTION
When a command is in `g:vimtex_syntax_nospell_commands`, its argument is excluded from spell checking; after the first patch this also works for commands with an optional argument.

After the second patch, a command in `g:vimtex_syntax_nospell_commands` can have more than one mandatory argument; spell check is disabled for all of them.

I use this for custom commands with optional arguments; also for some standard commands like `\numberwithin` (2 mandatory arguments).