### PR TITLE
use vimtex#util#trim() instead of trim() for Vim versions < 8.1

### DIFF
--- a/autoload/vimtex/fold/bib.vim
+++ b/autoload/vimtex/fold/bib.vim
@@ -21,7 +21,7 @@ endfunction
 
 function! vimtex#fold#bib#level(lnum) abort " {{{1
   " Handle blank lines
-  if empty(trim(getline(a:lnum)))
+  if empty(vimtex#util#trim(getline(a:lnum)))
     if a:lnum == 1 | return 0 | endif
 
     let l:prev_level = vimtex#fold#bib#level(a:lnum - 1)

--- a/autoload/vimtex/parser/bib.vim
+++ b/autoload/vimtex/parser/bib.vim
@@ -31,7 +31,7 @@ function! vimtex#parser#bib#parse_cheap(start_line, end_line, opts) abort " {{{1
   let l:entries = []
   let l:firstlines = filter(
         \ range(a:start_line, a:end_line),
-        \ {_, i -> trim(getline(i))[0] == "@"})
+        \ {_, i -> vimtex#util#trim(getline(i))[0] == "@"})
   let l:total_entries = len(l:firstlines)
   let l:entry_lines = map(l:firstlines, {idx, val -> [val,
         \ idx == l:total_entries - 1


### PR DESCRIPTION
The two occurrences of trim() in

  https://github.com/lervag/vimtex/blob/1782e479a0c6a716af3a92d5ed85b65ecfad3dc0/autoload/vimtex/parser/bib.vim#L34

and

  https://github.com/lervag/vimtex/blob/3807da1c530e46fb6a633a2268f6e435b16b657b/autoload/vimtex/fold/bib.vim#L24

are replaced by

  https://github.com/lervag/vimtex/blob/6228f72a8bcf25b31bf1a966de864349ed4ea61c/autoload/vimtex/util.vim#L192

for Vim versions < 8.1.

This creates dependencies outside of the bib file, but they have been there before anyway.