### PR TITLE
Allow braces in column specification for array env

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -570,7 +570,9 @@ function! vimtex#syntax#core#init() abort " {{{1
   " Support for array environment
   syntax match texMathCmdEnv contained contains=texCmdMathEnv "\\begin{array}" nextgroup=texMathArrayArg skipwhite skipnl
   syntax match texMathCmdEnv contained contains=texCmdMathEnv "\\end{array}"
-  call vimtex#syntax#core#new_arg('texMathArrayArg', {'contains': ''})
+  call vimtex#syntax#core#new_arg('texMathArrayArg', {
+        \ 'contains': '@texClusterTabular'
+        \})
 
   call s:match_math_sub_super()
   call s:match_math_delims()

--- a/test/test-syntax/test-array.tex
+++ b/test/test-syntax/test-array.tex
@@ -26,4 +26,12 @@
   \hline
 \end{tabular}
 
+\[
+\begin{array}{l*{4}{m{1cm}}}
+  \hline
+  \text{Hello world !}\tabularnewline
+  \hline
+\end{array}
+\]
+
 \end{document}

--- a/test/test-syntax/test-array.vim
+++ b/test/test-syntax/test-array.vim
@@ -5,6 +5,8 @@ silent edit test-array.tex
 if empty($INMAKE) | finish | endif
 
 call assert_true(vimtex#syntax#in('texTabularCol', 10, 17))
+call assert_true(vimtex#syntax#in('texTabularCol', 16, 18))
 call assert_true(vimtex#syntax#in('texTabularMathdelim', 10, 24))
+call assert_true(vimtex#syntax#in('texTabularCol', 30, 16))
 
 call vimtex#test#finished()


### PR DESCRIPTION
The `array` environment supports (most of) the same column specifications as the `tabular` environment does; update the syntax highlighting to reflect this fact and avoid a `texGroupError` when using braces in the column specification.

Screenshots from a [file](https://gist.github.com/psvenk/0fd74b6e271df9916e21f763f4fc1c8c) that I threw together (with `:colo default`):

| Before | After |
| --- | --- |
| ![screenshot-2021-07-29-20-19-36](https://user-images.githubusercontent.com/45520974/127582724-15aaeeeb-2979-44fa-9f42-ab915ccd4d01.png) | ![screenshot-2021-07-29-20-24-18](https://user-images.githubusercontent.com/45520974/127582728-775cf4c4-2f87-439f-a36c-10b50feec880.png) |

I also updated `test/test-syntax/test-array.tex` and `test/test-syntax/test-array.vim` with a test case for this, along with an analogous test case for `tabular` to the `.vim` file because that was not already tested.