### PR TITLE
prepend backslashes to `=word`s in 'indentkeys'

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -20,12 +20,12 @@ set cpoptions&vim
 
 setlocal autoindent
 setlocal indentexpr=VimtexIndentExpr()
-setlocal indentkeys=!^F,o,O,(,),],},\&,=item,=else,=fi
+setlocal indentkeys=!^F,o,O,(,),],},\&,=\\item,=\\else,=\\fi
 
 " Add standard closing math delimiters to indentkeys
 for s:delim in [
       \ 'rangle', 'rbrace', 'rvert', 'rVert', 'rfloor', 'rceil', 'urcorner']
-  let &l:indentkeys .= ',=' . s:delim
+  let &l:indentkeys .= ',=\' . s:delim
 endfor
 
 


### PR DESCRIPTION
Currently, inserting tex keywords `item`, `else`, `fi`, and tex delimiters autoindents the current line. 
However, there are some words that are part of these keywords. (For example, 'fix', 'figure', are part of 'fi'.) 
In these cases, it would be better _not_ to autoindent the current line.

Adding a backslash to these keywords and tex delimiters will reduce the number of unexpected autoindents (autoindent only on `\item`, `\else`, `\fi`, etc.)