### PR TITLE
Changes to SyncTeX backward search

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -378,6 +378,7 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_view_method', 'general')
   call s:init_option('vimtex_view_use_temp_files', 0)
   call s:init_option('vimtex_view_forward_search_on_start', 1)
+  call s:init_option('vimtex_view_reverse_search_edit_cmd', 'edit')
 
   " OS dependent defaults
   let l:os = vimtex#util#get_os()

--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -72,10 +72,10 @@ function! vimtex#view#reverse_goto(line, filename) abort " {{{1
   let l:file = resolve(a:filename)
 
   " Open file if necessary
-  if !bufexists(l:file)
+  if !bufloaded(l:file)
     if filereadable(l:file)
       try
-        execute 'edit' l:file
+        execute g:vimtex_view_reverse_search_edit_cmd l:file
       catch
         call vimtex#log#warning("Reverse goto failed")
         return
@@ -97,7 +97,7 @@ function! vimtex#view#reverse_goto(line, filename) abort " {{{1
     execute l:tabnr . 'tabnext'
     execute l:winnr . 'wincmd w'
   catch
-    execute 'edit' l:file
+    execute g:vimtex_view_reverse_search_edit_cmd l:file
   endtry
 
   execute 'normal!' a:line . 'G'

--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -87,11 +87,18 @@ function! vimtex#view#reverse_goto(line, filename) abort " {{{1
   endif
 
   " Go to correct buffer and line
+
+  " Get buffer number
   let l:bufnr = bufnr(l:file)
-  let l:winnr = bufwinnr(l:file)
-  execute l:winnr >= 0
-        \ ? l:winnr . 'wincmd w'
-        \ : 'buffer ' . l:bufnr
+  " Get window and tab numbers
+  try
+    let [l:winid] = win_findbuf(l:bufnr)
+    let [l:tabnr, l:winnr] = win_id2tabwin(l:winid)
+    execute l:tabnr . 'tabnext'
+    execute l:winnr . 'wincmd w'
+  catch
+    execute 'edit' l:file
+  endtry
 
   execute 'normal!' a:line . 'G'
   redraw

--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -80,7 +80,7 @@ function! s:zathura.latexmk_append_argument() dict abort " {{{1
     if self.has_synctex
       let zathura .= ' -x \"' . g:vimtex_compiler_progname
           \ . ' --servername ' . v:servername
-          \ . ' --remote +\%{line} \%{input}\" \%S'
+          \ . ' --remote-expr \"\\\"\"vimtex#view#reverse_goto(\%{line}, ''"''"''\%{input}''"''"'')\"\\\"\"\" \%S'
     endif
 
     let cmd  = vimtex#compiler#latexmk#wrap_option('new_viewer_always', '0')

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2743,6 +2743,18 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: 1
 
+*g:vimtex_view_reverse_search_edit_cmd*
+  When working in a multi-file project, initiating backward search
+  |vimtex-synctex-backward-search| may require opening a file that is not
+  currently open in a window. This option controls the command that is used to
+  open files as a result of a backward search.
+
+  Examples: `edit` (open buffer in current window); `tabedit` (open buffer in
+  new tab page, similar to the Vim command-line option `--remote-tab`);
+  `split` (split current window to open buffer, similar to `--remote`)
+
+  Default value: `edit`
+
 *g:vimtex_view_method*
   Set the viewer method.
 


### PR DESCRIPTION
Fixes #2127. This pull requests addresses three closely related issues related to SyncTeX backward search in multi-file projects, the last of which is the one originally brought up in #2127:
- The `latexmk` command line, invoked upon `<LocalLeader>ll`, opens Zathura with `--remote` for backward search, while running `<LocalLeader>lv` opens Zathura with `--remote-expr` for backward search. This can lead to inconsistent behavior; 2139057fe4 fixes this by properly escaping all arguments in the `latexmk` command line in order to use `--remote-expr`.
- Backward search does not properly take into account the possibility that a file is open in another buffer, but not in the current tab page. This was fixed in 9af661097f.
- The function `vimtex#view#reverse_goto`, which is called upon backward search, is hard-coded to use `edit` to open a new file, usurping the current window; b003fee92d makes this configurable and uses `bufloaded` instead of `bufexists` to avoid falling back to usurpation when a buffer exists but is not visible (e.g., if it were opened in another tab page and then closed, we want to reopen it in a tab page — if this is the user's preference — and not always try to usurp the current window to load that buffer).