### PR TITLE
More conservative filetype detection for .cls file

### DIFF
--- a/ftdetect/cls.vim
+++ b/ftdetect/cls.vim
@@ -6,4 +6,7 @@
 
 if !get(g:, 'vimtex_enabled', 1) | finish | endif
 
-autocmd BufRead,BufNewFile *.cls set filetype=tex
+autocmd BufNewFile,BufRead *.cls
+	\ if getline(1) =~ '^%' |
+	\  set filetype=tex |
+	\ endif


### PR DESCRIPTION
The filetype detection for tex files with extension cls is more restrictive in the vim repository https://github.com/vim/vim/blob/master/runtime/filetype.vim.
This change mimics this logic.