### PR TITLE
indentkeys autoindent only at the start of line

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -25,7 +25,7 @@ setlocal indentkeys=!^F,o,O,0(,0),0],0},\&,0=\\item,0=\\else,0=\\fi
 " Add standard closing math delimiters to indentkeys
 for s:delim in [
       \ 'rangle', 'rbrace', 'rvert', 'rVert', 'rfloor', 'rceil', 'urcorner']
-  let &l:indentkeys .= ',=\' . s:delim
+  let &l:indentkeys .= ',0=\' . s:delim
 endfor
 
 


### PR DESCRIPTION
This PR prefixes the 'indentkeys' `(,),],},\item,\else,\fi` with a `0`. 
The effect is that these indent keys only autoindent the line when they are typed at the start of the line (see `:h i_CTRL-F`).
ie. no autoindenting when typing a closing `),],}` mid-way through a statement.

(The assumption here is that one would *not* want an autoindent when, say, is in the midst of a long equation,
but only to autoindent when closing an existing block).