### PR TITLE
Added lhd (◁) and rhd (▷) to conceal symbols

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -1351,6 +1351,8 @@ let s:cmd_symbols = [
       \ ['leftharpoonup', '↼'],
       \ ['leftrightarrow', '↔'],
       \ ['Leftrightarrow', '⇔'],
+      \ ['lhd', '◁'],
+      \ ['rhd', '▷'],
       \ ['leq', '≤'],
       \ ['ll', '≪'],
       \ ['lmoustache', '╭'],


### PR DESCRIPTION
Added conceal symbols for `\lhd` (◁) and `\rhd` (▷).

thanks for all the great work!