### PR TITLE
fix: use unicode character for `\times` conceal

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -1421,7 +1421,7 @@ let s:cmd_symbols = [
       \ ['supseteq', '⊇'],
       \ ['surd', '√'],
       \ ['swarrow', '↙'],
-      \ ['times', 'x'],
+      \ ['times', '×'],
       \ ['to', '→'],
       \ ['top', '⊤'],
       \ ['triangle', '∆'],


### PR DESCRIPTION
Concealing `\times` with a letter `x` can make expressions like
`x \times x` awkward to read.