### PR TITLE
biblatex syntax:  support for concealment of additional biblatex commands

### DIFF
--- a/autoload/vimtex/syntax/p/biblatex.vim
+++ b/autoload/vimtex/syntax/p/biblatex.vim
@@ -39,21 +39,20 @@ function! vimtex#syntax#p#biblatex#load(cfg) abort " {{{1
 
   if g:vimtex_syntax_conceal.cites
     let s:re_concealed_cites = '\v\\%(' . join([
-			    \ '%([Tt]ext|[Ss]mart|[Aa]uto)cite[s]?',
-			    \ '(foot)?cite[tp]?',
-			    \ '[Aa]utocite[s]?',
-			    \ 'bibentry',
-			    \ '[Cc]ite%(title|author|year%(par)?|date)[s]?',
-			    \ '[Pp]arencite[s]?',
-			    \ '[Ppf]?[Nn]otecite',
-			    \ '[pPfFsStTaA]?[Vv]olcite[s]?',
-			    \ '[Ss]upercite[s]?',
-			    \ 'cite%(num|text|url|field|list|name)',
-			    \ 'citeal[tp]',
-			    \ 'foot%(full)?cite%(text)?',
-			    \ 'footcite%(s|texts)',
-			    \ 'fullcite[s]?',
-			    \ ], '|') . ')>\*?'
+          \ '%([Tt]ext|[Ss]mart|[Aa]uto)cite[s]?',
+          \ '(foot)?cite[tp]?',
+          \ '[Aa]utocite[s]?',
+          \ '[Cc]ite%(title|author|year%(par)?|date)[s]?',
+          \ '[Pp]arencite[s]?',
+          \ '[Ppf]?[Nn]otecite',
+          \ '[pPfFsStTaA]?[Vv]olcite[s]?',
+          \ '[Ss]upercite[s]?',
+          \ 'cite%(num|text|url|field|list|name)',
+          \ 'citeal[tp]',
+          \ 'foot%(full)?cite%(text)?',
+          \ 'footcite%(s|texts)',
+          \ 'fullcite[s]?',
+          \ ], '|') . ')>\*?'
     call s:match_conceal_cites_{g:vimtex_syntax_conceal_cites.type}()
   endif
 endfunction

--- a/autoload/vimtex/syntax/p/biblatex.vim
+++ b/autoload/vimtex/syntax/p/biblatex.vim
@@ -39,9 +39,21 @@ function! vimtex#syntax#p#biblatex#load(cfg) abort " {{{1
 
   if g:vimtex_syntax_conceal.cites
     let s:re_concealed_cites = '\v\\%(' . join([
-          \ '(foot)?cite[tp]?',
-          \ '%([Tt]ext|[Ss]mart|[Aa]uto)cite',
-          \ ], '|') . ')>\*?'
+			    \ '%([Tt]ext|[Ss]mart|[Aa]uto)cite[s]?',
+			    \ '(foot)?cite[tp]?',
+			    \ '[Aa]utocite[s]?',
+			    \ 'bibentry',
+			    \ '[Cc]ite%(title|author|year%(par)?|date)[s]?',
+			    \ '[Pp]arencite[s]?',
+			    \ '[Ppf]?[Nn]otecite',
+			    \ '[pPfFsStTaA]?[Vv]olcite[s]?',
+			    \ '[Ss]upercite[s]?',
+			    \ 'cite%(num|text|url|field|list|name)',
+			    \ 'citeal[tp]',
+			    \ 'foot%(full)?cite%(text)?',
+			    \ 'footcite%(s|texts)',
+			    \ 'fullcite[s]?',
+			    \ ], '|') . ')>\*?'
     call s:match_conceal_cites_{g:vimtex_syntax_conceal_cites.type}()
   endif
 endfunction


### PR DESCRIPTION
Adds support for concealment of additional biblatex commands.

(Additions to the test biblatex.tex file weren't require as the citation commands were already there. Previous to the changes suggested in this PR, several commands were not concealed. With it, all are.)