### PR TITLE
doc: fix the example for latexmk config

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -4714,9 +4714,9 @@ after compilation. This is used by VimTeX to achieve callbacks after
 compilation has finished through |vimtex#compiler#callback| with something
 like this: >
 
-  $compiling_cmd = "vim --remote-expr 'vimtex#compiler#callback(2)'";
-  $success_cmd = "vim --remote-expr 'vimtex#compiler#callback(1)'";
-  $failure_cmd = "vim --remote-expr 'vimtex#compiler#callback(0)'";
+  $compiling_cmd = "vim --remote-expr 'vimtex#compiler#callback(1)'";
+  $success_cmd = "vim --remote-expr 'vimtex#compiler#callback(2)'";
+  $failure_cmd = "vim --remote-expr 'vimtex#compiler#callback(3)'";
 
 Another neat way to use this is to use `xdotool` to change the window title of
 the viewer to indicate the compilation status: >


### PR DESCRIPTION
This example is [outdated](https://github.com/lervag/vimtex/blob/178e58a9d65f4e8cd0e646f0b1def0923e24c6f5/autoload/vimtex/compiler.vim#L45-L47) (and misleading!)