### PR TITLE
fix: add label env to texMathText

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -527,6 +527,7 @@ function! vimtex#syntax#core#init() abort " {{{1
         \ 'text%(normal|rm|up|tt|sf|sc)?',
         \ 'intertext',
         \ '[mf]box',
+        \ 'label',
         \]
     execute 'syntax match texMathCmdText'
           \ '"\v\\' . l:re_cmd . '>"'

--- a/test/test-syntax/test-core.tex
+++ b/test/test-syntax/test-core.tex
@@ -115,6 +115,14 @@ Line with $inline math$ here.\footnote{here {asd} with \cmd also}.
   Lorem ipsum \dots
 \end{theorem}
 
+\begin{equation}
+    e^{2 \pi i} = 1
+    \text{foo}
+    \intertext{bar}
+    \mbox{foo}
+    \label{bar}
+\end{equation}
+
 \begin{thebibliography}{1}
   \bibitem{abc} a citation.
   \bibitem[label]{abc} a citation.

--- a/test/test-syntax/test-core.vim
+++ b/test/test-syntax/test-core.vim
@@ -14,8 +14,14 @@ call assert_true(vimtex#syntax#in('texDelim', 64, 39))
 call assert_true(vimtex#syntax#in('texNewthmArgPrinted', 38, 23))
 " call assert_true(vimtex#syntax#in('texTheoremEnvOpt', 114, 18))
 
-call assert_true(vimtex#syntax#in('texCmdBibitem', 119, 3))
-call assert_true(vimtex#syntax#in('texBibitemArg', 119, 13))
-call assert_true(vimtex#syntax#in('texBibitemOpt', 120, 13))
+call assert_true(vimtex#syntax#in('texMathZone', 119, 12))
+call assert_true(vimtex#syntax#in('texMathText', 120, 12))
+call assert_true(vimtex#syntax#in('texMathText', 121, 16))
+call assert_true(vimtex#syntax#in('texMathText', 122, 12))
+call assert_true(vimtex#syntax#in('texMathText', 123, 12))
+
+call assert_true(vimtex#syntax#in('texCmdBibitem', 127, 3))
+call assert_true(vimtex#syntax#in('texBibitemArg', 127, 13))
+call assert_true(vimtex#syntax#in('texBibitemOpt', 128, 13))
 
 call vimtex#test#finished()


### PR DESCRIPTION
Added `\label{}` environment to text-inside-math detection, along with a few tests.