### PR TITLE
add option to control whether Skim gets focus upon first open

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -426,6 +426,7 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_view_mupdf_send_keys', '')
   call s:init_option('vimtex_view_sioyek_exe', 'sioyek')
   call s:init_option('vimtex_view_skim_activate', 0)
+  call s:init_option('vimtex_view_skim_activate_on_start', 1)
   call s:init_option('vimtex_view_skim_reading_bar', 1)
   call s:init_option('vimtex_view_zathura_options', '')
   call s:init_option('vimtex_view_zathura_check_libsynctex', 1)

--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -426,7 +426,7 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_view_mupdf_send_keys', '')
   call s:init_option('vimtex_view_sioyek_exe', 'sioyek')
   call s:init_option('vimtex_view_skim_activate', 0)
-  call s:init_option('vimtex_view_skim_activate_on_start', 1)
+  call s:init_option('vimtex_view_skim_latexmk_previewer', 'open -a Skim')
   call s:init_option('vimtex_view_skim_reading_bar', 1)
   call s:init_option('vimtex_view_zathura_options', '')
   call s:init_option('vimtex_view_zathura_check_libsynctex', 1)

--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -13,7 +13,6 @@ endfunction
 
 let s:viewer = vimtex#view#_template#new({
       \ 'name' : 'Skim',
-      \ 'startskim' : 'open -a Skim' . (g:vimtex_view_skim_activate_on_start ? '' : ' -g'),
       \})
 
 function! s:viewer.compiler_callback(outfile) dict abort " {{{1
@@ -74,7 +73,7 @@ endfunction
 
 " }}}1
 function! s:viewer._latexmk_append_argument() dict abort " {{{1
-  return vimtex#compiler#latexmk#wrap_option('pdf_previewer', self.startskim)
+  return vimtex#compiler#latexmk#wrap_option('pdf_previewer', g:vimtex_view_skim_latexmk_previewer)
 endfunction
 
 " }}}1

--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -13,7 +13,7 @@ endfunction
 
 let s:viewer = vimtex#view#_template#new({
       \ 'name' : 'Skim',
-      \ 'startskim' : 'open -a Skim',
+      \ 'startskim' : 'open -a Skim' . (g:vimtex_view_skim_activate_on_start ? '' : ' -g'),
       \})
 
 function! s:viewer.compiler_callback(outfile) dict abort " {{{1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2927,11 +2927,15 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: 0
 
-*g:vimtex_view_skim_activate_on_start*
-  Set this option to 1 to make Skim have focus and be moved to the foreground
-  after it is first opened (usually via |:VimtexCompile| or similar).
+*g:vimtex_view_skim_latexmk_previewer*
+  Command passed to `latexmk` to be used as the PDF previewer (i.e. the
+  `$pdf_previewer` variable for `latexmk`). This defaults to `'open -a Skim'`,
+  which means that `latexmk` will open Skim and give it focus after
+  successfully producing a PDF. If the focusing is unwanted, this can be
+  set to `'open -a Skim -g'`, which will open Skim but leave it in the
+  background.
 
-  Default value: 1
+  Default value: `'open -a Skim'`
 
 *g:vimtex_view_skim_reading_bar*
   Set this option to 1 to highlight current line in PDF after command

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2927,6 +2927,12 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: 0
 
+*g:vimtex_view_skim_activate_on_start*
+  Set this option to 1 to make Skim have focus and be moved to the foreground
+  after it is first opened (usually via |:VimtexCompile| or similar).
+
+  Default value: 1
+
 *g:vimtex_view_skim_reading_bar*
   Set this option to 1 to highlight current line in PDF after command
   |:VimtexView|.

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -5208,6 +5208,7 @@ the text you want to search.
 
 Associated settings:
 * |g:vimtex_view_skim_activate|
+* |g:vimtex_view_skim_activate_on_start|
 * |g:vimtex_view_skim_reading_bar|
 
                                                        *vimtex-view-sumatrapdf*


### PR DESCRIPTION
Just a tiny PR which introduces an option `g:vimtex_view_skim_activate_on_start`, to control whether Skim is brought to the foreground when it's first opened (using `\ll` or `\lv`). The default value is kept to `1` to match the current behaviour, i.e. bring to foreground. Seems to work nicely on my Mac (Monterey 12.0 here).

(Somewhat related to #180; but rather less general, because it's only Skim and hence only macOS.)