### PR TITLE
refactor skim viewer

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -426,7 +426,8 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_view_mupdf_send_keys', '')
   call s:init_option('vimtex_view_sioyek_exe', 'sioyek')
   call s:init_option('vimtex_view_skim_activate', 0)
-  call s:init_option('vimtex_view_skim_reading_bar', 1)
+  call s:init_option('vimtex_view_skim_sync', 0)
+  call s:init_option('vimtex_view_skim_reading_bar', 0)
   call s:init_option('vimtex_view_zathura_options', '')
   call s:init_option('vimtex_view_zathura_check_libsynctex', 1)
 

--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -4,42 +4,59 @@
 " Email:      karl.yngve@gmail.com
 "
 
+let s:viewer = vimtex#view#_template#new({ 'name' : 'Skim' })
+
 function! vimtex#view#skim#new() abort " {{{1
   return s:viewer.init()
 endfunction
 
 " }}}1
 
+function! s:make_cmd_view(outfile, sync) abort " {{{1
+  let cmd_view = join([ 'osascript -l JavaScript -e ''',
+        \ 'var app = Application("Skim");',
+        \ 'var theFile = Path("' . a:outfile . '");',
+        \ 'try { var theDocs = app.documents.whose({ file: { _equals: theFile }});',
+        \ 'if (theDocs.length > 0) app.revert(theDocs) }',
+        \ 'catch (e) {};',
+        \ 'app.open(theFile);' ])
+  if a:sync
+    let cmd_view .= join([
+          \ 'app.documents[0].go({ to: app.texLines[' . (line('.')-1) . '],',
+          \ 'from: Path("'. expand('%:p') . '")',
+          \ (g:vimtex_view_skim_reading_bar ? ', showingReadingBar: true' : ''),
+          \ '});' ])
+  endif
+  if g:vimtex_view_skim_activate
+    let cmd_view .= 'app.activate();'
+  endif
+  return cmd_view . ''''
+endfunction
 
-let s:viewer = vimtex#view#_template#new({
-      \ 'name' : 'Skim',
-      \ 'startskim' : 'open -a Skim',
-      \})
+" }}}1
 
 function! s:viewer.compiler_callback(outfile) dict abort " {{{1
-  let self.cmd_view_callback = join([
-        \ 'osascript',
-        \ '-e ''set theFile to POSIX file "' . a:outfile . '"''',
-        \ '-e ''set thePath to POSIX path of (theFile as alias)''',
-        \ '-e ''tell application "Skim"''',
-        \ '-e ''try''',
-        \ '-e ''set theDocs to get documents whose path is thePath''',
-        \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
-        \ '-e ''end try''',
-        \ '-e ''open theFile''',
-        \ '-e ''end tell''',
-        \])
+  call vimtex#jobs#run(s:make_cmd_view(a:outfile, g:vimtex_view_skim_sync))
+endfunction
 
-  call vimtex#jobs#run(self.cmd_view_callback)
+" }}}1
+
+function! s:viewer._start(outfile) dict abort " {{{1
+  call vimtex#jobs#run(s:make_cmd_view(a:outfile, 1))
+endfunction
+
+" }}}1
+
+function! s:viewer._latexmk_append_argument() dict abort " {{{1
+  return vimtex#compiler#latexmk#wrap_option('pdf_previewer',
+        \ 'open -a Skim' . g:vimtex_view_skim_activate ? ' -g' : '')
 endfunction
 
 " }}}1
 
 function! s:viewer._check() dict abort " {{{1
-  " Check if Skim is installed
   let l:output = vimtex#jobs#capture(
-        \ 'osascript -e '
-        \ . '''tell application "Finder" to get id of application "Skim"''')
+        \ 'osascript -l JavaScript -e ''Application("Skim").id()''')
 
   if l:output[0] !~# '^net.sourceforge.skim-app'
     call vimtex#log#error('Skim is not installed!')
@@ -47,34 +64,6 @@ function! s:viewer._check() dict abort " {{{1
   endif
 
   return v:true
-endfunction
-
-" }}}1
-function! s:viewer._start(outfile) dict abort " {{{1
-  let self.cmd_view = join([
-        \ 'osascript',
-        \ '-e ''set theLine to ' . line('.') . ' as integer''',
-        \ '-e ''set theFile to POSIX file "' . a:outfile . '"''',
-        \ '-e ''set thePath to POSIX path of (theFile as alias)''',
-        \ '-e ''set theSource to POSIX file "' . expand('%:p') . '"''',
-        \ '-e ''tell application "Skim"''',
-        \ '-e ''try''',
-        \ '-e ''set theDocs to get documents whose path is thePath''',
-        \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
-        \ '-e ''end try''',
-        \ '-e ''open theFile''',
-        \ '-e ''tell front document to go to TeX line theLine from theSource',
-        \ g:vimtex_view_skim_reading_bar ? 'showing reading bar true''' : '''',
-        \ g:vimtex_view_skim_activate ? '-e ''activate''' : '',
-        \ '-e ''end tell''',
-        \])
-
-  call vimtex#jobs#run(self.cmd_view)
-endfunction
-
-" }}}1
-function! s:viewer._latexmk_append_argument() dict abort " {{{1
-  return vimtex#compiler#latexmk#wrap_option('pdf_previewer', self.startskim)
 endfunction
 
 " }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2927,11 +2927,17 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: 0
 
+*g:vimtex_view_skim_sync*
+  Set this option to 1 to make Skim perform a forward search after successful
+  compilation.
+
+  Default value: 0
+
 *g:vimtex_view_skim_reading_bar*
   Set this option to 1 to highlight current line in PDF after command
-  |:VimtexView|.
+  |:VimtexView| or compiler callback.
 
-  Default value: 1
+  Default value: 0
 
 *g:vimtex_view_zathura_check_libsynctex*
   Check on startup if Zathura is compiled with libsynctex. This is done by


### PR DESCRIPTION
Refactor the Skim viewer backend to
* use JavaScript instead of AppleScript (nicer, and should fix #2279)
* make the initial start respect `g:vimtex_view_skim_activate`  (alternative to #2286, @yongrenjie )
* factor out common script parts into script function
* correct off-by-one line number for forward search
* introduce new option `g:vimtex_view_skim_sync` to perform forward  search after compilation (syncing viewer and editor), default false
* change default for `g:vimtex_view_skim_reading_bar` to false (location is highlighted anyway on sync)