### PR TITLE
Rewrite vimtex_syntax_conceal_disable doc

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2234,9 +2234,10 @@ OPTIONS                                                        *vimtex-options*
           \}
 
 *g:vimtex_syntax_conceal_disable*
-  The option |g:vimtex_syntax_conceal| allows to selectively disable conceal
-  features. For convenience, this option allows to disable all conceal
-  features in one go. For more info, see |vimtex-syntax-conceal|.
+  The option |g:vimtex_syntax_conceal| allows selectively disabling conceal
+  features. To disable all conceal features at once, set the option
+  |g:vimtex_syntax_conceal_disable| to 1 (or any nonzero value). For more
+  info, see |vimtex-syntax-conceal|.
 
   Default value: 0
 


### PR DESCRIPTION
When reading the documentation before, I was initially confused. It used
to refer to the option g:vimtex_syntax_conceal, and the following
sentence referred to *this option*. I had parsed that to mean
*g:vimtex_syntax_conceal* instead of *g:vimtex_syntax_conceal_disable*.

This commit rewords this part of the documentation.

As always, thank you for this wonderful plugin!