### PR TITLE
Add possible use of SVED to docs for evince

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -5078,12 +5078,13 @@ PDFs. It comes by default with Gnome.
 Configuration: >
   let g:vimtex_view_general_viewer = 'evince'
 
-Note: It is not so easy to setup forward and inverse search with Evince [0].
-      If anyone has a good setup that could be documented here, please open an
-      issue or email me. In the meantime, I can recommend to look into the
-      other alternative viewers.
 
-      [0]: https://github.com/lervag/vimtex/issues/179
+Note: VimTeX does not include everything necessary to setup forward and
+      inverse search for Evince. It is possible to use other plugins to add
+      this functionality in, such as `SVED` by Peter Jorgensen. See the plugin
+      page for `SVED` for more [0].
+
+      [0]: https://github.com/peterbjorgensen/sved
 
                                                             *vimtex-view-mupdf*
 MuPDF~


### PR DESCRIPTION
As mentioned in #179, it is possible to combine the plugin `sved` (https://github.com/peterbjorgensen/sved) with vimtex to allow forward and inverse search for evince. This small commit adds a note to this plugin in the documentation for evince.

I was reminded of this by coincidence today, when someone else wrote a comment on #179 about how sved worked for them too. I am happy to change anything about this pull request.