### PR TITLE
Improve highlight of commented code

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -436,6 +436,25 @@ function! vimtex#syntax#core#init() abort " {{{1
   syntax region texComment matchgroup=texCmd
         \ start="^\s*\\iffalse\>" end="\\\(fi\|else\)\>"
         \ contains=texCommentConditionals
+
+  syntax cluster texIftrueCluster contains=TOP
+  syntax cluster texIftrueClusterCommon contains=@texIftrueCluster,texIftrueConditionals
+
+  syntax region texIftrue matchgroup=texCmd
+        \ start="^\s*\\iftrue\>"  end="\(\\\(fi\|else\)\>\)\@="
+        \ transparent contains=@texIftrueClusterCommon
+        \ nextgroup=texIftrueElseComment
+
+  syntax region texIftrueElseComment matchgroup=texCmd
+        \ start="\(\(\\fi\>\)@=\|\\else\>\)"  end="\\fi\>"
+        \ contained contains=texCommentConditionals
+
+  highlight def link texIftrueElseComment texComment
+
+  syntax region texIftrueConditionals matchgroup=texCmd
+        \ start="\\if\w\+" end="\\fi\>"
+        \ contained contains=@texIftrueClusterCommon
+
   syntax region texCommentConditionals matchgroup=texComment
         \ start="\\if\w\+" end="\\fi\>"
         \ contained transparent

--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -434,7 +434,7 @@ function! vimtex#syntax#core#init() abort " {{{1
 
   " Highlight \iffalse ... \fi blocks as comments
   syntax region texComment matchgroup=texCmd
-        \ start="^\s*\\iffalse\>" end="\\fi\>"
+        \ start="^\s*\\iffalse\>" end="\\\(fi\|else\)\>"
         \ contains=texCommentConditionals
   syntax region texCommentConditionals matchgroup=texComment
         \ start="\\if\w\+" end="\\fi\>"

--- a/test/test-syntax/test-iffalse.tex
+++ b/test/test-syntax/test-iffalse.tex
@@ -11,8 +11,21 @@
 \iffalse
 Commented stuff
 Another \ifstuff here \fi
+\ifaa \else \fi
 \ifasd \fi \f \fii
 
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+\fi
+
+\iffalse
+Commented stuff
+Another \ifstuff here \fi
+\ifaa \else \fi
+\ifasd \fi \f \fii
+\else
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
 tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
 vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd

--- a/test/test-syntax/test-iftrue.tex
+++ b/test/test-syntax/test-iftrue.tex
@@ -1,0 +1,38 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{graphicx}
+
+\begin{document}
+
+\iftrue
+\section{asd}
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+\ifasd \fi
+\ifaa asd \else asd \fi
+\fi
+
+\section{qwe}
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+\iftrue
+\section{asd}
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+\ifasd \fi
+\ifaa asd \else asd \fi
+\else
+Commented stuff
+Another \ifstuff here \fi
+\ifaa \else \fi
+\ifasd \fi \f \fii
+\fi
+
+\end{document}


### PR DESCRIPTION
First commit is a simple fix for `\iffalse <commented-code>[\else <not-commented-code>]\fi ` command.
In the second commit i tried to add highlights for `\iftrue <not-commented-code> [\else <commented code>]\fi ` command.
I've never used vim syntax before, so i'm not sure if this is the correct way to implement \iftrue.

I must admit that this pr is not very useful. But it allows you, for example, a quick switch draft mode by simply replacing `\iftrue` with `\iffalse` etc.
![2022-02-01-210318_547x116_scrot](https://user-images.githubusercontent.com/16379308/152034415-c9c597a1-f679-4d25-a90a-3a6839ea1f57.png)
![2022-02-01-210334_559x122_scrot](https://user-images.githubusercontent.com/16379308/152034418-0cec451e-a2a7-4eab-82e5-69506107df63.png)
