### PR TITLE
Update core.vim

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -1492,6 +1492,7 @@ let s:cmd_symbols = [
       \ ['implies', '⇒'],
       \ ['choose', 'C'],
       \ ['sqrt', '√'],
+      \ ['colon', ':'],
       \ ['coloneqq', '≔'],
       \]
 


### PR DESCRIPTION
conceal \colon as well, the same way as \coloneqq