### PR TITLE
Use absolute path for Zathura forward search

### DIFF
--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -99,7 +99,7 @@ function! s:cmdline(outfile, synctex, start) abort " {{{1
           \ ' --synctex-forward %d:%d:%s',
           \ line('.'), col('.'),
           \ vimtex#util#shellescape(
-          \   vimtex#paths#relative(expand('%:p'), b:vimtex.root)))
+          \   expand('%:p')))
   endif
 
   return l:cmd . ' '


### PR DESCRIPTION
Hello,

I have always had issues with Zathura forward search (backward works fine on the other hand).

The only way to fix it for me is to use absolute paths instead of relative paths.

Maybe someone else has the same issue, I hope this is somewhat useful.

Thanks for the plugin, I have been using it for quite a while :)