### PR TITLE
Add support for tabularx

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -308,22 +308,6 @@ function! vimtex#syntax#core#init() abort " {{{1
         \ 'contains': '@texClusterTabular'
         \})
 
-  syntax match texCmdTabularx "\\begin{tabularx}"
-        \ skipwhite skipnl
-        \ nextgroup=texTabularxOpt,texTabularxWidth
-        \ contains=texCmdEnv
-  call vimtex#syntax#core#new_opt('texTabularxOpt', {
-        \ 'next': 'texTabularxWidth',
-        \ 'contains': 'texComment,@NoSpell',
-        \})
-  call vimtex#syntax#core#new_arg('texTabularxWidth', {
-        \ 'next': 'texTabularxArg',
-        \})
-  call vimtex#syntax#core#new_arg('texTabularxArg', {
-        \ 'contains': '@texClusterTabular'
-        \})
-
-
   syntax match texTabularCol   "[lcr]" contained
   syntax match texTabularCol   "p"     contained nextgroup=texTabularLength
   syntax match texTabularAtSep "@"     contained nextgroup=texTabularLength

--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -308,6 +308,22 @@ function! vimtex#syntax#core#init() abort " {{{1
         \ 'contains': '@texClusterTabular'
         \})
 
+  syntax match texCmdTabularx "\\begin{tabularx}"
+        \ skipwhite skipnl
+        \ nextgroup=texTabularxOpt,texTabularxWidth
+        \ contains=texCmdEnv
+  call vimtex#syntax#core#new_opt('texTabularxOpt', {
+        \ 'next': 'texTabularxWidth',
+        \ 'contains': 'texComment,@NoSpell',
+        \})
+  call vimtex#syntax#core#new_arg('texTabularxWidth', {
+        \ 'next': 'texTabularxArg',
+        \})
+  call vimtex#syntax#core#new_arg('texTabularxArg', {
+        \ 'contains': '@texClusterTabular'
+        \})
+
+
   syntax match texTabularCol   "[lcr]" contained
   syntax match texTabularCol   "p"     contained nextgroup=texTabularLength
   syntax match texTabularAtSep "@"     contained nextgroup=texTabularLength

--- a/autoload/vimtex/syntax/p/tabularx.vim
+++ b/autoload/vimtex/syntax/p/tabularx.vim
@@ -7,22 +7,24 @@
 function! vimtex#syntax#p#tabularx#load(cfg) abort " {{{1
   call vimtex#syntax#packages#load('array')
 
+  " The format is \begin{tabularx}{WIDTH}[POS]{PREAMBLE}
   syntax match texCmdTabularx "\\begin{tabularx}"
         \ skipwhite skipnl
-        \ nextgroup=texTabularxOpt,texTabularxWidth
+        \ nextgroup=texTabularxWidth
         \ contains=texCmdEnv
+  call vimtex#syntax#core#new_arg('texTabularxWidth', {
+        \ 'next': 'texTabularxPreamble,texTabularxOpt,',
+        \ 'contains': 'texLength',
+        \})
   call vimtex#syntax#core#new_opt('texTabularxOpt', {
-        \ 'next': 'texTabularxWidth',
+        \ 'next': 'texTabularxPreamble',
         \ 'contains': 'texComment,@NoSpell',
         \})
-  call vimtex#syntax#core#new_arg('texTabularxWidth', {
-        \ 'next': 'texTabularxArg',
-        \})
-  call vimtex#syntax#core#new_arg('texTabularxArg', {
+  call vimtex#syntax#core#new_arg('texTabularxPreamble', {
         \ 'contains': '@texClusterTabular'
         \})
 
-  highlight def link texTabularxArg         texOpt
+  highlight def link texTabularxPreamble    texOpt
   highlight def link texTabularxWidth       texOpt
   highlight def link texTabularxOpt         texEnvOpt
 endfunction

--- a/autoload/vimtex/syntax/p/tabularx.vim
+++ b/autoload/vimtex/syntax/p/tabularx.vim
@@ -21,6 +21,10 @@ function! vimtex#syntax#p#tabularx#load(cfg) abort " {{{1
   call vimtex#syntax#core#new_arg('texTabularxArg', {
         \ 'contains': '@texClusterTabular'
         \})
+
+  highlight def link texTabularxArg         texOpt
+  highlight def link texTabularxWidth       texOpt
+  highlight def link texTabularxOpt         texEnvOpt
 endfunction
 
 " }}}1

--- a/autoload/vimtex/syntax/p/tabularx.vim
+++ b/autoload/vimtex/syntax/p/tabularx.vim
@@ -25,7 +25,7 @@ function! vimtex#syntax#p#tabularx#load(cfg) abort " {{{1
         \})
 
   highlight def link texTabularxPreamble    texOpt
-  highlight def link texTabularxWidth       texOpt
+  highlight def link texTabularxWidth       texLength
   highlight def link texTabularxOpt         texEnvOpt
 endfunction
 

--- a/autoload/vimtex/syntax/p/tabularx.vim
+++ b/autoload/vimtex/syntax/p/tabularx.vim
@@ -6,6 +6,21 @@
 
 function! vimtex#syntax#p#tabularx#load(cfg) abort " {{{1
   call vimtex#syntax#packages#load('array')
+
+  syntax match texCmdTabularx "\\begin{tabularx}"
+        \ skipwhite skipnl
+        \ nextgroup=texTabularxOpt,texTabularxWidth
+        \ contains=texCmdEnv
+  call vimtex#syntax#core#new_opt('texTabularxOpt', {
+        \ 'next': 'texTabularxWidth',
+        \ 'contains': 'texComment,@NoSpell',
+        \})
+  call vimtex#syntax#core#new_arg('texTabularxWidth', {
+        \ 'next': 'texTabularxArg',
+        \})
+  call vimtex#syntax#core#new_arg('texTabularxArg', {
+        \ 'contains': '@texClusterTabular'
+        \})
 endfunction
 
 " }}}1

--- a/test/test-syntax/test-tabularx.tex
+++ b/test/test-syntax/test-tabularx.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+
+\usepackage{tabularx}
+
+\begin{document}
+	\begin{tabularx}{\linewidth}{llXX}
+		1 & 2 & 3 & 4 \\
+	\end{tabularx}
+
+	% Tabularx does not seem to have options
+	\begin{tabularx}[test]{\linewidth}{llXX}
+		1 & 2 & 3 & 4 \\
+	\end{tabularx}
+\end{document}

--- a/test/test-syntax/test-tabularx.tex
+++ b/test/test-syntax/test-tabularx.tex
@@ -7,8 +7,7 @@
 		1 & 2 & 3 & 4 \\
 	\end{tabularx}
 
-	% Tabularx does not seem to have options
-	\begin{tabularx}[test]{\linewidth}{llXX}
+	\begin{tabularx}{\linewidth}[pos]{llXX}
 		1 & 2 & 3 & 4 \\
 	\end{tabularx}
 \end{document}

--- a/test/test-syntax/test-tabularx.vim
+++ b/test/test-syntax/test-tabularx.vim
@@ -8,10 +8,10 @@ if empty($INMAKE) | finish | endif
 
 call assert_true(vimtex#syntax#in('texCmdTabularx', 6, 2))
 call assert_true(vimtex#syntax#in('texTabularxWidth', 6, 20))
-call assert_true(vimtex#syntax#in('texTabularxArg', 6, 32))
+call assert_true(vimtex#syntax#in('texTabularxPreamble', 6, 32))
 
-call assert_true(vimtex#syntax#in('texCmdTabularx', 11, 2))
-call assert_true(vimtex#syntax#in('texTabularxOpt', 11, 20))
-call assert_true(vimtex#syntax#in('texTabularxWidth', 11, 26))
-call assert_true(vimtex#syntax#in('texTabularxArg', 11, 38))
+call assert_true(vimtex#syntax#in('texCmdTabularx', 10, 2))
+call assert_true(vimtex#syntax#in('texTabularxWidth', 10, 20))
+call assert_true(vimtex#syntax#in('texTabularxOpt', 10, 32))
+call assert_true(vimtex#syntax#in('texTabularxPreamble', 10, 37))
 call vimtex#test#finished()

--- a/test/test-syntax/test-tabularx.vim
+++ b/test/test-syntax/test-tabularx.vim
@@ -1,0 +1,17 @@
+source common.vim
+
+silent edit test-tabularx.tex
+
+set spell
+
+if empty($INMAKE) | finish | endif
+
+call assert_true(vimtex#syntax#in('texCmdTabularx', 6, 2))
+call assert_true(vimtex#syntax#in('texTabularxWidth', 6, 20))
+call assert_true(vimtex#syntax#in('texTabularxArg', 6, 32))
+
+call assert_true(vimtex#syntax#in('texCmdTabularx', 11, 2))
+call assert_true(vimtex#syntax#in('texTabularxOpt', 11, 20))
+call assert_true(vimtex#syntax#in('texTabularxWidth', 11, 26))
+call assert_true(vimtex#syntax#in('texTabularxArg', 11, 38))
+call vimtex#test#finished()


### PR DESCRIPTION
This properly highlights the arguments of the `tabularx` environment, which takes two arguments unlike `tabular` that only takes one. The reason I added this was so that the second argument would properly get recognized as `@texClusterTabular`. Otherwise, the column specifiers get marked as a misspelled word when using `set spell`. This is a big problem for me because I use `]s` and `[s` to jump around and fix things. It is also preferable to have proper highlight groups for more reasons than just spelling.