### PR TITLE
Enable custom commands for inverse search in Zathura

### DIFF
--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -461,6 +461,7 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_view_skim_reading_bar', 0)
   call s:init_option('vimtex_view_zathura_options', '')
   call s:init_option('vimtex_view_zathura_check_libsynctex', 1)
+  call s:init_option('vimtex_view_zathura_synctex_command', '')
 
   " Fallback option
   if g:vimtex_context_pdf_viewer ==# 'NONE'

--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -88,9 +88,13 @@ function! s:cmdline(outfile, synctex, start) abort " {{{1
   if a:start
     let l:cmd .= ' ' . g:vimtex_view_zathura_options
     if a:synctex
-      let l:cmd .= printf(
-            \ ' -x "%s -c \"VimtexInverseSearch %%{line} ''%%{input}''\""',
-            \ s:inverse_search_cmd)
+      if empty(g:vimtex_view_zathura_synctex_command)
+        let l:cmd .= printf(
+              \ ' -x "%s -c \"VimtexInverseSearch %%{line} ''%%{input}''\""',
+              \ s:inverse_search_cmd)
+      else
+        let l:cmd .= ' -x ' . g:vimtex_view_zathura_synctex_command
+      endif
     endif
   endif
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2953,6 +2953,13 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: 1
 
+*g:vimtex_view_zathura_synctex_command*
+  Define a custom command for inverse search in Zathura. If empty, VimTeX
+  falls back to `VimtexInverseSeach`, which works straight out of the box in
+  most cases.
+
+  Default value: ''
+
 *g:vimtex_callback_progpath*
   The path to the Vim/neovim executable. This is currently passed to Zathura
   (|vimtex-view-zathura|) for use with synctex callbacks.
@@ -5307,6 +5314,7 @@ for Zathura configuration are `%{line}` and `%{input}`, not `%l` and `%f`.
 Associated settings:
 * |g:vimtex_view_zathura_check_libsynctex|
 * |g:vimtex_view_zathura_options|
+* |g:vimtex_view_zathura_synctex_command|
 
 Note: Forward search requires `xdotool` to work properly. That is, `xdotool`
       is used to avoid duplicate Zathura instances when the


### PR DESCRIPTION
This PR adds `g:vimtex_view_zathura_synctex_command` for calling custom inverse search commands in Zathura. Even though  `VimtexInverseSearch` works in most cases, users could make use of a custom command for finer control.

(Not so) minimal working example.

minimal.vim
```vim
set nocompatible
let &rtp = '../..,' . &rtp
let &rtp .= ',../../after'
filetype plugin indent on
syntax enable

nnoremap q :qall!<cr>

let g:vimtex_view_automatic = 0
let g:latex_view_general_viewer = 'zathura'
let g:vimtex_view_method = 'zathura'
let g:vimtex_compiler_method = 'latexmk'
let g:vimtex_compiler_progname = 'nvr'

" Using neovim-remote. Requires `pip install neovim neovim-remote`.
let g:vimtex_view_zathura_synctex_command =
      \ '"nvr --servername ' .
      \ v:servername .
      \ ' --remote-silent +%{line} %{input}"'

" or using just neovim.
" let g:vimtex_view_zathura_synctex_command =
"       \ '"nvim --server ' .
"       \ v:servername .
"       \ ' --remote-send '':e %{input} | :%{line}<CR>''"'

silent edit main.tex
```

main.tex
```tex
\documentclass{minimal}
\begin{document}
Hello world!

Line 5

Line 7

Line 9
\end{document}
```

