### PR TITLE
Fix outdir quoting issue for tectonic compiler

### DIFF
--- a/autoload/vimtex/compiler/tectonic.vim
+++ b/autoload/vimtex/compiler/tectonic.vim
@@ -38,7 +38,7 @@ endfunction
 function! s:compiler.__build_cmd() abort dict " {{{1
   let l:outdir = !empty(self.build_dir)
         \ ? self.build_dir
-        \ : fnamemodify(self.state.tex, ':p:h')
+        \ : fnamemodify(self.state.tex, ':p:h')->fnameescape()
 
   return 'tectonic ' . join(self.options)
         \ . ' --outdir=' . l:outdir

--- a/autoload/vimtex/compiler/tectonic.vim
+++ b/autoload/vimtex/compiler/tectonic.vim
@@ -38,10 +38,10 @@ endfunction
 function! s:compiler.__build_cmd() abort dict " {{{1
   let l:outdir = !empty(self.build_dir)
         \ ? self.build_dir
-        \ : fnamemodify(self.state.tex, ':p:h')->fnameescape()
+        \ : fnamemodify(self.state.tex, ':p:h')
 
   return 'tectonic ' . join(self.options)
-        \ . ' --outdir=' . l:outdir
+        \ . ' --outdir=' . fnameescape(l:outdir)
         \ . ' ' . vimtex#util#shellescape(self.state.base)
 endfunction
 


### PR DESCRIPTION
For the tectonic compiler: if the path to the file contains spaces, outdir is not quoted properly and hence the build command does not work. This commit fixes that by escaping the path with `fnameescape()`.

---

Minimal example of the fixed issue:

1. Create the directory and file:

```
mkdir ~/'dir with spaces'
touch ~/'dir with spaces'/main.tex
```

2. Edit `main.tex` to create a valid document.
3. Set `let g:vimtex_compiler_method='tectonic'`
4. Try to compile, observe an error. `:VimtexCompileOutput` shows that `'spaces'` in the path is treated as a separate argument, though it should not be.