### PR TITLE
Add `textcite` and `citeauthor` to the `texCmdRef` syntax item

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -262,6 +262,8 @@ function! vimtex#syntax#core#init() abort " {{{1
   syntax match texCmdRef nextgroup=texRefArg           skipwhite skipnl "\\v\?ref\>"
   syntax match texCmdRef nextgroup=texRefOpt,texRefArg skipwhite skipnl "\\cite\>"
   syntax match texCmdRef nextgroup=texRefOpt,texRefArg skipwhite skipnl "\\cite[tp]\>\*\?"
+  syntax match texCmdRef nextgroup=texRefOpt,texRefArg skipwhite skipnl "\\citeauthor\>"
+  syntax match texCmdRef nextgroup=texRefOpt,texRefArg skipwhite skipnl "\\textcite\>"
   call vimtex#syntax#core#new_opt('texRefOpt', {'next': 'texRefOpt,texRefArg'})
   call vimtex#syntax#core#new_arg('texRefArg', {'contains': 'texComment,@NoSpell'})
 


### PR DESCRIPTION
These commands are often used with Biblatex, so in my opinion they should be a part of the `texCmdRef` for correct highlighting (and avoiding spell-checking of the cite key).
It might be useful to also add other [citation commands from Biblatex](https://mirrors.nic.cz/tex-archive/macros/latex/contrib/biblatex/doc/biblatex.pdf); if you agree, I can do that.
Also, I'm not sure if it's better to have separate `syn match` definitions (i.e. one for `citeauthor` and one for `textcite`), or both in a regular expression in a single `syn match` (ie.g. `\\\(text\)\?cite\(author\)\?\>`). Multiple `syn match` definitions are more readable, but there might be a performance difference.