### PR TITLE
Allow inverse search to work even when VimTex is loaded only when filetype=tex

### DIFF
--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -89,7 +89,7 @@ function! s:cmdline(outfile, synctex, start) abort " {{{1
     let l:cmd .= ' ' . g:vimtex_view_zathura_options
     if a:synctex
       let l:cmd .= printf(
-            \ ' -x "%s -c \"VimtexInverseSearch %%{line} ''%%{input}''\""',
+            \ ' -x "%s -c \"set filetype=tex\" -c \"VimtexInverseSearch %%{line} ''%%{input}''\""',
             \ s:inverse_search_cmd)
     endif
   endif


### PR DESCRIPTION
When VimTex is loaded only when filetype=tex, the editor command VimtexInverseSearch is not recognized.

Specifying the filetype when calling vim/nvim solve this issue.