### PR TITLE
register the (arg)?mini[!*e]?, (arg)?maxi[!*]? environment from  to region_math

### DIFF
--- a/autoload/vimtex/syntax/p/optidef.vim
+++ b/autoload/vimtex/syntax/p/optidef.vim
@@ -1,0 +1,16 @@
+" VimTeX - LaTeX plugin for Vim
+"
+" Maintainer: Karl Yngve Lervåg
+" Email:      karl.yngve@gmail.com
+"
+
+scriptencoding utf-8
+
+function! vimtex#syntax#p#optidef#load(cfg) abort " {{{1
+  call vimtex#syntax#core#new_region_math('\(arg\)\?mini')
+  call vimtex#syntax#core#new_region_math('\(arg\)\?mini[e!]', {'starred': 0})
+  call vimtex#syntax#core#new_region_math('\(arg\)\?maxi')
+  call vimtex#syntax#core#new_region_math('\(arg\)\?maxi\!', {'starred': 0})
+endfunction
+
+" }}}1

--- a/autoload/vimtex/syntax/p/optidef.vim
+++ b/autoload/vimtex/syntax/p/optidef.vim
@@ -4,8 +4,6 @@
 " Email:      karl.yngve@gmail.com
 "
 
-scriptencoding utf-8
-
 function! vimtex#syntax#p#optidef#load(cfg) abort " {{{1
   call vimtex#syntax#core#new_region_math('\(arg\)\?mini')
   call vimtex#syntax#core#new_region_math('\(arg\)\?mini[e!]', {'starred': 0})

--- a/test/test-syntax/test-optidef.tex
+++ b/test/test-syntax/test-optidef.tex
@@ -1,0 +1,30 @@
+\documentclass{article}
+\usepackage{optidef}
+
+\begin{document}
+
+\begin{mini}
+    {x}{f(x)}{}{}
+\end{mini}
+
+\begin{mini!}
+    {x}{f(x)}{}{}
+\end{mini!}
+
+\begin{minie}
+    {x}{f(x)}{}{}
+\end{minie}
+
+\begin{mini*}
+    {x}{f(x)}{}{}
+\end{mini*}
+
+\begin{argmini}
+    {x}{f(x)}{}{}
+\end{argmini}
+
+\begin{maxi}
+    {x}{f(x)}{}{}
+\end{maxi}
+
+\end{document}

--- a/test/test-syntax/test-optidef.vim
+++ b/test/test-syntax/test-optidef.vim
@@ -1,0 +1,14 @@
+source common.vim
+
+silent edit test-optidef.tex
+
+" if empty($INMAKE) | finish | endif
+
+call assert_true(vimtex#syntax#in('texMathZoneEnv', 7, 1))
+call assert_true(vimtex#syntax#in('texMathZoneEnv', 11, 1))
+call assert_true(vimtex#syntax#in('texMathZoneEnv', 15, 1))
+call assert_true(vimtex#syntax#in('texMathZoneEnv', 19, 1))
+call assert_true(vimtex#syntax#in('texMathZoneEnv', 23, 1))
+call assert_true(vimtex#syntax#in('texMathZoneEnv', 27, 1))
+
+call vimtex#test#finished()


### PR DESCRIPTION
The package [optidef](https://ctan.org/pkg/optidef) provides mini, maxi, argmini, argmaxi environments that should be considered math environments.
 