### PR TITLE
Fix wrong .github/workflows/assets.yml

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,14 +1,14 @@
 ---
-# yamllint disable-line rule:truthy
 name: Validate assets
 
+# yamllint disable-line rule:truthy
 on:
   push:
     paths:
-      - ${{ github.paths }}
+      - ${{ env.paths }}
   pull_request:
     paths:
-      - ${{ github.paths }}
+      - ${{ env.paths }}
   workflow_dispatch:
 
 env:
@@ -21,6 +21,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check that fontawesome.json is sorted
         run: |
-          for json in ${{ github.paths }} ; do
+          for json in ${{ env.paths }} ; do
             diff <(jq -S . $json) $json || exit 1
           done


### PR DESCRIPTION
github should be env. :bug:

And `# yamllint disable-line rule:truthy` just let yamllint ignore `on` because
`on` in yaml equal to true, which the latter is preferred. If you don't like it,
you can delete it :smile:

![Screenshot from 2022-10-27 10-30-05](https://user-images.githubusercontent.com/32936898/198176931-7cfb7860-d7c6-4499-9d29-651f00cbb1e7.png)
