### PR TITLE
replaces nvim-config-local with exrc.nvim

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -365,7 +365,7 @@ Buffer variable~
         * https://github.com/tpope/vim-projectionist
         * https://github.com/jenterkin/vim-autosource
         * https://github.com/ii14/exrc.vim
-        * https://klen/nvim-config-local (neovim only)
+        * https://github.com/MunifTanjim/exrc.nvim (neovim only)
 
                                                               *vimtex-tex-root*
 TeX root directive~


### PR DESCRIPTION
nvim-config-local is unmaintained, and has known bugs. In the last few months, I have successfully managed to switch to `exrc.nvim`, a lua-only plugin for neovim. 