### PR TITLE
Replace texlab url with github link

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -759,7 +759,7 @@ Language servers~
   conjunction with VimTeX as an alternative to |vimtex-grammar|.
 
   [0]: https://langserver.org/
-  [1]: https://texlab.netlify.app/
+  [1]: https://github.com/latex-lsp/texlab
   [2]: https://github.com/prabirshrestha/vim-lsp
   [3]: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#texlab
   [4]: https://github.com/neoclide/coc.nvim


### PR DESCRIPTION
When trying to navigate to the original texlab netlify URL in the browser, it redirects to the github page for the project.