### PR TITLE
Improve the main-file detection

### DIFF
--- a/autoload/vimtex/state.vim
+++ b/autoload/vimtex/state.vim
@@ -475,23 +475,23 @@ endfunction
 function! s:file_is_main(file) abort " {{{1
   if !filereadable(a:file) | return 0 | endif
 
+  let l:preamble = vimtex#parser#preamble(a:file, {
+        \ 'inclusive' : 1,
+        \ 'root' : fnamemodify(a:file, ':p:h'),
+        \})
+
   " Check if a:file is a main file by looking for the \documentclass command,
   " but ignore the following:
-  "
-  "   \documentclass[...]{subfiles}
-  "   \documentclass[...]{standalone}
-  "
-  let l:lines = readfile(a:file, 0, 50)
+  " * \documentclass[...]{subfiles}
+  " * \documentclass[...]{standalone}
+  let l:lines = copy(l:preamble)
   call filter(l:lines, 'v:val =~# ''^\s*\\documentclass\_\s*[\[{]''')
   call filter(l:lines, 'v:val !~# ''{subfiles}''')
   call filter(l:lines, 'v:val !~# ''{standalone}''')
   if len(l:lines) == 0 | return 0 | endif
 
-  " A main file contains `\begin{document}`
-  let l:lines = vimtex#parser#preamble(a:file, {
-        \ 'inclusive' : 1,
-        \ 'root' : fnamemodify(a:file, ':p:h'),
-        \})
+  " A main file must also contain `\begin{document}`
+  let l:lines = copy(l:preamble)
   call filter(l:lines, 'v:val =~# ''^\s*\\begin\s*{document}''')
   return len(l:lines) > 0
 endfunction

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -453,8 +453,8 @@ Recursive search~
   and parent directories that
 
   1. includes the present file (directly or indirectly),
-  2. has a `\documentclass` line near the top, and
-  3. contains `\begin{document}` (or includes a file that does).
+  2. has a `\documentclass` line near the top of its parsed content, and
+  3. contains `\begin{document}` in its parsed content.
 
   As long as a project follows these rules, the recursive search should work.
   Notice, though, that the first point is important and is where the recursive
@@ -462,23 +462,6 @@ Recursive search~
   main file to the present file. If not, then rule 1 is violated.
 
   Let's consider a common construct that will fail: >
-
-    % preamble.tex
-    \documentclass{article}
-    \usepackage{mypackages}
-    ...
-
-    % main.tex
-    \input{preamble}
-    \begin{document}
-    Hello world
-    \end{document}
-<
-  In this case, `main.tex` is _not_ recognized as a valid main file, because
-  it does not include `\documentclass`. Further, no other main file is found
-  that includes this file. Thus, VimTeX is not able to properly parse it.
-
-  Another example where the algorithm may fail: >
 
     path1/main.tex
     path2/chapter.tex

--- a/test/test-get-main/test-included-preamble/main.tex
+++ b/test/test-get-main/test-included-preamble/main.tex
@@ -1,0 +1,3 @@
+\input{preamble}
+\begin{document}
+\end{document}

--- a/test/test-get-main/test-included-preamble/preamble.tex
+++ b/test/test-get-main/test-included-preamble/preamble.tex
@@ -1,0 +1,1 @@
+\documentclass{minimal}

--- a/test/test-get-main/test.vim
+++ b/test/test-get-main/test.vim
@@ -60,4 +60,9 @@ call vimtex#test#main('test-bib-alternate/references.bib', 'test-bib-alternate/m
 call vimtex#test#main('test-standalone/a/a.tex', 'test-standalone/main.tex')
 call vimtex#test#main('test-standalone/a/a.tex', 'test-standalone/a/a.tex', 1)
 
+" Test included preamble
+call vimtex#test#main(
+      \ './test-included-preamble/preamble.tex',
+      \ './test-included-preamble/main.tex')
+
 call vimtex#test#finished()


### PR DESCRIPTION
As a result of #2465, I added a restriction to the compiler module where it won't compile the document unless the main file was _verified_ to be a valid main file. This helped to ensure robustness, at the cost of breaking the work flow for several users.

This PR introduces a minor change to how VimTeX checks if a file is a main file that should resolve most of the issues reported after the more restrictive compiler module. However, I won't merge it immediately, because it _may_ come at a cost of reduced init performance. That is, slower load time for VimTeX. This should only affect large projects, and only if they consist of many/multiple files. But still, it may be a relevant blocker.

Therefore, before I merge this, I would be very happy if users who have large LaTeX documents with multiple files (e.g. books, large theses, etc) could test if this branch introduce a noticable reduced startup time. Please also report if you do not see a reduced performance.

Related issues:
* #2557
* #2471
* #2483

People who may have an interest in this issue: @Rmano, @fauust, @Yorkwn, @shuber2, @krishnakumarg1984, @clason