### PR TITLE
doc: Note on lazy loading and inverse search

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Or use some other plugin manager:
 * [neobundle](https://github.com/Shougo/neobundle.vim)
 * [pathogen](https://github.com/tpope/vim-pathogen)
 
+Note that some plugin managers provide mechanisms for lazy loading of plugins,
+e.g., based on the filetype. This is explicitly _discouraged_. Firstly, it
+complicates some mechansims, e.g., inverse search through PDF viewers.
+Secondly, there is also little gain in this since VimTeX is already lazily
+loaded as a filetype plugin.
+
 If you use the new package feature in Vim, please note the following:
 * Make sure to read and understand the package feature: `:help package`!
 * Use the `/pack/foo/start` subdirectory to make sure the filetype plugin is

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -5503,6 +5503,11 @@ This may be avoided, or at least reduced, with the following variants: >
 Note: Vim users should be aware that one may need to ensure that the server is
       really running, see |vimtex-clientserver|.
 
+Note: Various plugin managers support lazy plugin loading, e.g., based on the
+      filetype. It is discouraged to use this feature with VimTeX. In
+      particular, the above command lines for inverse search would need work
+      around this.
+
 ==============================================================================
 LATEX DOCUMENTATION                                           *vimtex-latexdoc*
 


### PR DESCRIPTION
The provided command lines for inverse search do not work when VimTeX is loaded lazily only for tex files, as provided by various plugin managers. Add a note on how to cope with that.