### PR TITLE
Fix TeX directive recognition

### DIFF
--- a/autoload/vimtex/doc.vim
+++ b/autoload/vimtex/doc.vim
@@ -57,7 +57,7 @@ function! vimtex#doc#make_selection(context) abort " {{{1
   endif
 
   if len(a:context.candidates) == 1
-    if g:vimtex_doc_confirm_single && vimtex#ui#confirm([
+    if !g:vimtex_doc_confirm_single || vimtex#ui#confirm([
           \ 'Open documentation for ' . a:context.type . ': ',
           \ ['VimtexSuccess', a:context.candidates[0]],
           \ '?'

--- a/autoload/vimtex/state/class.vim
+++ b/autoload/vimtex/state/class.vim
@@ -19,9 +19,7 @@ function! vimtex#state#class#new(main, main_parser, preserve_root) abort " {{{1
 
   let l:ext = fnamemodify(a:main, ':e')
   " Recognise (La)TeX-related file extensions
-  let l:new.tex = empty(filter(['^(la)?tex$', '^dtx$', '^tikz$'],
-                             \  'l:ext =~? v:val'))
-                \ ? a:main : ''
+  let l:new.tex = l:ext =~? '^\(\(la\)\=tex\|dtx\|tikz\)$' ? a:main : ''
 
   " Get preamble for some state parsing
   let l:preamble = !empty(l:new.tex)

--- a/autoload/vimtex/state/class.vim
+++ b/autoload/vimtex/state/class.vim
@@ -18,8 +18,10 @@ function! vimtex#state#class#new(main, main_parser, preserve_root) abort " {{{1
   endif
 
   let l:ext = fnamemodify(a:main, ':e')
-  let l:new.tex = index(['tex', 'dtx', 'tikz', 'ins'], l:ext) >= 0
-        \ ? a:main : ''
+  " Recognise (La)TeX-related file extensions
+  let l:new.tex = empty(filter(['^(la)?tex$', '^dtx$', '^tikz$'],
+                             \  'l:ext =~? v:val'))
+                \ ? a:main : ''
 
   " Get preamble for some state parsing
   let l:preamble = !empty(l:new.tex)
@@ -130,7 +132,7 @@ function! s:vimtex.get_tex_program() abort dict " {{{1
   let l:tex_program_re =
         \ '\v^\c\s*\%\s*!?\s*tex\s+%(ts-)?program\s*\=\s*\zs.*\ze\s*$'
 
-  let l:lines = vimtex#parser#preamble(self.base, {'root' : self.root})[:20]
+  let l:lines = vimtex#parser#preamble(self.tex, {'root' : self.root})[:20]
   call map(l:lines, 'matchstr(v:val, l:tex_program_re)')
   call filter(l:lines, '!empty(v:val)')
   return tolower(get(l:lines, -1, '_'))

--- a/autoload/vimtex/state/class.vim
+++ b/autoload/vimtex/state/class.vim
@@ -18,8 +18,7 @@ function! vimtex#state#class#new(main, main_parser, preserve_root) abort " {{{1
   endif
 
   let l:ext = fnamemodify(a:main, ':e')
-  " Recognise (La)TeX-related file extensions
-  let l:new.tex = l:ext =~? '^\(\(la\)\=tex\|dtx\|tikz\)$' ? a:main : ''
+  let l:new.tex = l:ext =~? '\v^%(%(la)?tex|dtx|tikz|ins)$' ? a:main : ''
 
   " Get preamble for some state parsing
   let l:preamble = !empty(l:new.tex)

--- a/autoload/vimtex/state/class.vim
+++ b/autoload/vimtex/state/class.vim
@@ -130,7 +130,7 @@ function! s:vimtex.get_tex_program() abort dict " {{{1
   let l:tex_program_re =
         \ '\v^\c\s*\%\s*!?\s*tex\s+%(ts-)?program\s*\=\s*\zs.*\ze\s*$'
 
-  let l:lines = vimtex#parser#preamble(self.tex, {'root' : self.root})[:20]
+  let l:lines = vimtex#parser#preamble(self.base, {'root' : self.root})[:20]
   call map(l:lines, 'matchstr(v:val, l:tex_program_re)')
   call filter(l:lines, '!empty(v:val)')
   return tolower(get(l:lines, -1, '_'))


### PR DESCRIPTION
This one simple typo—probably left over from some old version—rendered TeX directives like `%! TeX program = lualatex` useless and prevented Vimtex from recognising directives at all (very annoying!)

It seems likely that this very typo is littered throughout the codebase, but I haven't had the time to establish that; for now at least, it makes TeX directives usable again.