### PR TITLE
Added shortintertext as text context.

### DIFF
--- a/autoload/vimtex/syntax/p/mathtools.vim
+++ b/autoload/vimtex/syntax/p/mathtools.vim
@@ -23,6 +23,14 @@ function! vimtex#syntax#p#mathtools#load(cfg) abort " {{{1
   highlight def link texMathToolsOptPos1  texOpt
   highlight def link texMathToolsOptPos2  texOpt
   highlight def link texMathToolsOptWidth texOpt
+
+  " Support for shortintertext
+  syntax match texMathCmdText contained skipwhite nextgroup=texMathTextArg "\\shortintertext"
+
+  if g:vimtex_syntax_conceal.styles
+    syntax match texMathCmdText contained skipwhite conceal nextgroup=texMathTextConcArg "\\shortintertext"
+  endif
+
 endfunction
 
 " }}}1

--- a/test/test-syntax/test-mathtools.tex
+++ b/test/test-syntax/test-mathtools.tex
@@ -47,4 +47,10 @@
   \end{smallmatrix*}
 \]
 
+\begin{gather}
+  f(x) = x
+  \shortintertext{This is a short intertext.}
+  f(x) = x
+\end{gather}
+
 \end{document}


### PR DESCRIPTION
Currently the content of \shortintertext{} is consideted math context by the plugin. With this PR I added shortintertext to the "Text Inside Math regions" patterns.