### PR TITLE
Add vimtex_mappings_prefix to configure leader mappings prefix

### DIFF
--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -121,13 +121,15 @@ endfunction
 function! s:init_default_mappings() abort " {{{1
   if !g:vimtex_mappings_enabled | return | endif
 
-  call s:map(0, 'n', '<localleader>li', '<plug>(vimtex-info)')
-  call s:map(0, 'n', '<localleader>lI', '<plug>(vimtex-info-full)')
-  call s:map(0, 'n', '<localleader>lx', '<plug>(vimtex-reload)')
-  call s:map(0, 'n', '<localleader>lX', '<plug>(vimtex-reload-state)')
-  call s:map(1, 'n', '<localleader>ls', '<plug>(vimtex-toggle-main)')
-  call s:map(0, 'n', '<localleader>lq', '<plug>(vimtex-log)')
-  call s:map(1, 'n', '<localleader>la', '<plug>(vimtex-context-menu)')
+  let l:prfx = g:vimtex_mappings_prefix
+
+  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'i', '<plug>(vimtex-info)')
+  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'I', '<plug>(vimtex-info-full)')
+  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'x', '<plug>(vimtex-reload)')
+  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'X', '<plug>(vimtex-reload-state)')
+  call s:map(1, 'n', '<localleader>' .. l:prfx .. 's', '<plug>(vimtex-toggle-main)')
+  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'q', '<plug>(vimtex-log)')
+  call s:map(1, 'n', '<localleader>' .. l:prfx .. 'a', '<plug>(vimtex-context-menu)')
 
   call s:map(0, 'n', 'ds$', '<plug>(vimtex-env-delete-math)')
   call s:map(0, 'n', 'cs$', '<plug>(vimtex-env-change-math)')
@@ -157,17 +159,17 @@ function! s:init_default_mappings() abort " {{{1
   call s:map(0, 'n', '<F8>', '<plug>(vimtex-delim-add-modifiers)')
 
   if g:vimtex_compiler_enabled
-    call s:map(0, 'n', '<localleader>ll', '<plug>(vimtex-compile)')
-    call s:map(0, 'n', '<localleader>lo', '<plug>(vimtex-compile-output)')
-    call s:map(1, 'n', '<localleader>lL', '<plug>(vimtex-compile-selected)')
-    call s:map(1, 'x', '<localleader>lL', '<plug>(vimtex-compile-selected)')
-    call s:map(0, 'n', '<localleader>lk', '<plug>(vimtex-stop)')
-    call s:map(0, 'n', '<localleader>lK', '<plug>(vimtex-stop-all)')
-    call s:map(0, 'n', '<localleader>le', '<plug>(vimtex-errors)')
-    call s:map(0, 'n', '<localleader>lc', '<plug>(vimtex-clean)')
-    call s:map(0, 'n', '<localleader>lC', '<plug>(vimtex-clean-full)')
-    call s:map(0, 'n', '<localleader>lg', '<plug>(vimtex-status)')
-    call s:map(0, 'n', '<localleader>lG', '<plug>(vimtex-status-all)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'l', '<plug>(vimtex-compile)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'o', '<plug>(vimtex-compile-output)')
+    call s:map(1, 'n', '<localleader>' .. l:prfx .. 'L', '<plug>(vimtex-compile-selected)')
+    call s:map(1, 'x', '<localleader>' .. l:prfx .. 'L', '<plug>(vimtex-compile-selected)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'k', '<plug>(vimtex-stop)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'K', '<plug>(vimtex-stop-all)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'e', '<plug>(vimtex-errors)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'c', '<plug>(vimtex-clean)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'C', '<plug>(vimtex-clean-full)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'g', '<plug>(vimtex-status)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'G', '<plug>(vimtex-status-all)')
   endif
 
   if g:vimtex_motion_enabled
@@ -288,19 +290,19 @@ function! s:init_default_mappings() abort " {{{1
   endif
 
   if g:vimtex_toc_enabled
-    call s:map(0, 'n', '<localleader>lt', '<plug>(vimtex-toc-open)')
-    call s:map(0, 'n', '<localleader>lT', '<plug>(vimtex-toc-toggle)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 't', '<plug>(vimtex-toc-open)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'T', '<plug>(vimtex-toc-toggle)')
   endif
 
   if has_key(b:vimtex, 'viewer')
-    call s:map(0, 'n', '<localleader>lv', '<plug>(vimtex-view)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'v', '<plug>(vimtex-view)')
     if !empty(maparg('<plug>(vimtex-reverse-search)', 'n'))
-      call s:map(1, 'n', '<localleader>lr', '<plug>(vimtex-reverse-search)')
+      call s:map(1, 'n', '<localleader>' .. l:prfx .. 'r', '<plug>(vimtex-reverse-search)')
     endif
   endif
 
   if g:vimtex_imaps_enabled
-    call s:map(0, 'n', '<localleader>lm', '<plug>(vimtex-imaps-list)')
+    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'm', '<plug>(vimtex-imaps-list)')
   endif
 
   if g:vimtex_doc_enabled

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -118,18 +118,22 @@ function! s:init_buffer() abort " {{{1
 endfunction
 
 " }}}1
+function! s:map_prefixed(ftype, mode, lhs, rhs) abort " {{{1
+  let l:lhs = g:vimtex_mappings_prefix . a:lhs
+  call s:map(a:ftype, a:mode, l:lhs, a:rhs)
+endfunction
+
+" }}}1
 function! s:init_default_mappings() abort " {{{1
   if !g:vimtex_mappings_enabled | return | endif
 
-  let l:prfx = g:vimtex_mappings_prefix
-
-  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'i', '<plug>(vimtex-info)')
-  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'I', '<plug>(vimtex-info-full)')
-  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'x', '<plug>(vimtex-reload)')
-  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'X', '<plug>(vimtex-reload-state)')
-  call s:map(1, 'n', '<localleader>' .. l:prfx .. 's', '<plug>(vimtex-toggle-main)')
-  call s:map(0, 'n', '<localleader>' .. l:prfx .. 'q', '<plug>(vimtex-log)')
-  call s:map(1, 'n', '<localleader>' .. l:prfx .. 'a', '<plug>(vimtex-context-menu)')
+  call s:map_prefixed(0, 'n', 'i', '<plug>(vimtex-info)')
+  call s:map_prefixed(0, 'n', 'I', '<plug>(vimtex-info-full)')
+  call s:map_prefixed(0, 'n', 'x', '<plug>(vimtex-reload)')
+  call s:map_prefixed(0, 'n', 'X', '<plug>(vimtex-reload-state)')
+  call s:map_prefixed(1, 'n', 's', '<plug>(vimtex-toggle-main)')
+  call s:map_prefixed(0, 'n', 'q', '<plug>(vimtex-log)')
+  call s:map_prefixed(1, 'n', 'a', '<plug>(vimtex-context-menu)')
 
   call s:map(0, 'n', 'ds$', '<plug>(vimtex-env-delete-math)')
   call s:map(0, 'n', 'cs$', '<plug>(vimtex-env-change-math)')
@@ -159,17 +163,17 @@ function! s:init_default_mappings() abort " {{{1
   call s:map(0, 'n', '<F8>', '<plug>(vimtex-delim-add-modifiers)')
 
   if g:vimtex_compiler_enabled
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'l', '<plug>(vimtex-compile)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'o', '<plug>(vimtex-compile-output)')
-    call s:map(1, 'n', '<localleader>' .. l:prfx .. 'L', '<plug>(vimtex-compile-selected)')
-    call s:map(1, 'x', '<localleader>' .. l:prfx .. 'L', '<plug>(vimtex-compile-selected)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'k', '<plug>(vimtex-stop)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'K', '<plug>(vimtex-stop-all)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'e', '<plug>(vimtex-errors)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'c', '<plug>(vimtex-clean)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'C', '<plug>(vimtex-clean-full)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'g', '<plug>(vimtex-status)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'G', '<plug>(vimtex-status-all)')
+    call s:map_prefixed(0, 'n', 'l', '<plug>(vimtex-compile)')
+    call s:map_prefixed(0, 'n', 'o', '<plug>(vimtex-compile-output)')
+    call s:map_prefixed(1, 'n', 'L', '<plug>(vimtex-compile-selected)')
+    call s:map_prefixed(1, 'x', 'L', '<plug>(vimtex-compile-selected)')
+    call s:map_prefixed(0, 'n', 'k', '<plug>(vimtex-stop)')
+    call s:map_prefixed(0, 'n', 'K', '<plug>(vimtex-stop-all)')
+    call s:map_prefixed(0, 'n', 'e', '<plug>(vimtex-errors)')
+    call s:map_prefixed(0, 'n', 'c', '<plug>(vimtex-clean)')
+    call s:map_prefixed(0, 'n', 'C', '<plug>(vimtex-clean-full)')
+    call s:map_prefixed(0, 'n', 'g', '<plug>(vimtex-status)')
+    call s:map_prefixed(0, 'n', 'G', '<plug>(vimtex-status-all)')
   endif
 
   if g:vimtex_motion_enabled
@@ -290,19 +294,19 @@ function! s:init_default_mappings() abort " {{{1
   endif
 
   if g:vimtex_toc_enabled
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 't', '<plug>(vimtex-toc-open)')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'T', '<plug>(vimtex-toc-toggle)')
+    call s:map_prefixed(0, 'n', 't', '<plug>(vimtex-toc-open)')
+    call s:map_prefixed(0, 'n', 'T', '<plug>(vimtex-toc-toggle)')
   endif
 
   if has_key(b:vimtex, 'viewer')
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'v', '<plug>(vimtex-view)')
+    call s:map_prefixed(0, 'n', 'v', '<plug>(vimtex-view)')
     if !empty(maparg('<plug>(vimtex-reverse-search)', 'n'))
-      call s:map(1, 'n', '<localleader>' .. l:prfx .. 'r', '<plug>(vimtex-reverse-search)')
+      call s:map_prefixed(1, 'n', 'r', '<plug>(vimtex-reverse-search)')
     endif
   endif
 
   if g:vimtex_imaps_enabled
-    call s:map(0, 'n', '<localleader>' .. l:prfx .. 'm', '<plug>(vimtex-imaps-list)')
+    call s:map_prefixed(0, 'n', 'm', '<plug>(vimtex-imaps-list)')
   endif
 
   if g:vimtex_doc_enabled

--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -286,6 +286,8 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_mappings_disable', {})
   call s:init_option('vimtex_mappings_override_existing', 0)
 
+  call s:init_option('vimtex_mappings_prefix', "l")
+
   call s:init_option('vimtex_matchparen_enabled', 1)
   call s:init_option('vimtex_motion_enabled', 1)
 

--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -286,7 +286,7 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_mappings_disable', {})
   call s:init_option('vimtex_mappings_override_existing', 0)
 
-  call s:init_option('vimtex_mappings_prefix', "l")
+  call s:init_option('vimtex_mappings_prefix', '<localleader>l')
 
   call s:init_option('vimtex_matchparen_enabled', 1)
   call s:init_option('vimtex_motion_enabled', 1)

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2104,6 +2104,11 @@ OPTIONS                                                        *vimtex-options*
 <
   Default value: {}
 
+*g:vimtex_mappings_prefix*
+  The default prefix for all usually `<localleader>` based mappings.
+
+  Default value: <localleader>l
+
 *g:vimtex_mappings_override_existing*
   Control behaviour on mapping conflicts, in particular whether or not to
   override pre-existing mappings. By default, VimTeX does not override existing


### PR DESCRIPTION
Would it make sense to you to allow users to customize the prefix used for `<localleader>` based mappings?

**My Use-Case**:
Usually, all `<localleader>` vimtex mappings reside under `<localleader>l...`.
I like how the existing vimtex mappings are chosen, but `<localleader>l` is the prefix I have been using for language-server related mappings. To remedy this, I want to modify all existing vimtex keymaps to start with `<localleader>v` instead.  Remapping each function manually would not feel like a clean solution to this.

**Some Notes**:
- I have never used VimScript, so i hope I am using `g:` and `l:` correctly.
- The `l:prfx` shorthand is just for readability, as `g:vimtex_mappings_prefix` would lengthen the lines a lot.
- Not sure if the newer `..` or the older `.` is the preferred way to concat strings for this project.
