### PR TITLE
fix the problem that open viewer in windows/neovim will show a cmd pr…

### DIFF
--- a/autoload/vimtex/jobs/neovim.vim
+++ b/autoload/vimtex/jobs/neovim.vim
@@ -6,9 +6,18 @@
 
 function! vimtex#jobs#neovim#new(cmd) abort " {{{1
   let l:job = deepcopy(s:job)
-  let l:job.cmd = has('win32')
-        \ ? 'cmd /s /c "' . a:cmd . '"'
-        \ : ['sh', '-c', a:cmd]
+  let l:modifier = get(g:, 'vimtex_job_cmd_modifier', has('win32') ? 'start ' : '')
+  if type(l:modifier) == v:t_func || (type(l:modifier) == v:t_string && exists('*' . l:modifier)) 
+    let l:job.cmd = call(l:modifier, a:cmd)
+  else
+    if empty(l:modifier)
+      let l:job.cmd = has('win32')
+            \ ? 'cmd /s /c "' . a:cmd . '"'
+            \ : ['sh', '-c', a:cmd]
+    else
+      let l:job.cmd = l:modifier . a:cmd
+    endif
+  endif
   return l:job
 endfunction
 


### PR DESCRIPTION
In the case that runing on a Windows / neovim installation, the vimtex general viewer will open the viewer with a command prompt shown instead of open it silently.  I found that this is because the job run a command with a prefix `"cmd /s /c "` or  in a list with head `["sh", "-c" ]`. This may be fine on other platforms but not in my case. I want to prefix the command with `"start "` so I need a place to customize it as in this pull request.