### PR TITLE
Add wayland viewer workaround option g:vimtex_wayland

### DIFF
--- a/autoload/vimtex/view/_template.vim
+++ b/autoload/vimtex/view/_template.vim
@@ -203,6 +203,10 @@ endfunction
 
 " }}}1
 function! s:viewer.xdo_find_win_id_by_pid() dict abort " {{{1
+  g:vimtex_wayland = get(g:, 'vimtex_wayland', 0)
+  if g:vimtex_wayland
+    return 1
+  endif
   " Attempt to find the viewer's X window ID by the viewer's process ID.
   " Returns the viewer's window ID if one is found or 0. If more than one ID is
   " found, return the first.


### PR DESCRIPTION
Attempts to fix #2046

More information at https://github.com/lervag/vimtex/issues/2046#issuecomment-1435778939

I have not updated the documentation yet to reflect this change. @lervag I would need some pointers to do this (Where in the documentation hierarchy this should go, etc.)

Adding a `g:vimtex_wayland` option is somewhat conservative, since it ensures backward compatibility