### PR TITLE
Add simple Zathura viewer alternative

### DIFF
--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -44,7 +44,7 @@ function! vimtex#view#zathura#cmdline(outfile, synctex, start) abort " {{{1
     endif
   endif
 
-  if a:synctex && (!(a:start == 1) || g:vimtex_view_forward_search_on_start)
+  if a:synctex && (a:start != 1 || g:vimtex_view_forward_search_on_start)
     let l:cmd .= printf(
           \ ' --synctex-forward %d:%d:%s',
           \ line('.'), col('.'),

--- a/autoload/vimtex/view/zathura.vim
+++ b/autoload/vimtex/view/zathura.vim
@@ -9,15 +9,7 @@ function! vimtex#view#zathura#new() abort " {{{1
 endfunction
 
 " }}}1
-
-
-let s:viewer = vimtex#view#_template#new({
-      \ 'name': 'Zathura',
-      \ 'xwin_id': 0,
-      \ 'has_synctex': 1,
-      \})
-
-function! s:viewer._check() dict abort " {{{1
+function! vimtex#view#zathura#check(viewer) abort " {{{1
   " Check if Zathura is executable
   if !executable('zathura')
     call vimtex#log#error('Zathura is not executable!')
@@ -30,11 +22,57 @@ function! s:viewer._check() dict abort " {{{1
     if v:shell_error == 0
           \ && empty(filter(l:shared, 'v:val =~# ''libsynctex'''))
       call vimtex#log#warning('Zathura is not linked to libsynctex!')
-      let s:viewer.has_synctex = 0
+      if has_key(a:viewer, 'has_synctex')
+        let a:viewer.has_synctex = 0
+      endif
     endif
   endif
 
   return v:true
+endfunction
+
+" }}}1
+function! vimtex#view#zathura#cmdline(outfile, synctex, start) abort " {{{1
+  let l:cmd  = 'zathura'
+
+  if a:start
+    let l:cmd .= ' ' . g:vimtex_view_zathura_options
+    if a:synctex
+      let l:cmd .= printf(
+            \ ' -x "%s -c \"VimtexInverseSearch %%{line} ''%%{input}''\""',
+            \ s:inverse_search_cmd)
+    endif
+  endif
+
+  if a:synctex && (!(a:start == 1) || g:vimtex_view_forward_search_on_start)
+    let l:cmd .= printf(
+          \ ' --synctex-forward %d:%d:%s',
+          \ line('.'), col('.'),
+          \ vimtex#util#shellescape(expand('%:p')))
+  endif
+
+  return l:cmd . ' '
+        \ . vimtex#util#shellescape(vimtex#paths#relative(a:outfile, getcwd()))
+        \ . '&'
+endfunction
+
+let s:inverse_search_cmd = get(g:, 'vimtex_callback_progpath',
+      \                        get(v:, 'progpath', get(v:, 'progname', '')))
+      \ . (has('nvim')
+      \   ? ' --headless'
+      \   : ' -T dumb --not-a-term -n')
+
+" }}}1
+
+
+let s:viewer = vimtex#view#_template#new({
+      \ 'name': 'Zathura',
+      \ 'has_synctex': 1,
+      \ 'xwin_id': 0,
+      \})
+
+function! s:viewer._check() dict abort " {{{1
+  return vimtex#view#zathura#check(self)
 endfunction
 
 " }}}1
@@ -44,7 +82,8 @@ endfunction
 
 " }}}1
 function! s:viewer._start(outfile) dict abort " {{{1
-  let self.cmd_start = s:cmdline(a:outfile, self.has_synctex, 1)
+  let self.cmd_start
+        \ = vimtex#view#zathura#cmdline(a:outfile, self.has_synctex, 1)
 
   call vimtex#jobs#run(self.cmd_start)
 
@@ -58,7 +97,8 @@ function! s:viewer._forward_search(outfile) dict abort " {{{1
   let l:synctex_file = fnamemodify(a:outfile, ':r') . '.synctex.gz'
   if !filereadable(l:synctex_file) | return | endif
 
-  let self.cmd_forward_search = s:cmdline(a:outfile, self.has_synctex, 0)
+  let self.cmd_forward_search
+        \ = vimtex#view#zathura#cmdline(a:outfile, self.has_synctex, 0)
 
   call vimtex#jobs#run(self.cmd_forward_search)
 endfunction
@@ -80,37 +120,3 @@ function! s:viewer.get_pid() dict abort " {{{1
 endfunction
 
 " }}}1
-
-
-function! s:cmdline(outfile, synctex, start) abort " {{{1
-  let l:cmd  = 'zathura'
-
-  if a:start
-    let l:cmd .= ' ' . g:vimtex_view_zathura_options
-    if a:synctex
-      let l:cmd .= printf(
-            \ ' -x "%s -c \"VimtexInverseSearch %%{line} ''%%{input}''\""',
-            \ s:inverse_search_cmd)
-    endif
-  endif
-
-  if a:synctex && (!a:start || g:vimtex_view_forward_search_on_start)
-    let l:cmd .= printf(
-          \ ' --synctex-forward %d:%d:%s',
-          \ line('.'), col('.'),
-          \ vimtex#util#shellescape(expand('%:p')))
-  endif
-
-  return l:cmd . ' '
-        \ . vimtex#util#shellescape(vimtex#paths#relative(a:outfile, getcwd()))
-        \ . '&'
-endfunction
-
-" }}}1
-
-
-let s:inverse_search_cmd = get(g:, 'vimtex_callback_progpath',
-      \                        get(v:, 'progpath', get(v:, 'progname', '')))
-      \ . (has('nvim')
-      \   ? ' --headless'
-      \   : ' -T dumb --not-a-term -n')

--- a/autoload/vimtex/view/zathura_simple.vim
+++ b/autoload/vimtex/view/zathura_simple.vim
@@ -23,7 +23,7 @@ endfunction
 " }}}1
 function! s:viewer._start(outfile) dict abort " {{{1
   let self.cmd_start
-        \ = vimtex#view#zathura#cmdline(a:outfile, self.has_synctex, 1)
+        \ = vimtex#view#zathura#cmdline(a:outfile, self.has_synctex, 2)
 
   call vimtex#jobs#run(self.cmd_start)
 endfunction

--- a/autoload/vimtex/view/zathura_simple.vim
+++ b/autoload/vimtex/view/zathura_simple.vim
@@ -1,0 +1,31 @@
+" VimTeX - LaTeX plugin for Vim
+"
+" Maintainer: Karl Yngve Lervåg
+" Email:      karl.yngve@gmail.com
+"
+
+function! vimtex#view#zathura_simple#new() abort " {{{1
+  return s:viewer.init()
+endfunction
+
+" }}}1
+
+
+let s:viewer = vimtex#view#_template#new({
+      \ 'name': 'Zathura',
+      \ 'has_synctex': 1,
+      \})
+
+function! s:viewer._check() dict abort " {{{1
+  return vimtex#view#zathura#check(self)
+endfunction
+
+" }}}1
+function! s:viewer._start(outfile) dict abort " {{{1
+  let self.cmd_start
+        \ = vimtex#view#zathura#cmdline(a:outfile, self.has_synctex, 1)
+
+  call vimtex#jobs#run(self.cmd_start)
+endfunction
+
+" }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -3020,9 +3020,10 @@ OPTIONS                                                        *vimtex-options*
 
   Possible values:
     * `'general'`
-    * `'mupdf'`      |vimtex-view-mupdf|
-    * `'skim'`       |vimtex-view-skim|
-    * `'zathura'`    |vimtex-view-zathura|
+    * `'mupdf'`             |vimtex-view-mupdf|
+    * `'skim'`              |vimtex-view-skim|
+    * `'zathura'`           |vimtex-view-zathura|
+    * `'zathura_simple'`    |vimtex-view-zathura-simple|
 
   See |vimtex-view-configuration| for more information on various popular
   viewers and on how to configure them.
@@ -3042,8 +3043,10 @@ OPTIONS                                                        *vimtex-options*
 
 *g:vimtex_view_mupdf_options*
 *g:vimtex_view_zathura_options*
-  Set options for mupdf (|vimtex-view-mupdf|) and Zathura
-  (|vimtex-view-zathura|), respectively.
+  Set options for mupdf and Zathura, respectively. See also:
+    * |vimtex-view-mupdf|
+    * |vimtex-view-zathura|
+    * |vimtex-view-zathura-simple|
 
   Default value: ''
 
@@ -5574,6 +5577,16 @@ Note: Viewer handling uses window title matching. If there exists another pdf
       viewer with the same name as the current project pdf file, then there
       might be conflicts. In particular, this might affect forward/inverse
       searching for Zathura.
+
+                                                   *vimtex-view-zathura-simple*
+Zathura (simple) ~
+This is a simpler implementation of the Zathura viewer; the user should first
+read the docs for |vimtex-view-zathura|.
+
+This variant does not rely on `xdotool`. It leads to a much simpler version
+that should work well in most cases. However, `xdotool` is useful in order to
+prevent duplicate windows and to detect existing viewer windows when you start
+a VimTeX session.
 
 ------------------------------------------------------------------------------
 SYNCTEX SUPPORT                                                *vimtex-synctex*


### PR DESCRIPTION
This PR adds a `zathura_simple` viewer variant that does not depend on `xdotool`. This means it should work well on e.g. Wayland (see e.g. #2046).