### PR TITLE
fix(view): update skim check to macOS changes

### DIFF
--- a/autoload/vimtex/view/skim.vim
+++ b/autoload/vimtex/view/skim.vim
@@ -28,7 +28,7 @@ function! s:viewer._check() dict abort " {{{1
   let l:output = vimtex#jobs#capture(
         \ 'osascript -l JavaScript -e ''Application("Skim").id()''')
 
-  if l:output[0] !~# '^net.sourceforge.skim-app'
+  if join(l:output) !~# 'net.sourceforge.skim-app'
     call vimtex#log#error('Skim is not installed!')
     return v:false
   endif


### PR DESCRIPTION
Problem: macOS 13.4 adds a deprecation warning to the introspection method Skim uses for its scripting. This breaks the check whether Skim is installed, leading to an error message because the looked-for output is now on a second line.

Solution: Concatenate all output lines instead of only looking at the first line.