### PR TITLE
Add support for TeXShop previewer on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ by default and must be manually enabled.
   - [qpdfview](https://launchpad.net/qpdfview)
   - [Skim](http://skim-app.sourceforge.net/)
   - [SumatraPDF](http://www.sumatrapdfreader.org/free-pdf-reader.html)
+  - [TeXShop](https://pages.uoregon.edu/koch/texshop/)
   - [Zathura](https://pwmt.org/projects/zathura/)
   - Other viewers are supported through a general interface
 - Completion of

--- a/autoload/health/vimtex.vim
+++ b/autoload/health/vimtex.vim
@@ -153,3 +153,18 @@ function! s:check_view_skim() abort " {{{1
 endfunction
 
 " }}}1
+function! s:check_view_texshop() abort " {{{1
+  let l:cmd = join([
+        \ 'osascript -e ',
+        \ '''tell application "Finder" to POSIX path of ',
+        \ '(get application file id (id of application "TeXShop") as alias)''',
+        \])
+
+  if system(l:cmd)
+    call health#report_error('TeXShop is not installed!')
+  else
+    call health#report_ok('TeXShop viewer should work!')
+  endif
+endfunction
+
+" }}}1

--- a/autoload/vimtex/options.vim
+++ b/autoload/vimtex/options.vim
@@ -477,6 +477,8 @@ function! vimtex#options#init() abort " {{{1
   call s:init_option('vimtex_view_skim_activate', 0)
   call s:init_option('vimtex_view_skim_sync', 0)
   call s:init_option('vimtex_view_skim_reading_bar', 0)
+  call s:init_option('vimtex_view_texshop_activate', 0)
+  call s:init_option('vimtex_view_texshop_sync', 0)
   call s:init_option('vimtex_view_zathura_options', '')
   call s:init_option('vimtex_view_zathura_check_libsynctex', 1)
 

--- a/autoload/vimtex/view/texshop.vim
+++ b/autoload/vimtex/view/texshop.vim
@@ -1,0 +1,95 @@
+" VimTeX - LaTeX plugin for Vim
+"
+" Maintainer: Karl Yngve Lervåg
+" Email:      karl.yngve@gmail.com
+"
+
+function! vimtex#view#texshop#new() abort " {{{1
+  return s:viewer.init()
+endfunction
+
+" }}}1
+
+let s:viewer = vimtex#view#_template#new({'name' : 'TeXShop'})
+
+function! s:viewer.compiler_callback(outfile) dict abort " {{{1
+  let cmd = s:make_cmd_view(
+        \ a:outfile,
+        \ g:vimtex_view_automatic && !has_key(self, 'started_through_callback'),
+        \ g:vimtex_view_texshop_sync)
+  call vimtex#jobs#run(cmd)
+  let self.started_through_callback = 1
+endfunction
+
+" }}}1
+function! s:viewer._check() dict abort " {{{1
+  let l:output = vimtex#jobs#capture(
+        \ 'osascript -l JavaScript -e ''Application("TeXShop").id()''')
+
+  if l:output[0] !~# 'TeXShop'
+    call vimtex#log#error('TeXShop is not installed!')
+    return v:false
+  endif
+
+  return v:true
+endfunction
+
+" }}}1
+function! s:viewer._start(outfile) dict abort " {{{1
+  call vimtex#jobs#run(s:make_cmd_view(a:outfile, 1, 1))
+endfunction
+
+" }}}1
+function! s:make_cmd_view(outfile, open, sync) abort " {{{1
+  let l:scriptview = [
+        \ 'osascript',
+        \ '-e ''set theFile to POSIX file "' . a:outfile . '"''',
+        \ '-e ''set thePath to POSIX path of (theFile as alias)''',
+        \ '-e ''tell application "TeXShop"''',
+        \ '-e ''try''',
+        \ '-e ''set theDocs to get documents whose path is thePath''',
+        \ '-e ''if (count of theDocs) > 0 then revert theDocs''',
+        \ '-e ''end try''',
+        \ a:open ? '-e ''open theFile''' : '',
+        \ g:vimtex_view_texshop_activate ? '-e ''activate''' : '',
+        \ '-e ''end tell''',
+        \]
+  let l:script = join(l:scriptview)
+
+  " Define variables for the source file, line and column numbers:
+  let l:sourcefile = shellescape(expand('%'), 1)
+  let l:sourcefileFull = shellescape(expand('%:p'), 1)
+  let l:linenr = line('.')
+  let l:colnr = col('.')
+
+  " The applescript described in
+  " https://pages.uoregon.edu/koch/texshop/changes_3.html
+  " (Release notes for TeXShop 4.25) is directly integrated
+  " below:
+  let l:scriptsync = [
+        \ 'osascript',
+        \ '-e ''set currentLine to ' . l:linenr . ' as integer''',
+        \ '-e ''set currentCol to ' . l:colnr . ' as integer''',
+        \ '-e ''set currentTeXFile to "' . l:sourcefileFull . '"''',
+        \ '-e ''set currentPDFFile to "' . a:outfile . '"''',
+        \ '-e ''tell application "TeXShop"''',
+        \ a:open ? '-e ''  open currentTeXFile''' : '',
+        \ '-e ''  set the front_document to the front document''',
+        \ '-e ''  tell front_document''',
+        \ '-e ''    sync_preview_line theLine currentLine''',
+        \ '-e ''    sync_preview_index theIndex currentCol''',
+        \ '-e ''    sync_preview_name theName currentTeXFile''',
+        \ g:vimtex_view_texshop_activate ? '-e ''activate''' : '',
+        \ '-e ''    return 0''',
+        \ '-e ''  end tell''',
+        \ '-e ''end tell''',
+        \]
+
+  if a:sync
+    let l:script = join(l:scriptsync)
+  endif
+
+  return printf(l:script)
+endfunction
+
+" }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -98,6 +98,7 @@ CONTENTS                                                      *vimtex-contents*
       Sioyek                                    |vimtex-view-sioyek|
       Skim                                      |vimtex-view-skim|
       SumatraPDF                                |vimtex-view-sumatrapdf|
+      TeXShop                                   |vimtex-view-texshop|
       Zathura                                   |vimtex-view-zathura|
       Zathura (simple)                          |vimtex-view-zathura-simple|
     Synctex                                     |vimtex-synctex|
@@ -3150,6 +3151,19 @@ OPTIONS                                                        *vimtex-options*
 
   Default value: 0
 
+*g:vimtex_view_texshop_activate*
+  Set this option to 1 to make TeXShop have focus after command |:VimtexView| in
+  addition to being moved to the foreground.
+
+  Default value: 0
+
+*g:vimtex_view_texshop_sync*
+  Set this option to 1 to make TeXShop perform a forward search after successful
+  compilation.
+
+  Default value: 0
+
+
 *g:vimtex_view_zathura_check_libsynctex*
   Check on startup if Zathura is compiled with libsynctex. This is done by
   default because Zathura on some systems is compiled without libsynctex
@@ -5593,6 +5607,52 @@ Note: There is a known issue with VimTeX + SumatraPDF when you use `xelatex`,
       A workaround was found and posted by @Whitebeard0 here:
       https://github.com/lervag/vimtex/issues/1410#issuecomment-506143020
 
+                                                         *vimtex-view-texshop*
+TeXShop~
+https://pages.uoregon.edu/koch/texshop/index.html
+TeXShop is a TeX front-end program for macOS. It provides an editor
+(which can be replaced by other external editors, such as vim),
+a front-end to call TeX-related programs that process source files,
+and a PDF viewer with support for syncing between source and PDF.
+VimTeX supports both forward and inverse searches with TeXShop.
+
+Configuration: >
+  let g:vimtex_view_method = 'texshop'
+
+To configure inverse search in TeXShop:
+
+1. In a terminal, adjust TeXShop's preferences:  >
+
+   defaults write TeXShop OtherEditorSync YES
+   defaults write TeXShop UseExternalEditor -bool true
+<
+Note: These commands only need to be run once as they modify TeXShop's
+      preference file in `~/Library/Preferences/TeXShop.plist`, which persists
+      through sessions. While the first preference is a hidden preference
+      and must be set via a terminal command, the second can be
+      toggled from within TeXShop's preferences pane.
+
+2. Create a shell script `/usr/local/bin/othereditor` that contains a call to
+vim following the general principles explained in
+|vimtex-synctex-inverse-search|. Note: The interpolation variables `%l` and `%f` 
+should be replaced by `$1` and `$2`, respectively, as TeXShop will pass the
+line and file as the first and second argument when calling the script.
+
+Note: the script must be executable: >
+   chmod +x /usr/local/bin/othereditor
+
+From TeXShop, inverse search is activated by `Command`-clicking in the viewer.
+Furthermore, if TeXShop's compiler front-end is used, clicking `Goto Error`
+in the console (keyboard shortcut `Command-Control-E`) will also activate
+inverse search and jump to the line containing the error in the source.
+
+MacVim users should read |vimtex-faq-texshopviewer| for additional
+setup instructions and limitations.
+
+Associated settings:
+* |g:vimtex_view_texshop_activate|
+* |g:vimtex_view_texshop_sync|
+
                                                           *vimtex-view-zathura*
                                                    *vimtex-view-zathura-simple*
 Zathura ~
@@ -5908,6 +5968,7 @@ Contents:
 * |vimtex-faq-wsl|
 * |vimtex-faq-sumatrapdf-wsl|
 * |vimtex-faq-zathura-macos|
+* |vimtex-faq-texshopviewer|
 * |vimtex-faq-treesitter|
 
 ------------------------------------------------------------------------------
@@ -6264,6 +6325,43 @@ A: Yes, it is possible by using the "additional_vim_regex_highlighting" option
    [0]: https://tree-sitter.github.io/tree-sitter/
    [1]: https://github.com/nvim-treesitter/nvim-treesitter
    [2]: https://github.com/nvim-treesitter/nvim-treesitter#available-modules
+
+------------------------------------------------------------------------------
+                                                     *vimtex-faq-texshopviewer*
+Q: How do I set up VimTeX to work with TeXShop and MacVim (macOS)?
+A: Start by reading the section on |vimtex-view-texshop|. The examples
+   below apply to MacVim [0].
+
+   Here is an example `/usr/local/bin/othereditor` script that uses the
+   VimTeX's convenience function `VimtexInverseSearch`: >
+
+   #!/bin/bash
+   /usr/local/bin/mvim -v --not-a-term -T dumb -c "VimtexInverseSearch $1 '$2'"
+<
+   The call with the convenience function `VimtexInverseSearch`
+   offers the advantage that the buffer will be found if it is open,
+   regardless of how it was opened. If the buffer is not active, in a hidden
+   tab or if the file is not open at all, inverse search will fail.
+
+   As alternative, to `VimtexInverseSearch`if the .tex document was
+   opened with the `--remote-silent` option, i.e.: >
+
+   /usr/local/bin/mvim --remote-silent foo.tex
+<
+   the following script `/usr/local/bin/othereditor` can be used instead: >
+
+   #!/bin/bash
+   /usr/local/bin/mvim --remote-silent +$1 "$2"
+<
+   It will activate the buffer even if it is hidden, or open the file if
+   it is not yet loaded in any buffer.
+
+   Related information
+   the TeXShop release notes for versions 4.24 and 4.25 [1] contain information
+   related to backward searches with external editors in general.
+
+   [0] https://macvim-dev.github.io/macvim/
+   [1] https://pages.uoregon.edu/koch/texshop/changes_3.html
 
 ==============================================================================
 TROUBLESHOOTING                                       *vimtex-troubleshooting*


### PR DESCRIPTION
All proposed changes/additions are now in a single (clean) commit (I rebased the fork on the most recent commit, which closed the original PR). Let me know if this works.