### PR TITLE
Add more engine names as options to latexmk

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1069,6 +1069,9 @@ OPTIONS                                                        *vimtex-options*
         \ 'luatex'           : '-lualatex',
         \ 'lualatex'         : '-lualatex',
         \ 'xelatex'          : '-xelatex',
+        \ 'pdftex'           : '-pdf -pdflatex=pdftex'
+        \ 'xetex'            : '-pdf -pdflatex=xetex'
+        \ 'luatex'           : '-pdf -pdflatex=luatex'
         \ 'context (pdftex)' : '-pdf -pdflatex=texexec',
         \ 'context (luatex)' : '-pdf -pdflatex=context',
         \ 'context (xetex)'  : '-pdf -pdflatex=''texexec --xtx''',


### PR DESCRIPTION
Continuing [issue #2683](https://github.com/lervag/vimtex/issues/2683), I added 3 more lines to the documentation that describe how to compile a plain tex document with either `pdftex`, `xetex` or `luatex`.