### PR TITLE
Add .xdv extension to compiler.clean function

### DIFF
--- a/autoload/vimtex/compiler/_template.vim
+++ b/autoload/vimtex/compiler/_template.vim
@@ -128,7 +128,7 @@ endfunction
 " }}}1
 
 function! s:compiler.clean(full) abort dict " {{{1
-  let l:files = ['synctex.gz', 'toc', 'out', 'aux', 'log']
+  let l:files = ['synctex.gz', 'toc', 'out', 'aux', 'log', 'xdv']
   if a:full
     call extend(l:files, ['pdf'])
   endif


### PR DESCRIPTION
At least 1 compiler (Tectonic) produces these intermediate files.