### PR TITLE
Don't detach general viewer on Windows

### DIFF
--- a/autoload/vimtex/view/general.vim
+++ b/autoload/vimtex/view/general.vim
@@ -59,7 +59,9 @@ function! s:viewer._start(file) dict abort " {{{1
 
   " Start the view process
   " NB: Use vimtex#jobs#start to ensure it runs in the background
-  let self.job = vimtex#jobs#start(l:cmd, {'detached': v:true})
+  let self.job = vimtex#jobs#start(l:cmd, {
+        \ 'detached': vimtex#util#get_os() !=# 'win'
+        \})
 endfunction
 
 " }}}1


### PR DESCRIPTION
This should fix #2706 and possibly #2627. See also #2401.