### PR TITLE
Add dynamic compiler method setting

### DIFF
--- a/autoload/vimtex/compiler.vim
+++ b/autoload/vimtex/compiler.vim
@@ -312,24 +312,29 @@ endfunction
 
 
 function! s:init_compiler(options) abort " {{{1
+  if type(g:vimtex_compiler_method) == v:t_func
+        \ || exists('*' . g:vimtex_compiler_method)
+    let l:method = call(g:vimtex_compiler_method, [a:options.state.tex])
+  else
+    let l:method = g:vimtex_compiler_method
+  endif
+
   if index([
         \ 'arara',
         \ 'generic',
         \ 'latexmk',
         \ 'latexrun',
         \ 'tectonic',
-        \], g:vimtex_compiler_method) < 0
-    call vimtex#log#error(
-          \ 'Error! Invalid g:vimtex_compiler_method: '
-          \ . g:vimtex_compiler_method)
-    let g:vimtex_compiler_method = 'latexmk'
+        \], l:method) < 0
+    call vimtex#log#error('Error! Invalid compiler method: ' . l:method)
+    let l:method = 'latexmk'
   endif
 
   let l:options =
-        \ get(g:, 'vimtex_compiler_' . g:vimtex_compiler_method, {})
+        \ get(g:, 'vimtex_compiler_' . l:method, {})
   let l:options = extend(deepcopy(l:options), a:options)
   let l:compiler
-        \ = vimtex#compiler#{g:vimtex_compiler_method}#init(l:options)
+        \ = vimtex#compiler#{l:method}#init(l:options)
   return l:compiler
 endfunction
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -943,7 +943,17 @@ OPTIONS                                                        *vimtex-options*
   Default: 0
 
 *g:vimtex_compiler_method*
-  Set the compiler method. Available choices are:
+  Set the compiler method. There are two variants of setting this option:
+
+    i)  explicity as a string, or
+    ii) dynamically through a function.
+
+  For the latter variant, the option must be specified as a |Funcref| (only
+  possibly with Lua in Neovim) or the name of a function. The function takes
+  a single string argument (the path to the main TeX file) and must return the
+  desired method as a string.
+
+  The available compiler method choices are:
 
     Value      Documentation              Configuration ~
     `latexmk`    |vimtex-compiler-latexmk|    |g:vimtex_compiler_latexmk|
@@ -952,6 +962,24 @@ OPTIONS                                                        *vimtex-options*
     `arara`      |vimtex-compiler-arara|      |g:vimtex_compiler_arara|
     `generic`    |vimtex-compiler-generic|    |g:vimtex_compiler_generic|
 
+  Using a function allows a lot of flexibility in the choice of compiler
+  method. For instance, one could use `arara` for files that have `arara`
+  specifications at the top and fall back to `latexmk` for other files: >vim
+
+    function! SetCompilerMethod(mainfile)
+      if filereadable(a:mainfile)
+        for line in readfile(a:mainfile, '', 5)
+          if line =~# '^%\s*arara'
+            return 'arara'
+          endif
+        endfor
+      endif
+
+      return 'latexmk'
+    endfunction
+
+    let g:vimtex_compiler_method = 'SetCompilerMethod'
+<
   Default value: `'latexmk'`
 
 *g:vimtex_compiler_latexmk*

--- a/test/test-compiler-method-dynamic/Makefile
+++ b/test/test-compiler-method-dynamic/Makefile
@@ -1,0 +1,13 @@
+MYVIM ?= nvim --clean --headless
+
+INMAKE := 1
+export INMAKE
+
+TESTS := $(wildcard test*.vim)
+
+.PHONY: test $(TESTS)
+
+test: $(TESTS)
+
+$(TESTS):
+	@$(MYVIM) -u $@

--- a/test/test-compiler-method-dynamic/test-arara.tex
+++ b/test/test-compiler-method-dynamic/test-arara.tex
@@ -1,0 +1,5 @@
+% arara: pdflatex
+\documentclass{minimal}
+\begin{document}
+Hello world!
+\end{document}

--- a/test/test-compiler-method-dynamic/test-fallback.tex
+++ b/test/test-compiler-method-dynamic/test-fallback.tex
@@ -1,0 +1,4 @@
+\documentclass{minimal}
+\begin{document}
+Hello world!
+\end{document}

--- a/test/test-compiler-method-dynamic/test.vim
+++ b/test/test-compiler-method-dynamic/test.vim
@@ -1,0 +1,30 @@
+set nocompatible
+set runtimepath^=../..
+filetype plugin on
+
+nnoremap q :qall!<cr>
+
+function! SetCompilerMethod(mainfile)
+  if filereadable(a:mainfile)
+    for line in readfile(a:mainfile, '', 5)
+      if line =~# '^%\s*arara'
+        return 'arara'
+      endif
+    endfor
+  endif
+
+  return 'latexmk'
+endfunction
+
+let g:vimtex_compiler_method = 'SetCompilerMethod'
+
+silent edit test-arara.tex
+if empty($INMAKE) | finish | endif
+
+
+call assert_equal('arara', b:vimtex.compiler.name)
+
+silent edit test-fallback.tex
+call assert_equal('latexmk', b:vimtex.compiler.name)
+
+call vimtex#test#finished()


### PR DESCRIPTION
This allows to set `g:vimtex_compiler_method` to a function so as to allow dynamic settings. See feature suggestion in #2721.