### PR TITLE
fix: detect treesitter in the correct buffer

### DIFF
--- a/autoload/vimtex/nvim.vim
+++ b/autoload/vimtex/nvim.vim
@@ -4,16 +4,10 @@
 " Email:      karl.yngve@gmail.com
 "
 
-function! vimtex#nvim#check_treesitter(...) abort " {{{1
-lua <<EOF
-  local highlighter = require "vim.treesitter.highlighter"
-  local bufnr = vim.api.nvim_get_current_buf()
-  if vim.bo[bufnr].syntax == "" and highlighter.active[bufnr] then
-    vim.fn['vimtex#log#error'](
-      'Syntax highlighting is controlled by Tree-sitter!'
-    )
-  end
-EOF
+function! vimtex#nvim#check_treesitter(buf, ...) abort " {{{1
+  if empty(getbufvar(a:buf, '&syntax')) && luaeval('require("vim.treesitter.highlighter").active[_A[1]] ~= nil', [a:buf])
+    call vimtex#log#error('Syntax highlighting is controlled by Tree-sitter!')
+  endif
 endfunction
 
 " }}}1

--- a/ftplugin/tex.vim
+++ b/ftplugin/tex.vim
@@ -30,5 +30,5 @@ call vimtex#init()
 if has('nvim-0.5')
       \ && g:vimtex_syntax_enabled
       \ && !g:vimtex_syntax_conceal_disable
-  call timer_start(1000, 'vimtex#nvim#check_treesitter')
+  call timer_start(1000, function('vimtex#nvim#check_treesitter', [bufnr('%')]))
 endif


### PR DESCRIPTION
Problem:
Wrong treesitter detection error message when the user enters another buffer right after opening a tex file.

Solution:
Detect in the buffer in which the ftplugin is loaded.