### PR TITLE
fix: Don't do timeout in pvc mode after inactivity

### DIFF
--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -141,7 +141,7 @@ function! s:compiler.__build_cmd() abort dict " {{{1
   endif
 
   if self.continuous
-    let l:cmd .= ' -pvc -view=none'
+    let l:cmd .= ' -pvc -pvctimeout- -view=none'
 
     if self.callback
       for [l:opt, l:val] in [
@@ -164,7 +164,7 @@ function! s:compiler.__pprint_append() abort dict " {{{1
   if !empty(self.aux_dir)
     call add(l:list, ['aux_dir', self.aux_dir])
   endif
-  
+
   call add(l:list, ['callback', self.callback])
   call add(l:list, ['continuous', self.continuous])
   call add(l:list, ['executable', self.executable])


### PR DESCRIPTION
By default the `-pvc` mode will stop working after 30 mins of inactivity, where vimtex compiler and the latexmk process can fall into an inconsistent state (i.e., no longer able to build the latex project while vimtex still thinks the continuous mode is still running).

To disable this, we disable inactivity timeout in the pvc mode. Requires latexmk v4.55 (Jan 2018) or higher.

From https://texdoc.org/serve/latexmk/0

```
-pvctimeout
    Do timeout in pvc mode after period of inactivity, which is 30 min.
    by default. Inactivity means a period when latexmk has detected no
    file changes and hence has not taken any actions like compiling the
    document.

-pvctimeout-
    Don’t do timeout in pvc mode after inactivity.
```