### PR TITLE
Fix: Dictionary error in amsmath.vim

### DIFF
--- a/autoload/vimtex/syntax/p/amsmath.vim
+++ b/autoload/vimtex/syntax/p/amsmath.vim
@@ -16,10 +16,10 @@ function! vimtex#syntax#p#amsmath#load(cfg) abort " {{{1
         \ 'multline',
         \ 'xalignat',
         \]
-    call vimtex#syntax#core#new_env(#{
-          \ name: l:env,
-          \ starred: v:true,
-          \ math: v:true
+    call vimtex#syntax#core#new_env({
+          \ 'name': l:env,
+          \ 'starred': v:true,
+          \ 'math': v:true
           \})
   endfor
 


### PR DESCRIPTION
I was encountering an error, when loading the plugin. To my understanding, it was in the declaration of the dictionary. Changing it to valid(?) syntax fixed my error.
