### PR TITLE
feat(syntax): add keywords to texCommentTodo

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -430,6 +430,8 @@ function! vimtex#syntax#core#init_rules() abort " {{{1
   syntax keyword texCommentTodo combak fixme todo xxx
         \ containedin=texComment contained
   syntax case match
+  syntax keyword texCommentTodo ISSUE NOTE
+        \ containedin=texComment contained
 
   " Highlight \iffalse ... \fi blocks as comments
   syntax region texComment matchgroup=texCmdConditional


### PR DESCRIPTION
I believe that the words 'ISSUE' and 'NOTE' are often highlighted in comments as well, and therefore, so I modified the syntax `texCommentTodo`.