### PR TITLE
Fix problem preventing the compilation using arara

### DIFF
--- a/autoload/vimtex/compiler/arara.vim
+++ b/autoload/vimtex/compiler/arara.vim
@@ -23,9 +23,9 @@ function! s:compiler.__check_requirements() abort dict " {{{1
 endfunction
 
 " }}}1
-function! s:compiler.__build_cmd(opts) abort dict " {{{1
+function! s:compiler.__build_cmd(passed_options) abort dict " {{{1
   return 'arara ' . join(self.options)
-        \ . ' ' . join(a:opts)
+        \ . ' ' . a:passed_options
         \ . ' ' . vimtex#util#shellescape(self.state.base)
 endfunction
 


### PR DESCRIPTION
This fixes #2861  - and makes compilation with arara possible again. 

I also renamed `opts` to `passed_options` to be more consistent with the naming in other compile methods (e.g. https://github.com/lervag/vimtex/blob/930804866f1fecd0b337c0f3e7333c6dd46ba149/autoload/vimtex/compiler/latexmk.vim#L135). 