### PR TITLE
Switch back focus to vim/neovim after inverse search from Sioyek

### DIFF
--- a/autoload/vimtex/view/sioyek.vim
+++ b/autoload/vimtex/view/sioyek.vim
@@ -13,6 +13,7 @@ endfunction
 
 let s:viewer = vimtex#view#_template#new({
       \ 'name': 'sioyek',
+      \ 'xwin_id': 0,
       \})
 
 function! s:viewer._check() dict abort " {{{1


### PR DESCRIPTION
This PR addresses https://github.com/lervag/vimtex/issues/2579.

`xwin_id` was missing in `b:vimtex.viewer`.