### PR TITLE
Complete syntax support for SageTeX

### DIFF
--- a/autoload/vimtex/syntax.vim
+++ b/autoload/vimtex/syntax.vim
@@ -25,18 +25,13 @@ function! vimtex#syntax#in_comment(...) abort " {{{1
 endfunction
 
 " }}}1
-function! vimtex#syntax#in_sage(...) abort " {{{1
-  return call('vimtex#syntax#in', ['texSagetexArg'] + a:000) || call('vimtex#syntax#in', ['texSagetexZone'] + a:000)
-endfunction
-
-" }}}1
 function! vimtex#syntax#in_mathzone(...) abort " {{{1
   " The following checks if we are inside a texMathZone environment. The
-  " arguments to \label{...}, the texRefArg group, the texSagetexArg group,
-  " and \text{...} like commands, the texMathTextArg group, are actively
-  " ignored as these should not be considered to be math environments.
+  " arguments to \label{...}, the texRefArg group, and \text{...} like
+  " commands, the texMathTextArg group, are actively ignored as these should
+  " not be considered to be math environments.
   let l:groups = reverse(call('vimtex#syntax#stack', a:000))
-  let l:group = matchstr(l:groups, '\v^tex%(Math%(Zone|Text|Tag)|RefArg|SagetexArg)')
+  let l:group = matchstr(l:groups, '\v^tex%(Math%(Zone|Text|Tag)|RefArg)')
   return l:group =~# '^texMathZone'
 endfunction
 

--- a/autoload/vimtex/syntax.vim
+++ b/autoload/vimtex/syntax.vim
@@ -31,7 +31,7 @@ function! vimtex#syntax#in_mathzone(...) abort " {{{1
   " commands, the texMathTextArg group, are actively ignored as these should
   " not be considered to be math environments.
   let l:groups = reverse(call('vimtex#syntax#stack', a:000))
-  let l:group = matchstr(l:groups, '\v^tex%(Math%(Zone|Text|Tag)|RefArg)')
+  let l:group = matchstr(l:groups, '\v^tex%(Math%(Zone|Text|Tag)|RefArg|SagetexArg)')
   return l:group =~# '^texMathZone'
 endfunction
 

--- a/autoload/vimtex/syntax.vim
+++ b/autoload/vimtex/syntax.vim
@@ -25,11 +25,16 @@ function! vimtex#syntax#in_comment(...) abort " {{{1
 endfunction
 
 " }}}1
+function! vimtex#syntax#in_sage(...) abort " {{{1
+  return call('vimtex#syntax#in', ['texSagetexArg'] + a:000) || call('vimtex#syntax#in', ['texSagetexZone'] + a:000)
+endfunction
+
+" }}}1
 function! vimtex#syntax#in_mathzone(...) abort " {{{1
   " The following checks if we are inside a texMathZone environment. The
-  " arguments to \label{...}, the texRefArg group, and \text{...} like
-  " commands, the texMathTextArg group, are actively ignored as these should
-  " not be considered to be math environments.
+  " arguments to \label{...}, the texRefArg group, the texSagetexArg group,
+  " and \text{...} like commands, the texMathTextArg group, are actively
+  " ignored as these should not be considered to be math environments.
   let l:groups = reverse(call('vimtex#syntax#stack', a:000))
   let l:group = matchstr(l:groups, '\v^tex%(Math%(Zone|Text|Tag)|RefArg|SagetexArg)')
   return l:group =~# '^texMathZone'

--- a/autoload/vimtex/syntax/p/sagetex.vim
+++ b/autoload/vimtex/syntax/p/sagetex.vim
@@ -16,7 +16,7 @@ function! vimtex#syntax#p#sagetex#load(cfg) abort " {{{1
         \})
   call vimtex#syntax#core#new_opt('texSagetexOpt', {'next': 'texSagetexArg'})
 
-  for l:env in [
+  for l:env_name in [
         \ 'sageblock',
         \ 'sagesilent',
         \ 'sageverbatim',
@@ -24,26 +24,32 @@ function! vimtex#syntax#p#sagetex#load(cfg) abort " {{{1
         \ 'sagecommandline'
         \]
     call vimtex#syntax#core#new_env({
-          \ 'name': l:env,
+          \ 'name': l:env_name,
           \ 'region': 'texSagetexZone',
           \ 'contains': '@vimtex_nested_python'
           \})
   endfor
 
-  for l:env in [
+  " Note: The following commands are supported both inside and outside math zones
+  for l:cmd_name in [
         \ 'sage',
         \ 'sagestr'
         \]
-    execute 'syntax match texCmdSagetex /\\' . l:env .
-          \ '\>/ nextgroup=texSagetexArg skipwhite skipnl'
-    call vimtex#syntax#core#new_cmd({
-          \ 'name': l:env,
-          \ 'mathmode': 1,
-          \ 'nextgroup': 'texSagetexArg'
-          \})
+    for l:in_mathmode in [v:true, v:false]
+      call vimtex#syntax#core#new_cmd({
+            \ 'name': l:cmd_name,
+            \ 'mathmode': l:in_mathmode,
+            \ 'nextgroup': 'texSagetexArg'
+            \})
+    endfor
   endfor
 
   highlight def link texCmdSagetex texCmd
+endfunction
+
+" }}}1
+function! vimtex#syntax#p#sagetex#in_sage(...) abort " {{{1
+  return call('vimtex#syntax#in', ['texSagetex\(Arg\|Zone\)'] + a:000)
 endfunction
 
 " }}}1

--- a/autoload/vimtex/syntax/p/sagetex.vim
+++ b/autoload/vimtex/syntax/p/sagetex.vim
@@ -47,9 +47,6 @@ function! vimtex#syntax#p#sagetex#load(cfg) abort " {{{1
   highlight def link texCmdSagetex texCmd
 endfunction
 
-" }}}1
-function! vimtex#syntax#p#sagetex#in_sage(...) abort " {{{1
-  return call('vimtex#syntax#in', ['texSagetex\(Arg\|Zone\)'] + a:000)
-endfunction
+call vimtex#syntax#add_to_mathzone_ignore('texSagetexArg')
 
 " }}}1

--- a/autoload/vimtex/syntax/p/sagetex.vim
+++ b/autoload/vimtex/syntax/p/sagetex.vim
@@ -7,8 +7,6 @@
 function! vimtex#syntax#p#sagetex#load(cfg) abort " {{{1
   call vimtex#syntax#nested#include('python')
 
-  syntax match texCmdSagetex /\\sagestr\>/
-        \ nextgroup=texSagetexArg skipwhite skipnl
   syntax match texCmdSagetex /\\sageplot\>/
         \ nextgroup=texSagetexOpt,texSagetexArg skipwhite skipnl
 
@@ -36,6 +34,8 @@ function! vimtex#syntax#p#sagetex#load(cfg) abort " {{{1
         \ 'sage',
         \ 'sagestr'
         \]
+    execute 'syntax match texCmdSagetex /\\' . l:env .
+          \ '\>/ nextgroup=texSagetexArg skipwhite skipnl'
     call vimtex#syntax#core#new_cmd({
           \ 'name': l:env,
           \ 'mathmode': 1,

--- a/autoload/vimtex/syntax/p/sagetex.vim
+++ b/autoload/vimtex/syntax/p/sagetex.vim
@@ -32,6 +32,17 @@ function! vimtex#syntax#p#sagetex#load(cfg) abort " {{{1
           \})
   endfor
 
+  for l:env in [
+        \ 'sage',
+        \ 'sagestr'
+        \]
+    call vimtex#syntax#core#new_cmd({
+          \ 'name': l:env,
+          \ 'mathmode': 1,
+          \ 'nextgroup': 'texSagetexArg'
+          \})
+  endfor
+
   highlight def link texCmdSagetex texCmd
 endfunction
 

--- a/autoload/vimtex/syntax/p/sagetex.vim
+++ b/autoload/vimtex/syntax/p/sagetex.vim
@@ -44,9 +44,9 @@ function! vimtex#syntax#p#sagetex#load(cfg) abort " {{{1
     endfor
   endfor
 
+  call vimtex#syntax#add_to_mathzone_ignore('texSagetexArg')
+
   highlight def link texCmdSagetex texCmd
 endfunction
-
-call vimtex#syntax#add_to_mathzone_ignore('texSagetexArg')
 
 " }}}1


### PR DESCRIPTION
I read through the [SageTeX documentation](https://github.com/sagemath/sagetex/blob/master/example.tex) to make sure no commands were missed.

- A new in_sage() function was added.
- Bug fix: The texSagetexArg environment is now not considered a mathzone. This comes from the fact that `$2+2=\sage{2+2}$` is a valid use of `\sage` (see [SageTeX documentation](https://github.com/sagemath/sagetex/blob/f9f1ba62c9aa5b3a22f7ac2b5c583df749594cd3/example.tex#L35C20-L35C36)). The contents of its argument should not be considered math, rather Python code.
- The `\sage` and `\sagestr` commands can be used in a mathzone and not in a mathzone, since their purpose is to just convert their Sage input into LaTeX output. Added support for this.