### PR TITLE
Use `U+2216` to conceal `\setminus`

### DIFF
--- a/autoload/vimtex/syntax/core.vim
+++ b/autoload/vimtex/syntax/core.vim
@@ -1669,7 +1669,7 @@ let s:cmd_symbols = [
       \ ['rmoustache', '╮'],
       \ ['S', '§'],
       \ ['searrow', '↘'],
-      \ ['setminus', '⧵'],
+      \ ['setminus', '∖'],
       \ ['sharp', '♯'],
       \ ['sim', '∼'],
       \ ['simeq', '⋍'],


### PR DESCRIPTION
Hi, currently `\setminus` is concealed by `U+29F5`, the Reverse Solidus Operator, while Unicode provides the genuine Set Minus `U+2216`. For more discussion see this decade long [issue](https://github.com/latex3/unicode-math/issues/181).