### PR TITLE
New function to toggle `\\`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ by default and must be manually enabled.
   - Toggle inline and displaymath with `ts$`
   - Toggle between e.g. `()` and `\left(\right)` with `tsd`
   - Toggle (inline) fractions with `tsf`
+  - Toggle line end `\\` with `tsb`
   - Close the current environment/delimiter in insert mode with `]]`
   - Add `\left ... \right)` modifiers to surrounding delimiters with `<F8>`
   - Insert new command with `<F7>`

--- a/autoload/vimtex.vim
+++ b/autoload/vimtex.vim
@@ -178,6 +178,7 @@ function! s:init_default_mappings() abort " {{{1
   call s:map(0, 'n', 'tsc',  '<plug>(vimtex-cmd-toggle-star)')
   call s:map(0, 'n', 'tsf',  '<plug>(vimtex-cmd-toggle-frac)')
   call s:map(0, 'x', 'tsf',  '<plug>(vimtex-cmd-toggle-frac)')
+  call s:map(0, 'n', 'tsb',  '<plug>(vimtex-cmd-toggle-break)')
   call s:map(0, 'i', '<F7>', '<plug>(vimtex-cmd-create)')
   call s:map(0, 'n', '<F7>', '<plug>(vimtex-cmd-create)')
   call s:map(0, 'x', '<F7>', '<plug>(vimtex-cmd-create)')

--- a/autoload/vimtex/cmd.vim
+++ b/autoload/vimtex/cmd.vim
@@ -28,6 +28,9 @@ function! vimtex#cmd#init_buffer() abort " {{{1
 
   xnoremap <silent><buffer> <plug>(vimtex-cmd-toggle-frac)
         \ :<c-u>call vimtex#cmd#toggle_frac_visual()<cr>
+
+  nnoremap <silent><buffer> <plug>(vimtex-cmd-toggle-break)
+        \ :<c-u>call <sid>operator_setup('toggle_break')<bar>normal! g@l<cr>
 endfunction
 
 " }}}1
@@ -265,6 +268,25 @@ function! vimtex#cmd#toggle_frac_visual() abort " {{{1
   call setreg('a', l:frac.text_toggled)
   normal! gv"ap
   call setreg('a', l:save_reg)
+endfunction
+
+" }}}1
+function! vimtex#cmd#toggle_break() abort " {{{1
+  let l:lnum = line('.')
+  let l:line = getline(l:lnum)
+  let l:len = col('$') - 1
+
+  if l:len >= 3 && strpart(l:line, l:len - 3) == ' \\'
+    call setline(l:lnum, 
+          \ strpart(l:line, 0, l:len - 3))
+  elseif l:len >= 2 && strpart(l:line, l:len - 2) == '\\'
+    call setline(l:lnum, 
+          \ strpart(l:line, 0, l:len - 2))
+  else
+    call setline(l:lnum, 
+          \ l:line
+          \ . ' \\')
+  endif
 endfunction
 
 " }}}1
@@ -609,6 +631,7 @@ function! s:operator_function(_) abort " {{{1
         \   'delete': 'delete()',
         \   'toggle_star': 'toggle_star()',
         \   'toggle_frac': 'toggle_frac()',
+        \   'toggle_break': 'toggle_break()',
         \ }[s:operator]
 endfunction
 

--- a/autoload/vimtex/cmd.vim
+++ b/autoload/vimtex/cmd.vim
@@ -274,19 +274,12 @@ endfunction
 function! vimtex#cmd#toggle_break() abort " {{{1
   let l:lnum = line('.')
   let l:line = getline(l:lnum)
-  let l:len = col('$') - 1
 
-  if l:len >= 3 && strpart(l:line, l:len - 3) == ' \\'
-    call setline(l:lnum, 
-          \ strpart(l:line, 0, l:len - 3))
-  elseif l:len >= 2 && strpart(l:line, l:len - 2) == '\\'
-    call setline(l:lnum, 
-          \ strpart(l:line, 0, l:len - 2))
-  else
-    call setline(l:lnum, 
-          \ l:line
-          \ . ' \\')
-  endif
+  let l:replace = l:line =~# '\s*\\\\\s*$'
+        \ ? substitute(l:line, '\s*\\\\\s*$', '', '')
+        \ : substitute(l:line, '\s*$', ' \\\\', '')
+
+  call setline(l:lnum, l:replace)
 endfunction
 
 " }}}1

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -197,6 +197,7 @@ FEATURE OVERVIEW                                              *vimtex-features*
   - Toggle inline and displaymath with `ts$`
   - Toggle between e.g. `()` and `\left(\right)` with `tsd`/`tsD`
   - Toggle (inline) fractions with `tsf`
+  - Toggle line end `\\` with `tsb`
   - Close the current environment/delimiter in insert mode with `]]`
   - Add `\left ... \right)` modifiers to surrounding delimiters with `<F8>`
   - Insert new command with `<F7>`
@@ -870,6 +871,7 @@ This feature is explained in more detail later, see |vimtex-imaps|.
    tsc              |<plug>(vimtex-cmd-toggle-star)|                `n`
    tse              |<plug>(vimtex-env-toggle-star)|                `n`
    ts$              |<plug>(vimtex-env-toggle-math)|                `n`
+   tsb              |<plug>(vimtex-env-toggle-break)|               `n`
    <F6>             |<plug>(vimtex-env-surround-line)|              `n`
                     |<plug>(vimtex-env-surround-operator)|          `n`
    <F6>             |<plug>(vimtex-env-surround-visual)|            `x`
@@ -3739,6 +3741,9 @@ MAP DEFINITIONS                                               *vimtex-mappings*
                                  \]
 <
   One may change the toggle sequence with |g:vimtex_env_toggle_math_map|.
+
+*<plug>(vimtex-cmd-toggle-break)*
+  Toggle the line break command `\\` at the end of current line.
 
 *<plug>(vimtex-env-surround-line)*
 *<plug>(vimtex-env-surround-operator)*

--- a/test/test-commands/test-toggle-break.vim
+++ b/test/test-commands/test-toggle-break.vim
@@ -1,0 +1,16 @@
+set nocompatible
+set runtimepath^=../..
+filetype plugin on
+
+
+" tsb  /  Toggle line break
+for [s:in, s:out] in [
+      \ ['abc', 'abc \\'],
+      \ ['  a + b = c', '  a + b = c \\'],
+      \ ['abc \\', 'abc'],
+      \ ['abc\\', 'abc'],
+      \]
+  call vimtex#test#keys('tsb', s:in, s:out)
+endfor
+
+call vimtex#test#finished()


### PR DESCRIPTION
Hi, this is a new function that toggles `\\` at line end. In environments like `align`, sometimes the formulas are changed thus the line break is not optimal. One needs `$` or `A` to move to end of line, then either `xx` or `\\`, finally go back to the original position, which can be quite tiring for more than a couple lines.

So wrote this function and map `tsb` to it. If everything looks good will add tests and docs to finalize this request.