### PR TITLE
fix: use sh on path

### DIFF
--- a/autoload/vimtex/jobs/neovim.vim
+++ b/autoload/vimtex/jobs/neovim.vim
@@ -8,7 +8,7 @@ function! vimtex#jobs#neovim#new(cmd) abort " {{{1
   let l:job = deepcopy(s:job)
   let l:job.cmd = has('win32')
         \ ? 'cmd /s /c "' . a:cmd . '"'
-        \ : ['/bin/sh', '-c', a:cmd]
+        \ : ['sh', '-c', a:cmd]
   return l:job
 endfunction
 

--- a/autoload/vimtex/jobs/vim.vim
+++ b/autoload/vimtex/jobs/vim.vim
@@ -8,7 +8,7 @@ function! vimtex#jobs#vim#new(cmd) abort " {{{1
   let l:job = deepcopy(s:job)
   let l:job.cmd = has('win32')
         \ ? 'cmd /s /c "' . a:cmd . '"'
-        \ : ['/bin/sh', '-c', a:cmd]
+        \ : ['sh', '-c', a:cmd]
   return l:job
 endfunction
 


### PR DESCRIPTION
This reverts a change in 2dc2a5435809c13f6f4aa07964be4ef19a7864f5 that I believe is tangential to the issue that the commit addresses. This makes it more consistent with the default value of the `'shell'` option and the rest of the file. Personally, I have a different `sh` on `$PATH` than `/bin/sh` (actually, I do not have `/bin/sh` at all), which is how I noticed the change.

https://github.com/lervag/vimtex/blob/5ac62e0315c6f54f53a7d6da7c485cf8e9cf7240/autoload/vimtex/jobs/neovim.vim#L155-L162

https://github.com/lervag/vimtex/blob/5ac62e0315c6f54f53a7d6da7c485cf8e9cf7240/autoload/vimtex/jobs/vim.vim#L182-L185