### PR TITLE
Added note string suggesting adding full path for vim/nvim executeable in Skim

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -6132,6 +6132,10 @@ Note: Many plugin managers provide mechanisms to lazy load plugins. There is
       no need to use such a mechanism for VimTeX, and in fact, doing it will
       prevent Vim/neovim from loading the `:VimtexInverseSearch` command.
 
+Note: You may need to add the installation prefix for vim/neovim (ie
+      /opt/homebrew/bin) in your chosen PDF viewer if inverse search does not
+      work.
+
 ==============================================================================
 LATEX DOCUMENTATION                                           *vimtex-latexdoc*
 


### PR DESCRIPTION
Hi,
I recently had an issue with the skim synctex integration (detailed in the Skim repository at SourceForge https://sourceforge.net/p/skim-app/bugs/1539/).
The solution was to add the full path to neovim in the skim synctex dialog. I have added a brief note that should help with this. Keen to hear your thoughts!