### PR TITLE
just pick any window for inverse search if there are several

### DIFF
--- a/autoload/vimtex/view.vim
+++ b/autoload/vimtex/view.vim
@@ -106,7 +106,7 @@ function! vimtex#view#inverse_search(line, filename) abort " {{{1
   " * If tab/window exists, switch to it/them
   let l:bufnr = bufnr(l:file)
   try
-    let [l:winid] = win_findbuf(l:bufnr)
+    let [l:winid; _] = win_findbuf(l:bufnr)
     let [l:tabnr, l:winnr] = win_id2tabwin(l:winid)
     execute l:tabnr . 'tabnext'
     execute l:winnr . 'wincmd w'


### PR DESCRIPTION
For some reason I don't understand my `BufReadCmd` makes my files lose syntax highlighting when calling `edit %`. This is triggered by inverse search when I have two windows of the same file open. This avoids it.

I don't 100% understand the code in `vimtex#view#inverse_search` (in particular I don't know what could cause an error in the `try` block), so there might be a downside to doing this.

(sorry, I used the wrong branch in the previous PR)