### PR TITLE
Fix:  Removed includeonly from g:vimtex_include_indicators defaults

### DIFF
--- a/autoload/vimtex/re.vim
+++ b/autoload/vimtex/re.vim
@@ -11,7 +11,7 @@ let g:vimtex#re#tex_input_root =
       \ '\v^\c\s*\%\s*!?\s*tex\s+root\s*[=:]\s*\zs.*\ze\s*$'
 let g:vimtex#re#tex_input_latex = '\v\\%('
       \ . join(get(g:, 'vimtex_include_indicators',
-      \            ['input', 'include', 'includeonly']),
+      \            ['input', 'include']),
       \        '|')
       \ . ')\s*\{'
 let g:vimtex#re#tex_input_import = '\v\\%('

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -2149,7 +2149,7 @@ OPTIONS                                                        *vimtex-options*
   Note: This option is read during initialization of VimTeX, and so it must be
         set early. I.e., it can not be set in `after/ftplugin/tex.vim`.
 
-  Default value: `['input', 'include', 'includeonly']`
+  Default value: `['input', 'include']`
 
 *g:vimtex_include_search_enabled*
   VimTeX sets 'includeexpr' to recognize included files. If a file isn't found


### PR DESCRIPTION
Removed includeonly from g:vimtex_include_indicators defaults as a fix to #3044 .