### PR TITLE
Check for numbers after markers when setting fold level

### DIFF
--- a/autoload/vimtex/fold/markers.vim
+++ b/autoload/vimtex/fold/markers.vim
@@ -34,21 +34,17 @@ endfunction
 
 " }}}1
 function! s:folder.level(line, lnum) abort dict " {{{1
-  let l:start = matchlist(a:line, self.re.start . '\(\d\{0,2}\)')
-  let l:end = matchlist(a:line, self.re.end . '\(\d\{0,2}\)')
+  let l:start = matchlist(a:line, self.re.start .. '\(\d\?\)')
+  let l:end = matchlist(a:line, self.re.end .. '\(\d\?\)')
   if !empty(l:start)
-    if !empty(l:start[1])
-      return '>' . l:start[1]
-    else
-      return 'a1'
-    endif
+    return empty(l:start[1])
+          \ ? 'a1'
+          \ : '>' .. l:start[1]
     let self.opened = 1
   elseif !empty(l:end)
-    if !empty(l:end[1])
-      return '<' . l:end[1]
-    else
-      return 's1'
-    endif
+    return empty(l:end[1])
+          \ ? 's1'
+          \ : '<' .. l:end[1]
     let self.opened = 0
   endif
 endfunction

--- a/autoload/vimtex/fold/markers.vim
+++ b/autoload/vimtex/fold/markers.vim
@@ -34,12 +34,22 @@ endfunction
 
 " }}}1
 function! s:folder.level(line, lnum) abort dict " {{{1
-  if a:line =~# self.re.start
+  let l:start = matchlist(a:line, self.re.start . '\(\d\{0,2}\)')
+  let l:end = matchlist(a:line, self.re.end . '\(\d\{0,2}\)')
+  if !empty(l:start)
+    if !empty(l:start[1])
+      return '>' . l:start[1]
+    else
+      return 'a1'
+    endif
     let self.opened = 1
-    return 'a1'
-  elseif a:line =~# self.re.end
+  elseif !empty(l:end)
+    if !empty(l:end[1])
+      return '<' . l:end[1]
+    else
+      return 's1'
+    endif
     let self.opened = 0
-    return 's1'
   endif
 endfunction
 


### PR DESCRIPTION
# The Problem

Vim's built-in capability for folding code using markers (at least if one is using the default markers, as the Vim documentation recommends) is unsatisfactory when editing LaTeX documents, because it is not so unlikely that a line of LaTeX code will contain three closing braces and be misconstrued by Vim as the end of a fold. VimTeX's folding mechanism improves on this situation by only recognizing markers in comments (although if one uses the default markers, even this can sometimes have unexpected results, as dicussed in e.g. #1502 and #1515). However, VimTeX's folding mechanism falls short compared to Vim's in that VimTeX does not recognize numbers after markers, which are used in Vim to manually specify the fold level.

This difference between VimTeX's folding and Vim's native folding can have not only unexpected but also unfortunate consequences. I've uploaded an [example file](https://github.com/user-attachments/files/18050374/example.sty.txt) with various nested folds (It is supposed to imitate a personal `sty` file, although please note I had to upload it as a `txt` file, since GitHub wouldn't accept a `tex` file. Also, disclaimer: I don't necessarily endorse the folds in the example file with respect to style/organization; I just wanted to make sure there was some good nesting in there. :)) Here's how the file looks at first glance with Vim's built-in folding:
<img width="1470" alt="default_fold" src="https://github.com/user-attachments/assets/1a491455-9dcd-4b1f-8165-b1133c7c1919">
But here's how it looks with VimTeX's folding:
<img width="1470" alt="vimtex_current_fold" src="https://github.com/user-attachments/assets/3da95577-f1f7-4c1f-ab24-2962b15dbdee">
Because Vim allows you to manually specify the fold level, not every opening marker needs to be followed by a closing marker (which is nice, because it's less messy). My general policy, for example, is that I only add a closing marker when I want there to be white space visible after the fold. The result, in this file, is that no opening marker of fold level 1 is followed by a closing marker (except at the end of the document; that way, you can add things to the end of the document outside of the last fold), but every opening marker of fold level greater than 1 is followed by a corresponding closing fold marker. (I think you follow this sort of style in many, though not all, of your VimTeX source files). What happens, then, because VimTeX doesn't recognize the numbers following the fold markers, is that the fold level increases for each `{{{1`, without there being a closing marker to decrease the fold level again. So the fold level gets bigger and bigger, and everything gets subsumed under 'Options'.

# A Solution

Essentially, my code just looks for a number after the marker specified by the user (or the default marker) by appending a capture group to the existing regexes and using `matchlist` to get the number. If there is a number, the the `level` function returns e.g. '>2' if the marker is an opening marker, and e.g. '<2' if the marker is a closing marker. So we get the expected, Vim-like behavior, and VimTeX users can specify the `g:vimtex_fold_types.markers` option in the way that they always have. Here's how it looks at first glance:
<img width="1470" alt="vimtex_pr_fold" src="https://github.com/user-attachments/assets/03bb6d5a-624b-4c79-91be-c7be05dbad75">

# The `foldtext`

I personally feel dissatisfied with VimTeX's `foldtext` for markers. The markers themselves don't mean anything, so they shouldn't be part of the text, and there's also no way to see what level each fold is. I considered including an alternative `foldtext` in my PR, but then I decided I was getting myself involved in matters of taste... Others, including you, may well like the text returned by the current `foldtext`. And people like me, if they want e.g. the default Vim `foldtext`, can very easily get it like so:
```
" Make sure the g:vimtex_fold_types.markers dict is defined!
let g:vimtex_fold_types = {'markers': {}}

function! g:vimtex_fold_types.markers.text(line, level) abort dict
  return foldtext()
endfunction
```
The only recommendation I *might* make would be to inform people in the documentation that they can specify their own `foldtext` by adding a funcref to the appropriate dictionary in their `g:vimtex_fold_types` configuration, as above. Someone could only figure this out by reading the code (or reading this post, I suppose). *If* you want to add that tip to the documentation (I can see reasons not to), I would be happy to write something and submit it as a separate PR, if that would save you some time.

I appreciate all of your work on VimTeX, and I hope this code can be helpful. Thank you!
