### PR TITLE
Use caching for foldlevels to improve fold calculation performance

### DIFF
--- a/autoload/vimtex/fold.vim
+++ b/autoload/vimtex/fold.vim
@@ -5,6 +5,9 @@
 "
 
 function! vimtex#fold#init_buffer() abort
+  let b:__vimtex_fold_lasttick = -1
+  let b:__vimtex_fold_cache = []
+
   if !g:vimtex_fold_enabled
         \ || s:foldmethod_in_modeline() | return | endif
 
@@ -12,9 +15,6 @@ function! vimtex#fold#init_buffer() abort
   setlocal foldmethod=expr
   setlocal foldexpr=vimtex#fold#level(v:lnum)
   setlocal foldtext=vimtex#fold#text()
-
-  let b:__vimtex_fold_lasttick = -1
-  let b:__vimtex_fold_cache = []
 
   if g:vimtex_fold_manual
     " Remap zx to refresh fold levels


### PR DESCRIPTION
Should resolve #3049.

One thing, though: How can I properly test that this indeed performs better than before?

@Konfekt Do you have any suggestion for how to more precisely test performance for folding?