### PR TITLE
Update docs to explain customization of `foldtext`

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1810,6 +1810,32 @@ OPTIONS                                                        *vimtex-options*
   can be configured with a list of patterns or similar, the patterns assume
   that one uses very magic regexes (see |\v|).
 
+  One may also customize the text that is displayed in a closed fold of a
+  given type by setting the `text` key to a |Funcref| (see |fold-foldtext| and
+  |Dictionary-function|). The function that the |Funcref| refers to takes two
+  arguments, the text of the current line and the fold level of the current
+  line, and it returns the text that will be displayed in a closed fold. For
+  example, the following configuration will set the text for a closed marker
+  fold to Vim's default: >vim
+
+    let g:vimtex_fold_types = {
+          \ 'markers' : {},
+          \}
+
+    function! g:vimtex_fold_types.markers.text(line, level) abort dict
+      return foldtext()
+    endfunction
+<
+  (Note that the |g:vimtex_fold_types| `marker` dictionary must be
+  initialized, even if you are not setting custom markers!)
+
+  Using a |literal-Dict| and a |lambda|, one could specify the same
+  configuration more concisely: >vim
+
+    let g:vimtex_fold_types = #{
+          \ markers : #{text : {line, level -> foldtext()}}
+          \}
+<
   Each entry in |g:vimtex_fold_types| is combined with the corresponding entry
   of |g:vimtex_fold_types_defaults|. If there are conflicting entries, then
   |g:vimtex_fold_types| take precedence. This way, it is easy to customize

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1836,6 +1836,16 @@ OPTIONS                                                        *vimtex-options*
           \ markers : #{text : {line, level -> foldtext()}}
           \}
 <
+  And for completeness, the following would work with a Lua based config: >lua
+
+    vim.g.vimtex_fold_types = {
+      markers = {
+        text = function(line, level)
+          return vim.fn.foldtext()
+        end
+      }
+    }
+<
   Each entry in |g:vimtex_fold_types| is combined with the corresponding entry
   of |g:vimtex_fold_types_defaults|. If there are conflicting entries, then
   |g:vimtex_fold_types| take precedence. This way, it is easy to customize


### PR DESCRIPTION
As promised in #3052, here is a draft explaining how to customize the text displayed when folds are closed. For readers who are less familiar with dictionary functions, I included both the more verbose and the more concise variants we discussed (with appropriate references to Vim's documentation). I expect there are changes you'll want to make, but I hope this is a good starting point!