### PR TITLE
Switch the default texdoc server from http://texdoc.net to http://texdoc.org

### DIFF
--- a/autoload/vimtex/doc.vim
+++ b/autoload/vimtex/doc.vim
@@ -264,7 +264,7 @@ function! s:packages_open(context) abort " {{{1
   call vimtex#doc#make_selection(a:context)
   if empty(a:context.selected) | return 0 | endif
 
-  call vimtex#util#www('http://texdoc.net/pkg/' . a:context.selected)
+  call vimtex#util#www('http://texdoc.org/pkg/' . a:context.selected)
   redraw!
 endfunction
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -4855,7 +4855,7 @@ Note: The |fold-expr| method of folding is well known to be slow, e.g. for
 In order to get slightly cleaner fold text, I recommend setting the global
 'fillchars' option to a single space for folds: >vim
 
-  set fillchars=fold:\
+  set fillchars=fold:\ 
 
 Note: Remember to include the whitespace after backslash!
 

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1682,7 +1682,7 @@ OPTIONS                                                        *vimtex-options*
 
     `'vimtex#doc#handler#texdoc'`  Open documentation with local `texdoc`.
     Fallback                     Open documentation online through
-                                 http://texdoc.net/pkg/packagename.
+                                 http://texdoc.org/pkg/packagename.
 
   To use the local `texdoc`, set: >vim
 
@@ -4855,7 +4855,7 @@ Note: The |fold-expr| method of folding is well known to be slow, e.g. for
 In order to get slightly cleaner fold text, I recommend setting the global
 'fillchars' option to a single space for folds: >vim
 
-  set fillchars=fold:\ 
+  set fillchars=fold:\
 
 Note: Remember to include the whitespace after backslash!
 
@@ -5526,7 +5526,7 @@ LATEXRUN                                             *vimtex-compiler-latexrun*
 
                                         https://github.com/aclements/latexrun
 > See LaTeX run. Run latexrun.
-> 
+>
 > latexrun fits LaTeX into a modern build environment. It hides LaTeX's
 > circular dependencies, surfaces errors in a standard and user-friendly
 > format, and generally enables other tools to do what they do best.
@@ -6244,7 +6244,7 @@ VimTeX provides the command |:VimtexDocPackage| to open documentation for
 packages and documentclasses. The command is mapped to `K` by default.
 
 For simplicity, the standard method provided by VimTeX is to look up
-documentation online through http://texdoc.net/. However, this can be
+documentation online through http://texdoc.org/. However, this can be
 customized with the option |g:vimtex_doc_handlers|. The option allows much
 flexibility for advanced users. For users that want to use a local `texdoc`
 installation as the main method, they may use the following config: >vim


### PR DESCRIPTION
At least for me, http://texdoc.net is down for quite a white. So, this PR replaces it with http://texdoc.org.