### PR TITLE
Fix: indent comments and `verbatim` envs correctly

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -44,7 +44,7 @@ function! VimtexIndent(lnum) abort " {{{1
 
   let [l:prev_lnum, l:prev_line] = s:get_prev_lnum(prevnonblank(a:lnum - 1))
   if l:prev_lnum == 0 | return indent(a:lnum) | endif
-  let l:line = s:clean_line(getline(a:lnum))
+  let l:line = getline(a:lnum)
 
   " Check for verbatim modes
   if s:in_verbatim(a:lnum)
@@ -55,6 +55,9 @@ function! VimtexIndent(lnum) abort " {{{1
   if l:line =~# '^\s*%'
     return indent(a:lnum)
   endif
+
+  " Remove comments before subsequent checks
+  let l:line = s:clean_line(l:line)
 
   " Align on ampersands
   let l:ind = s:indent_amps.check(a:lnum, l:line, l:prev_lnum, l:prev_line)

--- a/test/test-indentation/test_tikz_reference.tex
+++ b/test/test-indentation/test_tikz_reference.tex
@@ -10,16 +10,16 @@ about something.
 \begin{tikzpicture}
   \draw [solid] let \p{I} = (0,0) in (1,1) -|
     (\x{I}-1cm,-1cm) node [yshift=-.25cm] {(i)};
-  % Just some comment
+     % Just some comment
 \end{tikzpicture}
 
 \begin{tikzpicture}
-  % (i) center contact head
+% (i) center contact head
   \draw [solid] let \p{I} = (centerContactHead) in (centerContactHead) -|
     (\x{I}-.75cm,-2.5)
     node [yshift=-.25cm] {(i)};
 
-  % (ii) outer conductor of the contact head
+% (ii) outer conductor of the contact head
   \coordinate (outerContactHead) at (.8,-1.7);
   \draw [solid] let \p{O} = (outerContactHead)
     in (outerContactHead) -- (\x{O},-2.5)


### PR DESCRIPTION
# A Side Effect

Before `VimtexIndent()` returns the number of spaces by which the current line ought to be indented, it strips comments from the line using `s:clean_line()`. This is necessary for proper indentation on the basis of environments, delimiters, and so on, because we don't want indentation to be influenced by a commented-out `\begin` or `\end` command, a commented-out delimiter, or whatever else.

A side effect of the current implementation is that the conditional expression `if l:line =~# '^\s*%'` (on line 55) is never true. (For good measure, I tested this on `csquotes.sty`, which is 2499 lines long and contains a lot of commented lines. I put an `echomsg` within the conditional and used `gg=G`, and no message was printed.) Because comments are removed before that point (at line 47), for any line that begins with a `%`, `l:line` is empty. As a result, commented lines sometimes do not use the indentation of the previous line, which the comment at line 54 indicates is the intended behavior.

# Affected Use Cases

Generally, this quirk in the code is not consequential. I had never noticed it until recently, and even then I thought it was the intended behavior, until I saw the comment on line 54. But one case where the current implementation can be a bummer (and where I first noticed it) is if you are editing a `.dtx` file. Suppose I were to start by inserting the following:

```tex
% Here begins the uninteresting documentation of the uninteresting macro
% \cs{foo}.
%    \begin{macrocode}
\NewDocumentCommand{\foo}{m}{%
%    \end{macrocode}
```

Suppose also I have `formatoptions` `o` and/or `r` set. If I have my cursor at the end of the last line of the above code, and I press `o` in normal mode or `<Return>` in insert mode, then the following occurs:

```tex
% Here begins the uninteresting documentation of the uninteresting macro
% \cs{foo}.
%    \begin{macrocode}
\NewDocumentCommand{\foo}{m}{%
%    \end{macrocode}
  %
```

This is initially an inconvenience because you have to manually realign the comment character with the start of the line. But, alas, the real bummer begins once you've swallowed the minor inconvenience and keep going. If ever after you press `o` in normal mode or `<Return>` in insert mode, the comment character will again be indented as above. Worse (or, at least, more unpredictable) is if you insert an `indentkeys` character like `}`. Suppose I've realigned the comment character in the above code and I continue editing like so:

```tex
% Here begins the uninteresting documentation of the uninteresting macro
% \cs{foo}.
%    \begin{macrocode}
\NewDocumentCommand{\foo}{m}{%
%    \end{macrocode}
%    Let me tell you something about the macro \cs{foo
```

As soon as you insert `}`, this happens:

```tex
% Here begins the uninteresting documentation of the uninteresting macro
% \cs{foo}.
%    \begin{macrocode}
\NewDocumentCommand{\foo}{m}{%
%    \end{macrocode}
  %    Let me tell you something about the macro \cs{foo}
```

(Note: for this example to work, you need to have returned to normal mode at some point. If, for example, you realign the comment character by pressing `CTRL-D` in insert mode, `indentkeys` respects your manual indentation. But if you do something more labor-intensive like using `<<` to realign the comment character in normal mode, or you exit insert mode for some other reason after using `CTRL-D`, the above behavior will occur).

The cause is simply that, because the commented lines are considered to be empty, they are indented by one `shiftwidth` after the opening brace at the end of `\NewDocumentCommand` like normal, rather than just inheriting the indent of the previous line, as intended. Every time we press `o` in normal mode or `<Return>` in insert mode, or we insert an `indentkeys` character, the line will be (re)indented to one `shiftwidth`. And as long as the lines continued to be commented, the indent is never changed. So the current implementation does make it rather inconvenient to edit `.dtx` files.

It should be noted (at the risk of obsessively documenting the issue ...) that the bug affects indentation in `verbatim` environments as well, although I doubt anyone is at much risk of being inconvenienced by it. Suppose I were to start typing the following:

```tex
\begin{verbatim}
  % For some reason, starting with an indented comment
```

Again, if I have the `o` and/or `r` options turned on, and I press `o` in normal mode or `<Return>` in insert mode, the following occurs:

```tex
\begin{verbatim}
  % For some reason, starting with an indented comment
%
```

The cause is that the last line is considered to be a blank line, and therefore it receives the indentation of the 'previous' line, which in a `verbatim` environment is considered to be the line that begins the environment. In the code above, that indentation is zero.

Usually, a new line in a `verbatim` environment is given the indent of the (actual) previous line after `o` in normal mode or `<Return>` in insert mode, so this behavior is unique to commented lines. Because there is no distinction between comments and code in a `verbatim` environment, I figured that there should be no difference in how they are indented in a `verbatim` environment, so this PR 'fixes' (at least according to that reasoning) indentation in `verbatim` environments as well.

# Suggested Fix

Despite the verbosity of the foregoing discussion (sorry), my suggested fix is simple. We can start by setting `l:line` to `getline(a:lnum)`, and then set `l:line` to `s:clean_line(l:line)` after we've checked for `verbatim` environments and commented lines. I think this is organized and readable, and it guarantees that everything other than `verbatim` environments and commented lines will be indented in the expected way.

Because this PR affects how comments are indented, it causes the `tikz` indentation test to fail. If you want to accept the PR, we would have to alter the reference file -- but I haven't touched that in this PR because I don't know what your workflow is for altering tests. If you end up wanting to approve the PR, let me know how you'd like me to proceed.

(Also, novice contributor note: I reasoned that, if I had a fix in mind, it would be more helpful to suggest the fix rather than opening a bug report and saying 'fix this please'. If I got it wrong, let me know!)

Thanks for your work, as always, and I hope this is helpful!