### PR TITLE
fix: allow lambdas and Lua functions as doc handlers

### DIFF
--- a/autoload/vimtex/doc.vim
+++ b/autoload/vimtex/doc.vim
@@ -32,9 +32,9 @@ function! vimtex#doc#package(word) abort " {{{1
   let l:context = vimtex#doc#get_context(a:word)
   if empty(l:context) | return | endif
 
-  for l:handler in g:vimtex_doc_handlers
+  for l:Handler in g:vimtex_doc_handlers
     try
-      if call(l:handler, [l:context]) | return | endif
+      if call(l:Handler, [l:context]) | return | endif
     catch /E117/
     endtry
   endfor


### PR DESCRIPTION
When `g:vimtex_doc_handlers` holds a lambda expression or bare Lua function, the iterator itself will become a Funcref. To avoid E704, this Funcref variable name must start with a capital letter.

In practice, this means one can directly pass in a Lua function:

```lua
vim.g.vimtex_doc_handlers = { MyVimtexDocHandler }
```

Instead of having to create a Vim wrapper function, which can be `call()`ed directly by its name:

```vim
function! MyVimtexDocHandler(context)
  return v:lua.MyVimtexDocHandler(a:context)
endfunction

let g:vimtex_doc_handlers = ['MyVimtexDocHandler']
```