### PR TITLE
doc: clean up unused session link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ filetype and syntax plugin for LaTeX files.
   - [Snippets and templates](#snippets-and-templates)
   - [Tag navigation](#tag-navigation)
 - [Alternatives](#alternatives)
-- [VimTeX on the Web](#vimtex-on-the-web)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
Remove the "VimTeX on the web" section link from README.md, as its content was previously deleted in [commit 1b4df78](https://github.com/lervag/vimtex/commit/1b4df785a530b7704d081972e438b5678a6d111c). This helps clean up dead anchors in the document and avoids confusion for users browsing the README.