### PR TITLE
Parse options for document class and packages

### DIFF
--- a/test/test-state/test_parse_documentclass_options.tex
+++ b/test/test-state/test_parse_documentclass_options.tex
@@ -1,0 +1,34 @@
+% Leading comments here
+
+\documentclass[% Options of scrbook
+  %
+  % draft,
+  fontsize=12pt,
+  % smallheadings,
+  headings=big,
+  english,
+  paper=a4,
+  twoside,
+  open=right,
+  DIV=14,
+  BCOR=20mm,
+  headinclude=false,
+  footinclude=false,
+  mpinclude=false,
+  % pagesize,
+  titlepage,
+  parskip=half,
+  headsepline,
+  chapterprefix=false,
+  appendixprefix=Appendix,
+  appendixwithprefixline=true,
+  bibliography=totoc,
+  toc=graduated,
+  numbers=noenddot,
+]{scrbook}
+
+\begin{document}
+
+Hello, world!
+
+\end{document}

--- a/test/test-state/test_parse_documentclass_options.vim
+++ b/test/test-state/test_parse_documentclass_options.vim
@@ -1,0 +1,39 @@
+set nocompatible
+set runtimepath^=../..
+filetype plugin on
+
+nnoremap q :qall!<cr>
+
+call vimtex#log#set_silent()
+
+silent edit test_parse_documentclass_options.tex
+
+if empty($INMAKE) | finish | endif
+
+call assert_equal('scrbook', b:vimtex.documentclass)
+
+let s:options = {
+      \  'fontsize': '12pt',
+      \  'headings': 'big',
+      \  'english': v:true,
+      \  'paper': 'a4',
+      \  'twoside': v:true,
+      \  'open': 'right',
+      \  'DIV': '14',
+      \  'BCOR': '20mm',
+      \  'headinclude': v:false,
+      \  'footinclude': v:false,
+      \  'mpinclude': v:false,
+      \  'titlepage': v:true,
+      \  'parskip': 'half',
+      \  'headsepline': v:true,
+      \  'chapterprefix': v:false,
+      \  'appendixprefix': 'Appendix',
+      \  'appendixwithprefixline': v:true,
+      \  'bibliography': 'totoc',
+      \  'toc': 'graduated',
+      \  'numbers': 'noenddot',
+      \ }
+call assert_equal(s:options, b:vimtex.documentclass_options)
+
+call vimtex#test#finished()

--- a/test/test-state/test_parse_package_options.tex
+++ b/test/test-state/test_parse_package_options.tex
@@ -1,0 +1,34 @@
+\RequirePackage[debrief]{silence}
+\documentclass{article}
+
+\usepackage[main=german,english]{babel}
+
+\usepackage[acronyms]{glossaries}
+\usepackage[record,style=long]{glossaries-extra}
+
+\usepackage[% comment
+  backend=biber,
+  style=numeric-comp,
+  maxcitenames=99,
+  % doi=false, % commented option
+  url=false,
+  giveninits=true,
+]{biblatex}
+
+\usepackage[notes, useibid]{biblatex-chicago} % with space
+
+% Issue in VimTeX 2.16 from January 2025:
+% Following multi-line syntax of \usepackage is not detected.
+\usepackage{
+  amsmath,
+  tikz
+}
+
+% Invalid syntax but parsed anyway
+\usepackage[draft]{package1, package2} % packages with a shared option
+
+\begin{document}
+
+Hello, world!
+
+\end{document}

--- a/test/test-state/test_parse_package_options.vim
+++ b/test/test-state/test_parse_package_options.vim
@@ -1,0 +1,33 @@
+set nocompatible
+set runtimepath^=../..
+filetype plugin on
+
+nnoremap q :qall!<cr>
+
+call vimtex#log#set_silent()
+
+silent edit test_parse_package_options.tex
+
+if empty($INMAKE) | finish | endif
+
+let s:packages = {
+      \ 'glossaries-extra': {'style': 'long', 'record': v:true},
+      \ 'biblatex': {
+      \    'backend': 'biber',
+      \    'url': v:false,
+      \    'giveninits': v:true,
+      \    'style': 'numeric-comp',
+      \    'maxcitenames': '99'
+      \ },
+      \ 'glossaries': {'acronyms': v:true},
+      \ 'tikz': {},
+      \ 'babel' : {'main': 'german', 'english': v:true},
+      \ 'silence': {'debrief': v:true},
+      \ 'package1': {'draft': v:true},
+      \ 'biblatex-chicago': {'notes': v:true, 'useibid': v:true},
+      \ 'amsmath': {},
+      \ 'package2': {'draft': v:true}
+      \ }
+call assert_equal(s:packages, b:vimtex.packages)
+
+call vimtex#test#finished()


### PR DESCRIPTION
This fixes also an issue for following multi-line notation

```tex
\usepackage{
  amsmath,
  tikz
}
```

Related issues, discussions and PRs:

- https://github.com/lervag/vimtex/issues/3180
- https://github.com/lervag/vimtex/pull/3175 (refers to question 2 in the first comment)
- https://github.com/lervag/vimtex/discussions/3178 (now you can take options into account)