### PR TITLE
fix: E688 with option with empty value

### DIFF
--- a/autoload/vimtex/state/class.vim
+++ b/autoload/vimtex/state/class.vim
@@ -328,7 +328,7 @@ function! s:parse_optionlist(string) abort " {{{1
       continue
     elseif l:element =~# '='
       " Key-value option
-      let [l:key, l:value] = map(split(l:element, '='), {_, x -> trim(x)})
+      let [l:key, l:value] = map(split(l:element, '=', 1), {_, x -> trim(x)})
 
       if l:value ==? 'true'
         let l:options[l:key] = v:true


### PR DESCRIPTION
Problem:
If a file contains a line like this
```
\usepackage[key=]{package}
```
option parsing raises E688: More targets than List items.

Solution:
Use {keepempty} argument.