### PR TITLE
Fix indentation for comments

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -53,7 +53,7 @@ function! VimtexIndent(lnum) abort " {{{1
 
   " Use previous indentation for comments
   if l:line =~# '^\s*%'
-    return indent(a:lnum)
+    return indent(l:prev_lnum)
   endif
 
   " Remove comments before subsequent checks

--- a/test/test-indentation/test_tikz_reference.tex
+++ b/test/test-indentation/test_tikz_reference.tex
@@ -19,7 +19,7 @@ about something.
     (\x{I}-.75cm,-2.5)
     node [yshift=-.25cm] {(i)};
 
-% (ii) outer conductor of the contact head
+    % (ii) outer conductor of the contact head
   \coordinate (outerContactHead) at (.8,-1.7);
   \draw [solid] let \p{O} = (outerContactHead)
     in (outerContactHead) -- (\x{O},-2.5)

--- a/test/test-indentation/test_tikz_reference.tex
+++ b/test/test-indentation/test_tikz_reference.tex
@@ -10,7 +10,7 @@ about something.
 \begin{tikzpicture}
   \draw [solid] let \p{I} = (0,0) in (1,1) -|
     (\x{I}-1cm,-1cm) node [yshift=-.25cm] {(i)};
-     % Just some comment
+    % Just some comment
 \end{tikzpicture}
 
 \begin{tikzpicture}


### PR DESCRIPTION
As indicated by this [comment](https://github.com/lervag/vimtex/blob/7f2633027c8f496a85284de0c11aa32f1e07e049/indent/tex.vim#L54) the intent is to apply the indent of the preceding line, not the current.

Without this patch, the code
```tex
        \begin{equation}
                  a = b \\
                  % comment
                  c = d
        \end{equation}
```
Gets indented (for example with `vie=`) to
```tex
        \begin{equation}
          a = b \\
                  % comment
          c = d
        \end{equation}
```

With the patch I get

```tex
        \begin{equation}
          a = b \\
          % comment
          c = d
        \end{equation}
```