### PR TITLE
Fix: 'a'-kind textobjs never operated linewise

### DIFF
--- a/autoload/vimtex/text_obj.vim
+++ b/autoload/vimtex/text_obj.vim
@@ -327,7 +327,7 @@ function! s:get_sel_delimited(open, close, is_inner) abort " {{{1
         \ 'pos_start' : [l1, c1],
         \ 'pos_end' : [l2, c2],
         \ 'is_inline' : l:is_inline,
-        \ 'select_mode' : l:is_inline && l:linewise
+        \ 'select_mode' : l:linewise
         \      ? 'V' : (v:operator ==# ':') ? visualmode() : 'v',
         \}
 endfunction

--- a/test/test-textobj/test-envs.vim
+++ b/test/test-textobj/test-envs.vim
@@ -58,7 +58,6 @@ call vimtex#test#keys('4j$d2ae',
       \ ],
       \ [
       \   '\begin{document}',
-      \   '  ',
       \   '\end{document}',
       \ ])
 


### PR DESCRIPTION
The intention in
https://github.com/lervag/vimtex/issues/365#issuecomment-193966866 is that non-inline regions should be linewise.
So I don't know why `l:is_inline` is a requirement on top of `l:linewise`