### PR TITLE
add support for plural versions of \gls in glossaries.vim

### DIFF
--- a/autoload/vimtex/syntax/p/glossaries.vim
+++ b/autoload/vimtex/syntax/p/glossaries.vim
@@ -7,7 +7,7 @@
 scriptencoding utf-8
 
 function! vimtex#syntax#p#glossaries#load(cfg) abort " {{{1
-  syntax match texCmdGls "\v\c\\gls%(desc|link)?>"
+  syntax match texCmdGls "\v\c\\gls%(desc|link|pl)?>"
         \ nextgroup=texGlsArg skipwhite skipnl
   call vimtex#syntax#core#new_arg('texGlsArg', {'contains': '@NoSpell'})
 


### PR DESCRIPTION
Hello, thank you so much for the amazing plugin and the countless hours dedicated to its development.

Following issue #3073 and commit 31250a8, I propose to modify a line in  autoload/vimtex/syntax/p/glossaries.vim to have plural versions of \gls (\glspl, \Glspl, \GLSpl) also supported for the spell check disabling inside the \gls argument.

Best regards.