### PR TITLE
make `toggle_math` star aware

### DIFF
--- a/autoload/vimtex/env.vim
+++ b/autoload/vimtex/env.vim
@@ -366,7 +366,8 @@ function! vimtex#env#toggle_math() abort
   let l:current = get(l:open, 'name', l:open.match)
   let l:target = get(g:vimtex_env_toggle_math_map, l:current, '$')
 
-  call vimtex#env#change(l:open, l:close, l:target)
+  call vimtex#env#change(l:open, l:close, 
+        \ get(l:open, 'starred', 0) ? l:target . '*' : l:target)
 endfunction
 
 

--- a/test/test-env/test-toggle-math.tex
+++ b/test/test-env/test-toggle-math.tex
@@ -14,6 +14,10 @@ Hello
   1+1=2
 \end{equation}
 
+\begin{equation*}
+  1+1=2
+\end{equation*}
+
 World
 
 \begin{equation}

--- a/test/test-env/test-toggle-math.vim
+++ b/test/test-env/test-toggle-math.vim
@@ -7,7 +7,7 @@ nnoremap q :qall!<cr>
 
 silent edit test-toggle-math.tex
 
-normal! 20G
+normal! 24G
 call vimtex#env#toggle_math()
 call assert_equal([
       \ 'World',
@@ -15,7 +15,7 @@ call assert_equal([
       \ '$f(x) = 1 + e^x$',
       \ '',
       \ '\end{document}',
-      \], getline(17, 21))
+      \], getline(21, 25))
 
 normal! 7G
 call vimtex#env#toggle_math()
@@ -23,5 +23,25 @@ call assert_equal([
       \ '  This is the proof of Theorem 1. $1+1=2$',
       \ '\end{proof}',
       \], getline(5, 6))
+
+let g:vimtex_env_toggle_math_map = {
+      \ 'equation': 'align',
+      \}
+
+normal! 11G
+call vimtex#env#toggle_math()
+call assert_equal([
+      \ '\begin{align}',
+      \ '  1+1=2',
+      \ '\end{align}',
+      \], getline(10, 12))
+
+normal! 15G
+call vimtex#env#toggle_math()
+call assert_equal([
+      \ '\begin{align*}',
+      \ '  1+1=2',
+      \ '\end{align*}',
+      \], getline(14, 16))
 
 call vimtex#test#finished()


### PR DESCRIPTION
Hi, instead of the default `vimtex_env_toggle_math_map` I generally use this to toggle between `equation`, `align`, `multline`, etc. One disadvantage is that the current implementation will always use the no-star version after the toggle. Here is a few changes to make it `*` aware along with a couple tests. Please let me know if everything looks good, thanks.