### PR TITLE
doc: Hint about using the full path to vim in Skim settings on OS X

### DIFF
--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -6079,6 +6079,11 @@ may use the `MacVim` preset. However, it may be more convenient to use a
 
   nvim --headless -c "VimtexInverseSearch %line '%file'"
 
+Depending on your system configuration, it may be necessary to specify the 
+full path to the Vim binary, e.g. if Neovim was installed via homebrew, one
+can specify Command = /opt/homebrew/bin/nvim and 
+Arguments = --headless -c "VimtexInverseSearch %line '%file'" in the Skim
+settings panel.
 Inverse search is activated by pressing `Shift` and `Command`, then clicking
 the text you want to search. For more info on inverse search, see
 |vimtex-synctex-inverse-search|.


### PR DESCRIPTION
Maybe obvious, but I spent an embarrassing amount of time debugging this issue in a new OS X configuration :)
Feel free to reformat/close as necessary!