### PR TITLE
feat(latexmk): allow passing a list to executable

### DIFF
--- a/autoload/vimtex/compiler/_template.vim
+++ b/autoload/vimtex/compiler/_template.vim
@@ -62,6 +62,42 @@ function! s:compiler.__check_requirements() abort dict " {{{1
 endfunction
 
 " }}}1
+
+function! s:compiler._get_executable_string() abort dict " {{{1
+  "
+  " Convert executable (string or list) to a command string
+  "
+  " The executable property can be:
+  "   - A string: 'latexmk'
+  "   - A list: ['docker', 'exec', 'my-container', 'latexmk']
+  "
+  if type(self.executable) == v:t_string
+    return self.executable
+  elseif type(self.executable) == v:t_list
+    return join(self.executable)
+  else
+    throw 'VimTeX: executable must be a string or list'
+  endif
+endfunction
+
+" }}}1
+
+function! s:compiler._is_executable_available() abort dict " {{{1
+  "
+  " Check if the executable is available
+  "
+  " For string executables, check directly.
+  " For list executables, check only the first element.
+  "
+  if type(self.executable) == v:t_string
+    return executable(self.executable)
+  elseif type(self.executable) == v:t_list && !empty(self.executable)
+    return executable(self.executable[0])
+  endif
+  return v:false
+endfunction
+
+" }}}1
 function! s:compiler.__init() abort dict " {{{1
 endfunction
 

--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -102,8 +102,11 @@ let s:compiler = vimtex#compiler#_template#new({
       \})
 
 function! s:compiler.__check_requirements() abort dict " {{{1
-  if !executable(self.executable)
-    call vimtex#log#warning(self.executable . ' is not executable')
+  if !self._is_executable_available()
+    let l:exe = type(self.executable) == v:t_list
+          \ ? self.executable[0]
+          \ : self.executable
+    call vimtex#log#warning(l:exe . ' is not executable')
     let self.enabled = v:false
   endif
 endfunction
@@ -135,7 +138,7 @@ endfunction
 function! s:compiler.__build_cmd(passed_options) abort dict " {{{1
   let l:cmd = (has('win32')
         \ ? 'set max_print_line=2000 & '
-        \ : 'max_print_line=2000 ') . self.executable
+        \ : 'max_print_line=2000 ') . self._get_executable_string()
 
   let l:cmd .= ' ' . join(self.options) . a:passed_options
   let l:cmd .= ' ' . self.get_engine()
@@ -227,7 +230,7 @@ endfunction
 function! s:compiler.clean(full) abort dict " {{{1
   call self.__clean_temp_files(a:full)
 
-  let l:cmd = self.executable
+  let l:cmd = self._get_executable_string()
   let l:cmd .= a:full ? ' -C' : ' -c'
 
   if !empty(self.out_dir)

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1110,7 +1110,10 @@ OPTIONS                                                        *vimtex-options*
           are only relevant when this option is enabled.
 
   executable ~
-    The name/path to the `latexmk` executable.
+    The name/path to the `latexmk` executable. Can be a string or a list.
+    If a list is provided, it will be interpreted as a command sequence
+    (e.g., `['docker', 'exec', 'container', 'latexmk']` for running latexmk
+    through a container).
 
   hooks ~
     A list of |Funcref|s. If running in continuous mode, each hook will be

--- a/test/test-compiler/test-executable-list.vim
+++ b/test/test-compiler/test-executable-list.vim
@@ -1,0 +1,38 @@
+set nocompatible
+let &rtp = '../..,' . &rtp
+filetype plugin on
+
+let g:status = 0
+nnoremap q :qall!<cr>
+
+let g:vimtex_compiler_latexmk = {'executable': ['latexmk', '-outdir=build']}
+
+call vimtex#log#set_silent()
+
+augroup test_executable_list
+  autocmd!
+  autocmd User VimtexEventCompileSuccess let g:status = 1
+  autocmd User VimtexEventCompileFailed let g:status = 2
+augroup END
+
+silent edit test-builddir.tex
+
+if empty($INMAKE) | finish | endif
+
+silent VimtexCompileSS
+
+let s:n = 0
+while g:status < 1 && s:n < 100
+  sleep 20m
+  let s:n += 1
+endwhile
+
+call assert_equal(1, g:status)
+
+call assert_true(filereadable('build/test-builddir.pdf'))
+
+silent VimtexClean!
+
+call assert_false(filereadable('build/test-builddir.pdf'))
+
+call vimtex#test#finished()


### PR DESCRIPTION
This PR permits to pass a list to `executable` in latexmk compiler.

Created tests by setting an executable so that I pass a CLI option to pass `-outdir=build` and check that it successfully created the PDF and can also remove it.

Close #3252 