### PR TITLE
Add clean_ext option to `g:vimtex_compiler_latexmk`  

### DIFF
--- a/autoload/vimtex/compiler/latexmk.vim
+++ b/autoload/vimtex/compiler/latexmk.vim
@@ -91,6 +91,7 @@ let s:compiler = vimtex#compiler#_template#new({
       \ 'name' : 'latexmk',
       \ 'aux_dir': '',
       \ 'callback' : 1,
+      \ 'clean_ext': '',
       \ 'continuous': 1,
       \ 'executable' : 'latexmk',
       \ 'options' : [
@@ -228,25 +229,41 @@ endfunction
 " }}}1
 
 function! s:compiler.clean(full) abort dict " {{{1
-  call self.__clean_temp_files(a:full)
+    call self.__clean_temp_files(a:full)
 
-  let l:cmd = self._get_executable_string()
-  let l:cmd .= a:full ? ' -C' : ' -c'
+    let l:cmd = self._get_executable_string()
+    let l:full = a:full ? ' -C' : ' -c'
 
-  if !empty(self.out_dir)
-    let l:cmd .= ' -outdir=' . fnameescape(self.out_dir)
-  endif
-  if !empty(self.aux_dir)
-    let l:cmd .= ' -emulate-aux-dir'
-    let l:cmd .= ' -auxdir=' . fnameescape(self.aux_dir)
-  endif
+    let l:val_found = vimtex#compiler#latexmk#get_rc_opt(
+          \self.file_info.root, 'clean_ext', 0, -1)[1]
+    if !empty('clean_ext') && l:val_found ==-1
+      let l:quote = vimtex#util#get_os() ==# 'Windows' ? '"' : ''''
+      let l:cmd .= join([' -e ',
+            \l:quote,
+            \'$clean_ext = q/',
+            \self.clean_ext,
+            \'/;',
+            \l:quote,
+            \l:full], '')
+    else
+      let l:cmd .= l:full
+    endif
 
-  let l:cmd .= ' ' . vimtex#util#shellescape(self.file_info.target_basename)
+    if !empty(self.out_dir)
+      let l:cmd .= ' -outdir=' . fnameescape(self.out_dir)
+    endif
 
-  call vimtex#jobs#run(l:cmd, {'cwd': self.file_info.root})
-endfunction
+    if !empty(self.aux_dir)
+      let l:cmd .= ' -emulate-aux-dir'
+      let l:cmd .= ' -auxdir=' . fnameescape(self.aux_dir)
+    endif
 
-" }}}1
+    let l:cmd .= ' ' . vimtex#util#shellescape(self.file_info.target_basename)
+
+    call vimtex#jobs#run(l:cmd, {'cwd': self.file_info.root})
+  endfunction
+
+" }}}
 function! s:compiler.get_engine() abort dict " {{{1
   " Parse tex_program from TeX directive
   let l:tex_program_directive = b:vimtex.get_tex_program()

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1026,11 +1026,6 @@ OPTIONS                                                        *vimtex-options*
   Warning: Each resolved path will be deleted with |delete()| with the `"rf"`
            flag!
 
-  Note: For `latexmk`, a similar feature is available with `$clean_ext`; see
-        the documentation https://texdoc.org/serve/latexmk/0.
-
-  Default value: `[]`
-
 *g:vimtex_compiler_latexmk*
   This dictionary allows customization of the |vimtex-compiler-latexmk|
   compiler. The values set by the user will take precedence over the default
@@ -1043,6 +1038,7 @@ OPTIONS                                                        *vimtex-options*
         \ 'out_dir' : '',
         \ 'callback' : 1,
         \ 'continuous' : 1,
+        \ 'clean_ext' : '',
         \ 'executable' : 'latexmk',
         \ 'hooks' : [],
         \ 'options' : [
@@ -1107,6 +1103,19 @@ OPTIONS                                                        *vimtex-options*
             will have priority.
     Note 3: If |$VIMTEX_OUTPUT_DIRECTORY| is defined, it will have the highest
             priority.
+
+  clean_ext ~
+    This option specifies additional file extensions to be removed by
+    `:VimtexClean` and `:VimtexClean!`. It corresponds to `latexmk`'s
+    `$clean_ext` option.
+
+    It consists of a single string of space-separated extensions with no
+    preceding dot, for example: `"ex1 ex2 ex3"`
+
+    By default, `latexmk` will remove `aux`, `bcf`, `fls`, `idx`, `ind`, `lof`, `lot`,
+       `out`, `toc`, `blg`, `ilg`, `log`, and `xdv` files.
+
+    see the documentation: https://texdoc.org/serve/latexmk/0
 
   callback ~
     If enabled, this option tells `latexmk` to run |vimtex#compiler#callback|


### PR DESCRIPTION
### Change

Added `clean_ext` option to `g:vimtex_compiler_latexmk` `latexmk`'s own `$clean_ext` option.

### Rationale

Loved the autocommand to automatically clean up latex build files after exiting, but my vim configuration is shared across devices and moves regularly, so I needed a portable way to consistently remove `synctex.gz`.

### Other

I have tests written and ready to go but couldn't get the original to work on my machine so unsure whether or not they work, don't want to push code that doesn't work. I have tested it "informally" and it works as expected.